### PR TITLE
Implement an optimization pass removing unneeded slice_updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ To convert a StableHLO module, do the following:
 ```python
 import coremltools as ct
 from stablehlo_coreml.converter import convert
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE
 
 mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
-cml_model = ct.convert(mil_program, source="milinternal", minimum_deployment_target=ct.target.iOS18)
+cml_model = ct.convert(
+    mil_program,
+    source="milinternal",
+    minimum_deployment_target=ct.target.iOS18,
+    pass_pipeline=DEFAULT_HLO_PIPELINE,
+)
 ```
 
 For a Jax project, the `hlo_module` can be obtained the following way:

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,4 +1,5 @@
 from .converter import convert
+from .passes.utils import register_optimizations, DEFAULT_HLO_PIPELINE
 
 __version__ = "0.0.0"
-__all__ = ['convert']
+__all__ = ['convert', 'register_optimizations', 'DEFAULT_HLO_PIPELINE']

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -7,6 +7,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import (
     promote_input_dtypes,
 )
 from .utils import index_by_slices, update_tensor_by_slice, iterate_indexes_in_shapes
+# from .passes.utils import register_optimizations
 
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects.func import FuncOp, CallOp, ReturnOp as FuncReturnOp
@@ -30,6 +31,8 @@ from functools import partial, reduce
 def convert(module, minimum_deployment_target: AvailableTarget):
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
+
+    # register_optimizations()
 
     converter = StableHloConverter(opset_version=minimum_deployment_target)
     return converter.convert(module)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -7,7 +7,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import (
     promote_input_dtypes,
 )
 from .utils import index_by_slices, update_tensor_by_slice, iterate_indexes_in_shapes
-# from .passes.utils import register_optimizations
+from .passes.utils import register_optimizations
 
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects.func import FuncOp, CallOp, ReturnOp as FuncReturnOp
@@ -32,7 +32,7 @@ def convert(module, minimum_deployment_target: AvailableTarget):
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
 
-    # register_optimizations()
+    register_optimizations()
 
     converter = StableHloConverter(opset_version=minimum_deployment_target)
     return converter.convert(module)

--- a/stablehlo_coreml/passes/remove_noop_slice_update.py
+++ b/stablehlo_coreml/passes/remove_noop_slice_update.py
@@ -1,0 +1,84 @@
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+import numpy as np
+
+
+def _match_pattern(op):
+    if op.op_type == "slice_update":
+        x_rank = len(op.x.shape)
+
+        x_and_update_shape_matches = op.x.shape == op.update.shape
+
+        expected_start_indices = np.array([0] * x_rank, dtype=np.int32)
+        start_values_all_zero = np.array_equal(op.begin.val, expected_start_indices)
+
+        end_value_matches_x_shape = np.array_equal(op.end.val, op.x.shape)
+
+        expected_strides = np.array([1] * x_rank, dtype=np.int32)
+        strides_all_1 = not op.stride or np.array_equal(op.stride.val, expected_strides)
+        no_extra_options = strides_all_1 and not op.begin_mask and not op.end_mask
+
+        return x_and_update_shape_matches and start_values_all_zero and end_value_matches_x_shape and no_extra_options
+
+    return False
+
+
+def _try_to_transform(slice_update_op):
+    # Rename the slice_update_op to the `slice_update_op.update` variable name, to make sure
+    # naming remains sane once we delete `slice_update_op`
+    slice_update_op.outputs[0].name = slice_update_op.update.name
+
+    # Replace occurences of the `slice_update_op` output with the `slice_update_op.update` variable
+    slice_update_op.enclosing_block.replace_uses_of_var_after_op(
+        anchor_op=slice_update_op, old_var=slice_update_op.outputs[0], new_var=slice_update_op.update
+    )
+    slice_update_op.remove_from_block()
+    return True
+
+
+@block_context_manager
+def _remove_noop_slice_update(block):
+    did_optimize = False
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for b in op.blocks:
+            block_changed = True
+            while block_changed:
+                block_changed = _remove_noop_slice_update(b)
+        if len(op.blocks) > 0:
+            continue
+
+        if _match_pattern(op):
+            if _try_to_transform(op):
+                did_optimize = True
+    return did_optimize
+
+
+@register_pass(namespace="common")
+class remove_noop_slice_update(AbstractGraphPass):
+    """
+    If a slice_update is called on the full tensor with an update of the same size,
+    just use the update tensor going forward.
+
+    This optimization is very useful for the way the HLO DotGeneralOp and ReduceOp are implemented.
+
+    Given:
+        %1 = <buffer tensor of shape S>
+        %2 = <update tensor of shape S>
+        %2 = slice_update(x=%buffer, update=%2, begin=[0] * rank(%1), end=S, stride=[1] * rank(%1))
+        %3 = some_op(%2)
+
+    Result:
+        %1 = <tensor of shape S>
+        %3 = some_op(%1)
+        ...
+    """
+    def apply(self, prog):
+        for f in prog.functions.values():
+            block_changed = True
+            while block_changed:
+                block_changed = _remove_noop_slice_update(f)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -1,0 +1,11 @@
+import coremltools as ct
+
+DEFAULT_HLO_PIPELINE: ct.PassPipeline = ct.PassPipeline.DEFAULT
+
+
+def register_optimizations():
+    from .remove_noop_slice_update import remove_noop_slice_update
+    custom_passes = [remove_noop_slice_update]
+
+    for custom_pass in custom_passes:
+        DEFAULT_HLO_PIPELINE.append_pass(f"common::{custom_pass.__name__}")

