### PR TITLE
Avoid generating super big programs with large tensor dimensions

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -399,6 +399,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         # the lhs and rhs tensors
         lhs_shape = [lhs.shape[dim] for dim in lhs_result_dim[:-1]]
         rhs_shape = [rhs.shape[dim] for dim in rhs_result_dim[:-1]]
+        # In principle all of the matrix multiplications generated here, could be done in parallel.
+        # MIL does not seem to support this.
+        # We could try to combine the matrix multiplications when the shapes allow it, but for now
+        # we will just loop through them sequentially.
         result = iterate_indexes_in_shapes(calculate_result_index, result, [lhs_shape, rhs_shape])
 
         context.add_variable(op.result.get_name(), result)

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -1,14 +1,18 @@
 from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.var import Var
 
 from dataclasses import dataclass
 from typing import List
+from functools import reduce
+import itertools
 
 
 @dataclass
 class ResolvedSliceSpec:
-    start_indices: List[int]
-    end_indices: List[int]
+    start_indices: List[int] | Var
+    end_indices: List[int] | Var
     strides: List[int]
+    shape: List[int]
 
 
 def index_by_slices(tensor, slice_spec):
@@ -25,15 +29,7 @@ def index_by_slices(tensor, slice_spec):
 def update_tensor_by_slice(tensor, slice_spec, value):
     resolved_slices = _resolve_slice_spec(tensor, slice_spec)
 
-    reshaped_value = [
-        (end - start) // stride for start, end, stride
-        in zip(
-            resolved_slices.start_indices,
-            resolved_slices.end_indices,
-            resolved_slices.strides
-        )
-    ]
-    value = mb.reshape(x=value, shape=reshaped_value)
+    value = mb.reshape(x=value, shape=resolved_slices.shape)
     return mb.slice_update(
         x=tensor,
         update=value,
@@ -43,55 +39,186 @@ def update_tensor_by_slice(tensor, slice_spec, value):
     )
 
 
+def _flatten_list(lst):
+    flat_list = []
+    for item in lst:
+        if isinstance(item, (list, tuple)):
+            flat_list += _flatten_list(item)
+        else:
+            flat_list.append(item)
+    return flat_list
+
+
+def _count_dimensions(slice_spec):
+    dim_count = 0
+    for spec in slice_spec:
+        if isinstance(spec, Var):
+            if spec.rank != 1:
+                raise ValueError("The Var spec must have rank 1!")
+            dim_count += spec.shape[0]
+        elif isinstance(spec, type(Ellipsis)):
+            raise ValueError("Can not count dimensions for slice spec containing Ellipsis")
+        else:
+            dim_count += 1
+    return dim_count
+
+
 def _resolve_slice_spec(tensor, slice_spec) -> ResolvedSliceSpec:
     start_indices = []
     end_indices = []
     strides = []
+    shape = []
 
+    # We allow the slice_spec to have nested lists. In that case we flatten it
+    slice_spec = _flatten_list(slice_spec)
     if len(slice_spec) == 0:
         # Special case for scalar
         slice_spec = [slice(None)]
 
     tensor_rank = len(tensor.shape)
-    ellipsis_encountered = False
+    contains_var_type = False
     dim_counter = 0
     for i, spec in enumerate(slice_spec):
         if isinstance(spec, type(slice(None))):
             start_indices.append(spec.start or 0)
             end_indices.append(spec.stop or tensor.shape[dim_counter])
             strides.append(spec.step or 1)
