### PR TITLE
Implement reductions on a tensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ parallel = true
 
 extra-dependencies = [
     "pytest",
-    "jax",
-    "flax",
+    "jax>=0.4.32",
+    "flax>=0.9.0",
     "flatbuffers",
     "einops",
     "pillow",

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -22,7 +22,6 @@ from typing import List, Optional
 import inspect
 from functools import partial, reduce
 import operator
-import itertools
 
 
 def convert(module, minimum_deployment_target: AvailableTarget):
@@ -692,7 +691,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         # In principle we could calculate all HLO reductions by using a MIL while loop
         # However, there would be no acceleration for this, and the computation is likely
         # to take much longer than the user expected.
-        # Therefore wes will restrict the supported reductions to what is supported through
+        # Therefore we will restrict the supported reductions to what is supported through
         # native MIL instructions
 
         def match_reduction_type(hlo_body):

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -27,6 +27,9 @@ def index_by_slices(tensor, slice_spec):
 
 
 def update_tensor_by_slice(tensor, slice_spec, value):
+    if len(tensor.shape) == 0:
+        tensor = mb.reshape(x=tensor, shape=(1,))
+
     resolved_slices = _resolve_slice_spec(tensor, slice_spec)
 
     value = mb.reshape(x=value, shape=resolved_slices.shape)

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -103,14 +103,15 @@ def test_complex_reductions():
     """
     These reductions are complicated, and will be handled using while loops (potentially unrolled)
     """
-    run_and_compare(jnp.argmax, (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.argmax, axis=0), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.argmax, axis=2), (jnp.zeros((2, 3, 4)),))
-    # run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((20, 30, 40)),))
+    run_and_compare(jnp.argmax, (jnp.zeros((2, 3, 3)),))
+    run_and_compare(jnp.argmax, (jnp.zeros((20, 30, 40)),))
+    run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmax, axis=0), (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmax, axis=2), (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((20, 30, 40)),))
 
-    run_and_compare(jnp.argmin, (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(jnp.argmin, (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 3)),))
 
 
 def test_topk():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -84,7 +84,8 @@ def test_tensor_multiplication():
     run_and_compare(full_tensor_product_4_1, (jnp.zeros(((2, 2, 2, 3))), jnp.zeros((2,))))
 
 
-def test_reduction():
+def test_simple_reductions():
+    # TODO: Test that these reductions are not computed using a while loop
     run_and_compare(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.max, axis=1, keepdims=True), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.sum, axis=0), (jnp.zeros((2, 3, 4)),))
@@ -97,9 +98,19 @@ def test_reduction():
     run_and_compare(partial(jnp.mean, axis=0), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.prod, axis=1), (jnp.zeros((2, 3, 4)),))
 
-    # TODO: These are much harder matching on
-    # run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 4)),))
-    # run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 4)),))
+
+def test_complex_reductions():
+    """
+    These reductions are complicated, and will be handled using while loops (potentially unrolled)
+    """
+    run_and_compare(jnp.argmax, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.argmax, axis=0), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.argmax, axis=2), (jnp.zeros((2, 3, 4)),))
+    # run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((20, 30, 40)),))
+
+    run_and_compare(jnp.argmin, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 4)),))
 
 
 def test_topk():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -11,6 +11,7 @@ import coremltools as ct
 from coremltools.converters.mil.testing_utils import compare_backend
 from coremltools.converters.mil.mil import Program, Block
 
+from functools import partial
 
 def test_addition():
     def plus(x, y):
@@ -83,6 +84,30 @@ def test_tensor_multiplication():
     run_and_compare(full_tensor_product_3_2, (jnp.zeros((2, 2, 3)), jnp.zeros((2, 3))))
     run_and_compare(full_tensor_product_4_1, (jnp.zeros(((15, 20, 5, 3))), jnp.zeros((10,))))
     run_and_compare(full_tensor_product_4_1, (jnp.zeros(((2, 2, 2, 3))), jnp.zeros((2,))))
+
+
+def test_reduction():
+    def max_reduce_keep_dims(a):
+        return jnp.max(a, axis=1, keepdims=True)
+
+    def max_reduce_discard_dims(a):
+        return jnp.max(a, axis=1, keepdims=True)
+
+    run_and_compare(max_reduce_keep_dims, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(max_reduce_discard_dims, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.sum, axis=0), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.sum, axis=1), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.sum, axis=2), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.sum, axis=(0, 2)), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.sum, axis=(0, 1, 2)), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.min, axis=0), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.min, axis=(1, 2)), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.mean, axis=0), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.prod, axis=1), (jnp.zeros((2, 3, 4)),))
+
+    # TODO: These are much harder matching on
+    # run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 4)),))
+    # run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 4)),))
 
 
 def jax_export(jax_func, input_spec):

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -15,11 +15,8 @@ from functools import partial
 
 
 def test_addition():
-    def plus(x, y):
-        return jnp.add(x, y)
-
-    run_and_compare(plus, (jnp.float32(1), jnp.float32(1)))
-    run_and_compare(plus, (jnp.zeros((2, 2, 2)), jnp.zeros((2, 2, 2))))
+    run_and_compare(jnp.add, (jnp.float32(1), jnp.float32(1)))
+    run_and_compare(jnp.add, (jnp.zeros((2, 2, 2)), jnp.zeros((2, 2, 2))))
 
 
 def test_tensor_multiplication():
@@ -88,14 +85,8 @@ def test_tensor_multiplication():
 
 
 def test_reduction():
