### PR TITLE
[fix] Support variables in parent scope exposed in jax v0.4.34

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -73,11 +73,15 @@ class TranscriptionContext:
         self.variables[path][name] = mil_var
 
     def __getitem__(self, name: str):
-        path = self.path()
-        ctx = self.variables[path]
-        if name not in ctx:
-            raise ValueError(f"Variable with name {name} is not defined in path {path}")
-        return ctx[name]
+        # Walk up along the path list to find the first correctly named variable in scope
+        path = self._path.copy()
+        while True:
+            ctx = self.variables["/".join(path)]
+            if name in ctx:
+                return ctx[name]
+            if len(path) == 0:
+                raise ValueError(f"Variable with name {name} is not defined in path {path}")
+            path.pop()
 
     def path(self) -> str:
         return "/".join(self._path)


### PR DESCRIPTION
After testing with [Jax v0.4.34](https://github.com/jax-ml/jax/releases/tag/jax-v0.4.34) two of the flax tests started failing, because a loop would refer a variable not available in the child-loop body context. Instead the variable was defined in the parent scope of the context.

This PR extends the variable search to include all parent contexts.