+            shape.append(end_indices[-1] - start_indices[-1] // strides[-1])
             dim_counter += 1
         elif isinstance(spec, type(Ellipsis)):
-            if ellipsis_encountered:
+            if any([isinstance(s, type(Ellipsis)) for s in slice_spec[i+1:]]):
                 raise ValueError("Only supports one ellipsis when indexing")
-            ellipsis_encountered = True
 
-            dims_before = i
-            dims_after = len(slice_spec) - i - 1
+            dims_before = dim_counter
+            dims_after = _count_dimensions(slice_spec[i+1:])
             num_ellipsis_dims = tensor_rank - (dims_before + dims_after)
 
             ellipsis_starts = [0] * num_ellipsis_dims
-            ellipsis_ends = [tensor.shape[dim] for dim in range(i, i + num_ellipsis_dims)]
+            ellipsis_ends = [tensor.shape[dim] for dim in range(dim_counter, dim_counter + num_ellipsis_dims)]
             ellipsis_strides = [1] * num_ellipsis_dims
+            ellipsis_shape = [
+                (end - start) // stride for start, end, stride
+                in zip(ellipsis_starts, ellipsis_ends, ellipsis_strides)
+            ]
 
             start_indices += ellipsis_starts
             end_indices += ellipsis_ends
             strides += ellipsis_strides
+            shape += ellipsis_shape
 
             dim_counter += num_ellipsis_dims
+        elif isinstance(spec, Var):
+            if spec.rank != 1:
+                raise ValueError("The Var spec must have rank 1!")
+            contains_var_type = True
+            start_indices.append(spec)
+            end_indices.append(mb.add(x=spec, y=1))
+            strides += [1] * spec.shape[0]
+            shape += [1] * spec.shape[0]
+            dim_counter += spec.shape[0]
         else:
             # Assume it is an integer index
             idx = int(spec)
             start_indices.append(idx)
             end_indices.append(idx + 1)
             strides.append(1)
+            shape.append(1)
             dim_counter += 1
 
-    if len(start_indices) != tensor_rank:
+    # If slice_spec contained any Var types, we will need to concatenate the full result
+    # to be one big Var type
+    if contains_var_type:
+        def partition_list(lst):
+            parts = [[]]
+            for element in lst:
+                if isinstance(element, Var):
+                    if len(parts[-1]) == 0:
+                        parts.pop()
+                    parts.append(element)
+                    parts.append([])
+                else:
+                    parts[-1].append(element)
+            if len(parts[-1]) == 0:
+                # The last partition may be empty, if so we skip it
+                return parts[:-1]
+            return parts
+
+        def concat_to_var(lst):
+            parts = partition_list(lst)
+            return mb.concat(values=parts, axis=0)
+
+        start_indices = concat_to_var(start_indices)
+        end_indices = concat_to_var(end_indices)
+
+    if len(strides) != tensor_rank or len(shape) != tensor_rank:
         raise ValueError("Slice does not line up!")
 
     return ResolvedSliceSpec(
         start_indices=start_indices,
         end_indices=end_indices,
         strides=strides,
+        shape=shape,
     )
+
+
+def iterate_indexes_in_shapes(func, init_value, shapes, unroll_limit: int = 25):
+    """
+    Given a list of `shapes`, fx [(3, 2, 3), (5, 2, 3)] this method will iterate
+    the product of all valid indexes into the given shapes.
+    The function `func: Acc, Idx1, Idx2, ..., Idxn -> Res` is expected to given the
+    list of indexes and the accumulated result so far, to update the result based
+    on the index.
+    The indexes, Idx1, ..., Idn, may be either a mil mb.Var type of a python
+    tuple depending on if the loop is unrolled or not. `func` is expected to be
+    able to handle this.
+
+    If the total number of traversed indexes is <`unroll_limit`, the loop will be
+    fully un-rolled into MIL instructions. Otherwise it will be constructed as
+    a dynamic while loop executed at runtime.
+    """
+    shapes_elements = [reduce(lambda a, b: a * b, shape, 1) for shape in shapes]
+    total_iterations = reduce(lambda a, b: a * b, shapes_elements, 1)
+
+    result = init_value
+    if total_iterations <= unroll_limit:
+        # Fully unroll the loop
+        ranges = [itertools.product(*[range(dim) for dim in shape]) for shape in shapes]
+        for indexes in itertools.product(*ranges):
+            result = func(result, *indexes)
+    else:
+        # Dynamically compute the loop
+        def suffix_product(lst):
+            res = []
+            acc = 1
+            for i in reversed(lst):
+                res.append(acc)
+                acc *= i
+            return list(reversed(res))
+        integer_index_strides = suffix_product(shapes_elements)
+        index_strides = [suffix_product(shape) for shape in shapes]
+
+        # Attempt at looping over result indexes without fully unrolling
+        def cond(i, _result):
+            return mb.less(x=i, y=total_iterations)
+
+        def body(i, acc):
+            # Split out the index i to an integer index into the individual shapes.
+            integer_indexes = [
+                mb.mod(x=mb.floor_div(x=i, y=stride), y=elements)
+                for stride, elements in zip(integer_index_strides, shapes_elements)
+            ]
+            # Map the integer index in the shapes to an actual shaped index
+            indexes = [
+                mb.concat(values=[
+                    mb.mod(x=mb.floor_div(x=idx, y=stride), y=dim) for stride, dim in zip(strides, shape)
+                ], axis=0)
+                if len(shape) > 0 else []
+                for idx, strides, shape in zip(integer_indexes, index_strides, shapes)
+            ]
+
+            result = func(acc, *indexes)
+            return mb.add(x=i, y=1), result
+
+        _counter, result = mb.while_loop(_cond=cond, _body=body, loop_vars=(0, init_value))
+
+    return result

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -76,7 +76,6 @@ def test_tensor_multiplication():
     run_and_compare(full_tensor_product, (jnp.zeros((2, 3)), jnp.zeros((2, 4, 3))))
 
     # Test the full tensor product with a big dimensions, and ensure that the program gets handled by a dynamic loop
-    # TODO: Check this size of the program!
     run_and_compare(full_tensor_product, (jnp.zeros((10, 3)), jnp.zeros((15, 20, 3))))
     run_and_compare(full_tensor_product_1_4, (jnp.zeros((10,)), jnp.zeros((15, 20, 5, 3))))
     run_and_compare(full_tensor_product_1_4, (jnp.zeros((2,)), jnp.zeros((2, 2, 2, 3))))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -66,6 +66,17 @@ def test_tensor_multiplication():
     run_and_compare(full_tensor_product, (jnp.zeros((2, 3)), jnp.zeros((2, 4, 3))))
 
 
+def test_reduction():
+    def max_reduce_keep_dims(a):
+        return jnp.max(a, axis=1, keepdims=True)
+
+    def max_reduce_discard_dims(a):
+        return jnp.max(a, axis=1, keepdims=True)
+
+    run_and_compare(max_reduce_keep_dims, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(max_reduce_discard_dims, (jnp.zeros((2, 3, 4)),))
+
+
 def jax_export(jax_func, input_spec):
     def compute_input_shapes(input_specs):
         shapes = []

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -9,6 +9,7 @@ import numpy as np
 from stablehlo_coreml.converter import convert
 import coremltools as ct
 from coremltools.converters.mil.testing_utils import compare_backend
+from coremltools.converters.mil.mil import Program, Block
 
 
 def test_addition():
@@ -53,6 +54,15 @@ def test_tensor_multiplication():
     def full_tensor_product(lhs, rhs):
         return jnp.einsum("ab,ihj->abihj", lhs, rhs)
 
+    def full_tensor_product_1_4(lhs, rhs):
+        return jnp.einsum("a,ihjk->aihjk", lhs, rhs)
+
+    def full_tensor_product_3_2(lhs, rhs):
+        return jnp.einsum("abc,ih->abcih", lhs, rhs)
+
+    def full_tensor_product_4_1(lhs, rhs):
+        return jnp.einsum("abcd,i->abcdi", lhs, rhs)
+
     run_and_compare(scalar_product, (jnp.zeros((1)), jnp.zeros((1))))
     run_and_compare(scalar_with_vector, (jnp.zeros((1)), jnp.zeros((5))))
     run_and_compare(scalar_with_matrix, (jnp.zeros((1)), jnp.zeros((5, 3))))
@@ -65,16 +75,15 @@ def test_tensor_multiplication():
     run_and_compare(contract_all, (jnp.zeros((2, 3, 4, 5)), jnp.zeros((2, 4, 3, 5))))
     run_and_compare(full_tensor_product, (jnp.zeros((2, 3)), jnp.zeros((2, 4, 3))))
 
-
-def test_reduction():
-    def max_reduce_keep_dims(a):
-        return jnp.max(a, axis=1, keepdims=True)
-
-    def max_reduce_discard_dims(a):
-        return jnp.max(a, axis=1, keepdims=True)
-
-    run_and_compare(max_reduce_keep_dims, (jnp.zeros((2, 3, 4)),))
-    run_and_compare(max_reduce_discard_dims, (jnp.zeros((2, 3, 4)),))
+    # Test the full tensor product with a big dimensions, and ensure that the program gets handled by a dynamic loop
+    # TODO: Check this size of the program!
+    run_and_compare(full_tensor_product, (jnp.zeros((10, 3)), jnp.zeros((15, 20, 3))))
+    run_and_compare(full_tensor_product_1_4, (jnp.zeros((10,)), jnp.zeros((15, 20, 5, 3))))
+    run_and_compare(full_tensor_product_1_4, (jnp.zeros((2,)), jnp.zeros((2, 2, 2, 3))))
+    run_and_compare(full_tensor_product_3_2, (jnp.zeros((20, 10, 3)), jnp.zeros((15, 3))))
+    run_and_compare(full_tensor_product_3_2, (jnp.zeros((2, 2, 3)), jnp.zeros((2, 3))))
+    run_and_compare(full_tensor_product_4_1, (jnp.zeros(((15, 20, 5, 3))), jnp.zeros((10,))))
+    run_and_compare(full_tensor_product_4_1, (jnp.zeros(((2, 2, 2, 3))), jnp.zeros((2,))))
 
 
 def jax_export(jax_func, input_spec):
@@ -136,7 +145,26 @@ def __nest_flat_jax_input_to_input_spec(input_spec, flat_input):
     return structured_input
 
 
-def run_and_compare(jax_func, input_spec):
+def _count_program_complexity(mil_program: Program):
+    """
+    Counts the number of instructions in the given `mil_program`
+    This is used to ensure we don't generate crazy big programs
+    """
+    def count_block(block: Block):
+        complexity = 0
+        for op in block.operations:
+            for child_block in op.blocks:
+                complexity += count_block(child_block)
+            complexity += 1
+        return complexity
+
+    total_complexity = 0
+    for func in mil_program.functions.values():
+        total_complexity += count_block(func)
+    return total_complexity
+
+
+def run_and_compare(jax_func, input_spec, max_complexity: int = 10_000):
     jax_func = jax.jit(jax_func)
     exported = jax_export(jax_func, input_spec)
     context = jax_mlir.make_ir_context()
@@ -144,6 +172,13 @@ def run_and_compare(jax_func, input_spec):
     # print(f"HLO module: {hlo_module}")
 
     mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+    program_complexity = _count_program_complexity(mil_program)
+    if program_complexity > max_complexity:
+        raise ValueError(
+            f"Generated a MIL program with complexity {program_complexity}, "
+            "max allowed complexity is {max_complexity}"
+        )
+
     cml_model = ct.convert(mil_program, source="milinternal", minimum_deployment_target=ct.target.iOS18)
 
     # Generate random inputs that matches cml_model input spec


### PR DESCRIPTION
If the result dimensions of a tensor are very large, the computation is currently being fully unrolled, leading to insanely big programs.
Instead utilize a while loop to do it on runtime.