-    def max_reduce_keep_dims(a):
-        return jnp.max(a, axis=1, keepdims=True)
-
-    def max_reduce_discard_dims(a):
-        return jnp.max(a, axis=1, keepdims=True)
-
-    run_and_compare(max_reduce_keep_dims, (jnp.zeros((2, 3, 4)),))
-    run_and_compare(max_reduce_discard_dims, (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4)),))
+    run_and_compare(partial(jnp.max, axis=1, keepdims=True), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.sum, axis=0), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.sum, axis=1), (jnp.zeros((2, 3, 4)),))
     run_and_compare(partial(jnp.sum, axis=2), (jnp.zeros((2, 3, 4)),))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -12,6 +12,7 @@ from coremltools.converters.mil.testing_utils import compare_backend
 from coremltools.converters.mil.mil import Program, Block
 
 from functools import partial
+from typing import List
 
 
 def test_addition():
@@ -85,18 +86,21 @@ def test_tensor_multiplication():
 
 
 def test_simple_reductions():
-    # TODO: Test that these reductions are not computed using a while loop
-    run_and_compare(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.max, axis=1, keepdims=True), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.sum, axis=0), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.sum, axis=1), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.sum, axis=2), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.sum, axis=(0, 2)), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.sum, axis=(0, 1, 2)), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.min, axis=0), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.min, axis=(1, 2)), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.mean, axis=0), (jnp.zeros((2, 3, 4)),))
-    run_and_compare(partial(jnp.prod, axis=1), (jnp.zeros((2, 3, 4)),))
+    def compare_and_ensure_no_loops(jax_func, input_spec):
+        cml_model = run_and_compare(jax_func, input_spec)
+        assert "while_loop" not in get_model_instruction_types(cml_model)
+
+    compare_and_ensure_no_loops(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.max, axis=1, keepdims=True), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.sum, axis=0), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.sum, axis=1), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.sum, axis=2), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.sum, axis=(0, 2)), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.sum, axis=(0, 1, 2)), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.min, axis=0), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.min, axis=(1, 2)), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.mean, axis=0), (jnp.zeros((2, 3, 4)),))
+    compare_and_ensure_no_loops(partial(jnp.prod, axis=1), (jnp.zeros((2, 3, 4)),))
 
 
 def test_complex_reductions():
@@ -104,14 +108,18 @@ def test_complex_reductions():
     These reductions are complicated, and will be handled using while loops (potentially unrolled)
     """
     run_and_compare(jnp.argmax, (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmax, keepdims=True), (jnp.zeros((2, 3, 3)),))
     run_and_compare(jnp.argmax, (jnp.zeros((20, 30, 40)),))
+    run_and_compare(partial(jnp.argmax, keepdims=True), (jnp.zeros((20, 30, 40)),))
     run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((2, 3, 3)),))
-    run_and_compare(partial(jnp.argmax, axis=0), (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmax, axis=0, keepdims=True), (jnp.zeros((2, 3, 3)),))
     run_and_compare(partial(jnp.argmax, axis=2), (jnp.zeros((2, 3, 3)),))
     run_and_compare(partial(jnp.argmax, axis=1), (jnp.zeros((20, 30, 40)),))
 
     run_and_compare(jnp.argmin, (jnp.zeros((2, 3, 3)),))
     run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((2, 3, 3)),))
+    run_and_compare(partial(jnp.argmin, axis=1), (jnp.zeros((20, 30, 40)),))
+    run_and_compare(partial(jnp.argmin, axis=1, keepdims=True), (jnp.zeros((20, 30, 40)),))
 
 
 def test_topk():
@@ -199,6 +207,13 @@ def _count_program_complexity(mil_program: Program):
 
 
 def run_and_compare(jax_func, input_spec, max_complexity: int = 10_000):
+    """
+    Converts the given `jax_func` to a CoreML model.
+    Both models will be run on random input data with shapes specified by `input_spec`.
+    If the CoreML model and `jax_func` does not agree on the output, an error will be raised.
+    The resulting CoreML model will be returned.
+    """
+
     jax_func = jax.jit(jax_func)
     exported = jax_export(jax_func, input_spec)
     context = jax_mlir.make_ir_context()
@@ -251,3 +266,22 @@ def run_and_compare(jax_func, input_spec, max_complexity: int = 10_000):
         cml_expected_outputs[output_name] = np.asarray(output_value)
 
     compare_backend(cml_model, cml_input_key_values, cml_expected_outputs)
+
+    return cml_model
+
+
+def get_model_instruction_types(cml_model) -> List[str]:
+    def collect_ops(ops: List) -> List[str]:
+        collected_ops = []
+        for op in ops:
+            collected_ops.append(op.op_type)
+            for block in op.blocks:
+                collected_ops += collect_ops(block.operations)
+
+        return collected_ops
+
+    mil_program = cml_model._mil_program
+    all_ops = []
+    for func in mil_program.functions.values():
+        all_ops += collect_ops(func.operations)
+    return all_ops

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -13,6 +13,7 @@ from coremltools.converters.mil.mil import Program, Block
 
 from functools import partial
 
+
 def test_addition():
     def plus(x, y):
         return jnp.add(x, y)


### PR DESCRIPTION
Ability to do reductions on a tensor.
The min, max, sum and product reductions will be translated to native MIL instructions.

The code is currently failing to run due to incorrectly generated MLIR python bindings: https://github.com/llvm/llvm-project/issues/101132