--- a/tests/passes/test_remove_noop_slice_update.py
+++ b/tests/passes/test_remove_noop_slice_update.py
@@ -1,0 +1,85 @@
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+import coremltools as ct
+
+import numpy as np
+
+from stablehlo_coreml import register_optimizations
+
+register_optimizations()
+
+
+class TestRemoveNoopSliceUpdate:
+
+    def test_is_removed(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((10, 20))
+            # Because this function ends up being a complete no-op, we need to ensure the naming of inputs and outputs
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, name="x")
+            return x
+        self.__test_program(prog, should_remove=True)
+
+    def test_not_removed_if_non_zero_begin_shape(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((11, 20))
+            x = mb.slice_update(x=buffer, update=x, begin=[1, 0], end=buffer.shape)
+            return x
+        self.__test_program(prog, should_remove=False)
+
+    def test_not_removed_if_end_not_matching(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((11, 20))
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=[10, 20])
+            return x
+        self.__test_program(prog, should_remove=False)
+
+    def test_not_removed_if_strided(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((20, 20))
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, stride=[2, 1])
+            return x
+        self.__test_program(prog, should_remove=False)
+
+    def test_not_removed_if_begin_mask(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((10, 20))
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, begin_mask=[True, False])
+            return x
+        self.__test_program(prog, should_remove=False)
+
+    def test_not_removed_if_end_mask(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((10, 20))
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, end_mask=[True, False])
+            return x
+        self.__test_program(prog, should_remove=False)
+
+    def __test_program(self, prog, should_remove: bool):
+        assert get_op_types_in_program(prog) == ["slice_update"]
+
+        apply_pass_and_basic_check(
+            prog, "common::remove_noop_slice_update"
+        )
+        _, _, _ = apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+
+        if should_remove:
+            assert get_op_types_in_program(prog) == []
+        else:
+            assert get_op_types_in_program(prog) == ["slice_update"]
+
+        assert_model_is_valid(
+            prog,
+            {"x": (10, 20)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32")
+        )

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -2,8 +2,6 @@ import jax
 from flax import nnx
 import jax.numpy as jnp
 
-from functools import partial
-
 from tests.test_jax import run_and_compare
 
 from tests.flax_blocks import ResidualConv, Encoder, UNet, UNetWithXlstm
@@ -56,7 +54,8 @@ def test_flax_stacked_linear():
 def test_flax_stacked_lax_scan():
     class TestStackedLaxScanLinear(nnx.Module):
         def __init__(self, rngs=nnx.Rngs):
-            @partial(nnx.vmap, axis_size=3)  # 3 hidden layers
+            @nnx.split_rngs(splits=3)  # 3 hidden layers
+            @nnx.vmap(axis_size=3)
             def create_hidden_layers(rngs: nnx.Rngs):
                 return nnx.Linear(in_features=4, out_features=4, bias_init=nnx.initializers.ones, rngs=rngs)
             self.hidden_layers = create_hidden_layers(rngs)
@@ -139,7 +138,8 @@ def test_flax_3d_convolution():
 def test_flax_stacked_convolution():
     class TestStackedConvolution(nnx.Module):
         def __init__(self, rngs=nnx.Rngs):
-            @partial(nnx.vmap, axis_size=3)  # 3 hidden layers
+            @nnx.split_rngs(splits=3)  # 3 hidden layers
+            @nnx.vmap(axis_size=3)
             def create_convs(rngs: nnx.Rngs):
                 return nnx.Conv(in_features=2, out_features=2, kernel_size=3, rngs=rngs)
             self.conv_layers = create_convs(rngs)

--- a/tests/test_flax.py
+++ b/tests/test_flax.py
@@ -4,10 +4,10 @@ import jax.numpy as jnp
 
 from functools import partial
 
-from .test_jax import run_and_compare
+from tests.test_jax import run_and_compare
 
-from .flax_blocks import ResidualConv, Encoder, UNet, UNetWithXlstm
-from .flax_xlstm import sLSTMCell, sLSTMBlock, mLSTMCell, mLSTMBlock, xLSTMModule, xLSTM
+from tests.flax_blocks import ResidualConv, Encoder, UNet, UNetWithXlstm
+from tests.flax_xlstm import sLSTMCell, sLSTMBlock, mLSTMCell, mLSTMBlock, xLSTMModule, xLSTM
 
 
 def test_flax_nnx_linear():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -7,6 +7,7 @@ from jax._src.interpreters import mlir as jax_mlir
 import numpy as np
 
 from stablehlo_coreml.converter import convert
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE
 import coremltools as ct
 from coremltools.converters.mil.testing_utils import compare_backend
 from coremltools.converters.mil.mil import Program, Block
@@ -183,7 +184,7 @@ def run_and_compare(jax_func, input_spec, max_complexity: int = 10_000):
             "max allowed complexity is {max_complexity}"
         )
 
-    pipeline = ct.PassPipeline.DEFAULT
+    pipeline = DEFAULT_HLO_PIPELINE
     # We temporarily avoid fp16 conversions in tests because of https://github.com/apple/coremltools/issues/2324
     passes_to_remove = [
          'common::add_fp16_cast'


### PR DESCRIPTION
When converting DotGeneralOp, we generate `slice_update`s to fill the output buffer with the intended values. There is a special case where there is only one matrix multiplication. In that case there is no need to do a `slice_update`.