### PR TITLE
Stable sort via bit magic

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+exclude = env
+max-line-length = 127
+count = true
+statistics = true
+show-source = true

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -416,25 +416,27 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         if sort_keys is None:
             raise ValueError("Unrecognized comparator format")
 
+        def precast_gather(tensor, indices):
+            if tensor.dtype == types.int32:
+                # gather bit casts to int16 then value casts back, so we need to
+                # cast to int16 before gather to avoid overflow for negative values
+                tensor = mb.cast(x=tensor, dtype="int16")
+                res = mb.gather_along_axis(x=tensor, indices=indices, axis=sort_dim)
+                return mb.cast(x=res, dtype="int32")
+            else:
+                return mb.gather_along_axis(x=tensor, indices=indices, axis=sort_dim)
+
         # Apply the sort
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
         indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
         for key, ascending in sort_keys[-2::-1]:
-            gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
+            gathered_key = precast_gather(key, indices)
             relative_indices = stable_argsort(x=gathered_key, axis=sort_dim, ascending=ascending)
             indices = mb.gather_along_axis(x=indices, indices=relative_indices, axis=sort_dim)
 
         for i, tensor in enumerate(inputs):
-            if tensor.dtype == types.int32:
-                # gather bit casts to int16 then value casts back, so we need to
-                # manually cast to int16 before gather to avoid overflow
-                tensor_val = mb.cast(x=tensor, dtype="int16")
-                res = mb.gather_along_axis(x=tensor_val, indices=indices, axis=sort_dim)
-                res = mb.cast(x=res, dtype="int32")
-            else:
-                res = mb.gather_along_axis(x=tensor, indices=indices, axis=sort_dim)
-            context.add_result(op.results[i], res)
+            context.add_result(op.results[i], precast_gather(tensor, indices))
 
     @register_stablehlo_op
     def op_case(self, context: TranslationContext, op: CaseOp):

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -420,6 +420,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
         indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
+        # context.add_result(op.results[0], indices)
+        # context.add_result(op.results[1], indices)
+        # return
+
         for key, ascending in sort_keys[-2::-1]:
             gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
             relative_indices = stable_argsort(x=gathered_key, axis=sort_dim, ascending=ascending)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -418,7 +418,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
         # Apply the sort
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
-        indices = mb.argsort(x=key, axis=sort_dim, ascending=ascending)
+        indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
         for key, ascending in sort_keys[-2::-1]:
             gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -420,10 +420,6 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
         indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
-        context.add_result(op.results[0], indices)
-        context.add_result(op.results[1], indices)
-        return
-
         for key, ascending in sort_keys[-2::-1]:
             gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
             relative_indices = stable_argsort(x=gathered_key, axis=sort_dim, ascending=ascending)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -420,6 +420,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
         indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
+        context.add_result(op.results[0], indices)
+        context.add_result(op.results[1], indices)
+        return
+
         for key, ascending in sort_keys[-2::-1]:
             gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
             relative_indices = stable_argsort(x=gathered_key, axis=sort_dim, ascending=ascending)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -995,8 +995,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         iota_dim = int(op.iota_dimension)
         tensor_shape = op.result.type.shape
         vec_shape = [tensor_shape[dim] if dim == iota_dim else 1 for dim in range(len(tensor_shape))]
+        vec_reps = [1 if dim == iota_dim else tensor_shape[dim] for dim in range(len(tensor_shape))]
         dtype = get_numpy_type(op.result.type.element_type)
-        res = np.reshape(np.arange(tensor_shape[iota_dim], dtype=dtype), vec_shape) * np.ones(tensor_shape, dtype=dtype)
+        res = mb.reshape(x=mb.range_1d(start=dtype(0), end=dtype(tensor_shape[iota_dim]), step=dtype(1)), shape=vec_shape)
+        res = mb.tile(x=res, reps=vec_reps)
         context.add_result(op.result, res)
 
     @register_stablehlo_op

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -422,7 +422,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             if types.is_int(key.dtype):
                 indices = mb.argsort(x=key, axis=sort_dim, ascending=ascending)
             else:
-                # MIL puts NaN just above -inf instead of above +inf like StableHLO
+                # MIL puts NaN as equal to -inf instead of above +inf like StableHLO
                 nans = mb.not_equal(x=key, y=key)
                 inf_masking_nans = mb.select(cond=nans, a=np.inf, b=key)
                 indices = mb.argsort(x=inf_masking_nans, axis=sort_dim, ascending=ascending)

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -9,7 +9,7 @@ from coremltools.converters.mil.mil.ops.defs._utils import (
 from .utils import (
     index_by_slices, update_tensor_by_slice, iterate_indexes_in_shapes,
     inverse_permutation, get_mil_type, dtype_str, get_mil_type_from_ir, get_numpy_type,
-    clamp_index
+    clamp_index, range_along_dim
 )
 from .passes.utils import register_optimizations
 from .translation_context import TranslationContext
@@ -992,13 +992,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
     @register_stablehlo_op
     def op_iota(self, context: TranslationContext, op: IotaOp):
-        iota_dim = int(op.iota_dimension)
-        tensor_shape = op.result.type.shape
-        vec_shape = [tensor_shape[dim] if dim == iota_dim else 1 for dim in range(len(tensor_shape))]
-        vec_reps = [1 if dim == iota_dim else tensor_shape[dim] for dim in range(len(tensor_shape))]
-        dtype = get_numpy_type(op.result.type.element_type)
-        res = mb.reshape(x=mb.range_1d(start=dtype(0), end=dtype(tensor_shape[iota_dim]), step=dtype(1)), shape=vec_shape)
-        res = mb.tile(x=res, reps=vec_reps)
+        res = range_along_dim(op.result.type.shape, int(op.iota_dimension), get_numpy_type(op.result.type.element_type))
         context.add_result(op.result, res)
 
     @register_stablehlo_op

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -420,10 +420,6 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
         indices = stable_argsort(x=key, axis=sort_dim, ascending=ascending)
 
-        # context.add_result(op.results[0], indices)
-        # context.add_result(op.results[1], indices)
-        # return
-
         for key, ascending in sort_keys[-2::-1]:
             gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
             relative_indices = stable_argsort(x=gathered_key, axis=sort_dim, ascending=ascending)

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -94,8 +94,10 @@ def compute_reduction(converter, context: TranslationContext, inputs, dimensions
         ]
 
     mil_results = [
-        np.zeros(result_type.shape, dtype=get_numpy_type(result_type))
-        for result_type in result_types
+        mb.tile(
+            x=np.zeros((1,) * len(result_type.shape), dtype=get_numpy_type(result_type)),
+            reps=result_type.shape
+        ) for result_type in result_types
     ]
     mil_results = iterate_indexes_in_shapes(compute_reduction_loop, [result_shape], mil_results, unroll_limit=5)
     return mil_results

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -94,10 +94,10 @@ def compute_reduction(converter, context: TranslationContext, inputs, dimensions
         ]
 
     mil_results = [
-        mb.tile(
-            x=np.zeros((1,) * len(result_type.shape), dtype=get_numpy_type(result_type)),
-            reps=result_type.shape
-        ) for result_type in result_types
+        np.zeros(result_type.shape, dtype=get_numpy_type(result_type))
+        if len(result_type.shape) == 0 else
+        mb.tile(x=np.zeros((1,) * len(result_type.shape), dtype=get_numpy_type(result_type)), reps=result_type.shape)
+        for result_type in result_types
     ]
     mil_results = iterate_indexes_in_shapes(compute_reduction_loop, [result_shape], mil_results, unroll_limit=5)
     return mil_results

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -58,7 +58,7 @@ def bitcast_fp(x):
     mantissa = mb.select(cond=is_subnormal, a=mantissa_subnormal, b=mantissa_normal)
 
     # Handle Inf/NaN
-    max_exp = 2**exponent - 1
+    max_exp = 2 ** exponent - 1
     e_shifted = mb.select(cond=is_special, a=max_exp, b=e_shifted)
 
     # Inf: mantissa = 0, NaN: mantissa = max (to sort after Inf)
@@ -75,7 +75,10 @@ def bitcast_fp(x):
 
 def bitcast_int(x):
     width = x.dtype.width
-    assert types.is_int(x.dtype) and width in {8, 16, 32}
+    assert types.is_int(x.dtype) and width in {8, 16, 32}, (
+        f"Stable argsort recieved unexpected integer dtype width of {width} bits which is unsupported because "
+        "MIL's gather op only supports integer sizes of 8, 16, and 32 bits"
+    )
     packed, signed = width == 32, not x.dtype.is_unsigned()
     assert not packed or signed, "CoreML has no uint32 type"
 

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -90,10 +90,14 @@ def stable_argsort(x, axis=-1, ascending=True):
     arange = np.indices(x.shape)[axis]
     mask = bitcast_window(x, x.shape[axis])
     splits = bitcast_split(x, mask, ascending)
+    # return splits[0]
+    # return splits[1]
     shifted = lambda x: mb.add(x=mb.mul(x=x, y=2 ** (x.dtype.width - 1 - mask)), y=arange)
     indices = mb.argsort(x=shifted(splits[0]), axis=axis, ascending=True)
     for window in splits[1:]:
         gathered_key = mb.gather_along_axis(x=window, indices=indices, axis=axis)
+        # gather bit casts to int16 then value casts back, so fix the sign bit
+        gathered_key = mb.select(cond=mb.less(x=gathered_key, y=0), a=mb.add(x=gathered_key, y=0x1_0000), b=gathered_key)
         relative_indices = mb.argsort(x=shifted(x=gathered_key), axis=axis, ascending=True)
         indices = mb.gather_along_axis(x=indices, indices=relative_indices, axis=axis)
     return indices

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -125,7 +125,7 @@ def bitcast_window(x, n):
     if n < 2 ** 15:
         # 16 bit operand mask, 15 bit index mask
         return 16
-    elif x.dtype.width == 32 and n < 2 ** 20:
+    elif types.nptype_from_builtin(x.dtype) in {np.int32, np.float32} and n < 2 ** 20:
         # 11 bit operand mask, 20 bit index mask
         return 11
     elif n < 2 ** 23:

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -75,10 +75,11 @@ def bitcast_fp(x):
 
 def bitcast_int(x):
     width = x.dtype.width
-    assert types.is_int(x.dtype) and width in {8, 16, 32}, (
-        f"Stable argsort recieved unexpected integer dtype width of {width} bits which is unsupported because "
-        "MIL's gather op only supports integer sizes of 8, 16, and 32 bits"
-    )
+    if not types.is_int(x.dtype) or width not in {8, 16, 32}:
+        raise ValueError(
+            f"Stable argsort recieved unexpected integer dtype width of {width} bits which is unsupported because "
+            "MIL's gather op only supports integer sizes of 8, 16, and 32 bits"
+        )
     packed, signed = width == 32, not x.dtype.is_unsigned()
     assert not packed or signed, "CoreML has no uint32 type"
 

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -139,8 +139,10 @@ def stable_argsort(x, axis=-1, ascending=True):
     arange = np.indices(x.shape)[axis]
     mask = bitcast_window(x, x.shape[axis])
     splits = bitcast_split(x, mask, ascending)
+
     def shifted(x):
         return mb.add(x=mb.mul(x=x, y=2 ** (x.dtype.width - 1 - mask)), y=arange)
+
     indices = mb.argsort(x=shifted(splits[0]), axis=axis, ascending=True)
     for window in splits[1:]:
         gathered_key = mb.gather_along_axis(x=window, indices=indices, axis=axis)

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from jaxlib.mlir import ir
 from jaxlib.mlir.dialects.stablehlo import (
-    CompareOp, SelectOp, ConstantOp
+    CompareOp, SelectOp, ConstantOp, OrOp, AndOp
 )
 from jax._src.lib.mlir.dialects import hlo
 
@@ -11,43 +11,42 @@ from coremltools.converters.mil.mil import types
 
 # TODO: nan, inf, subnormals
 def bitcast_fp(x):
-    width = x.dtype.width
-    ieee754 = { 32: (8, 23), 16: (5, 10) }
+    width = types.nptype_from_builtin(x.dtype)
+    ieee754 = { np.float32: (8, 23), np.float16: (5, 10) }
     assert types.is_float(x.dtype) and width in ieee754
     exponent, fraction = ieee754[width]
     e_bias = 2 ** (exponent - 1) - 1
     e_offset = 2 ** fraction
 
-    positive = mb.greater_equal(x=x, y=0.)
-    zero = mb.equal(x=x, y=0.)
+    positive = mb.greater_equal(x=x, y=width(0.))
+    zero = mb.equal(x=x, y=width(0.))
     x = mb.abs(x=x)
-    e_raw = mb.floor_div(x=mb.log(x=x), y=mb.log(x=2.))
-    e_shifted = mb.cast(x=mb.add(x=e_raw, y=float(e_bias)), dtype="int32")
-    fractional = mb.sub(x=mb.real_div(x=x, y=mb.pow(x=2., y=e_raw)), y=1.)
-    mantissa = mb.cast(x=mb.floor(x=mb.mul(x=fractional, y=float(e_offset))), dtype="int32")
+    e_raw = mb.floor_div(x=mb.log(x=x), y=mb.log(x=width(2.)))
+    e_shifted = mb.cast(x=mb.add(x=e_raw, y=width(e_bias)), dtype="int32")
+    fractional = mb.sub(x=mb.real_div(x=x, y=mb.pow(x=width(2.), y=e_raw)), y=width(1.))
+    mantissa = mb.cast(x=mb.floor(x=mb.mul(x=fractional, y=width(e_offset))), dtype="int32")
     bits = mb.add(x=mb.mul(x=e_shifted, y=e_offset), y=mantissa)
     bits = mb.select(cond=zero, a=0, b=bits)
-    return positive, bits
+    return positive, bits, exponent + fraction + 1
 
 
 def bitcast_int(x):
     width = x.dtype.width
     assert types.is_int(x.dtype) and width in { 8, 16, 32 }
     packed, signed = width == 32, x.dtype.is_unsigned()
-    assert not split or not signed, "CoreML has no uint32 type"
+    assert not packed or not signed, "CoreML has no uint32 type"
 
     positive = mb.greater_equal(x=x, y=0) if signed else None
     x = mb.abs(x=x) if signed else x
     x = x if packed else mb.cast(x=x, dtype="int32")
-    return positive, x
+    return positive, x, width
 
 
 def bitcast_split(x, mask=16, ascending=True):
-    width = x.dtype.width
-    if types.is_int(x):
-        sign, x = bitcast_int(x)
-    elif types.is_float(x):
-        sign, x = bitcast_fp(x)
+    if types.is_int(x.dtype):
+        sign, x, width = bitcast_int(x)
+    elif types.is_float(x.dtype):
+        sign, x, width = bitcast_fp(x)
     else:
         raise TypeError("only int and float are supported for sorting")
 
@@ -70,7 +69,7 @@ def bitcast_split(x, mask=16, ascending=True):
             out = mb.select(cond=sign, a=flipped, b=split)
         results.append(out)
         x = mb.floor_div(x=x, y=2 ** mask)
-    return tuple(mb.mul(x=x, y=2 ** (31 - mask)) for x in reversed(results))
+    return tuple(mb.mul(x=x, y=2 ** (x.dtype.width - 1 - mask)) for x in reversed(results))
 
 
 def bitcast_window(x, n):
@@ -87,207 +86,90 @@ def bitcast_window(x, n):
         raise ValueError("refusing to split stable argsort into more than 4 unstable argsorts")
 
 
-def match_sort(comparator_root, args, inputs):
-    """
-    Analyzes the comparator region of a SortOp to determine if it implements a supported sorting pattern.
-    We try to analyze the comparator logic for multi-key sorts.
+def stable_argsort(x, axis=-1, ascending=True):
+    x = mb.cast(x=np.array(3.1415), dtype="fp32")
+    y = mb.cast(x=np.array(3.1415), dtype="fp16")
+    z = mb.cast(x=np.array(31415), dtype="int32")
+    w = mb.cast(x=np.array(31415), dtype="int16")
+    v = mb.cast(x=np.array(31415), dtype="int8")
+    print(bitcast_split(x))
+    print(bitcast_split(x, 11))
+    print(bitcast_split(y))
+    print(bitcast_split(z))
+    print(bitcast_split(w))
+    print(bitcast_split(v))
+    breakpoint()
 
-    Multi-key sort compares multiple keys in sequence. If the primary keys are equal,
-    it moves to the secondary keys, and so on.
 
-    The comparator logic is expected to look like a chain of SelectOps:
-    if (k1 == k2) then compare(next_keys) else compare(k1 < k2)
-
-    Args:
-        comparator_root: The current operation in the comparator region being analyzed (starts at the return value).
-        args: The arguments of the comparator block (representing the two elements being compared).
-        inputs: The list of input tensors to the SortOp.
-
-    Returns:
-        A list of (tensor, ascending) tuples representing the sort keys, or None if the pattern doesn't match.
-    """
-    def get_op(val):
-        if isinstance(val.owner, ir.Block):
-            return None
-        return val.owner.opview
-
+def match_sort(tracing, args, inputs):
     def get_arg_index(value):
         if value in args:
             return args.index(value)
-        op = get_op(value)
-        if op is None:
-            return None
-        return match_nan_and_zero_handling(op, args)
+        return verify_zero_nan(value.owner.opview, args)
 
-    def identify_comparison_args(compare_op: CompareOp) -> tuple[int | None, bool | None]:
-        lhs = get_arg_index(compare_op.lhs)
-        rhs = get_arg_index(compare_op.rhs)
-        if lhs is None or rhs is None:
-            return None, None
-
-        # According to StableHLO sort spec, arguments are guaranteed to be interleaved:
-        #   (lhs_0, rhs_0, lhs_1, rhs_1, ...)
-        # Therefore the input pair being compared should be adjacent, and the corresponding
-        # key index can be derived by integer division by 2.
-        # Reference: https://openxla.org/stablehlo/spec#sort
-        if (lhs // 2) != (rhs // 2):
-            return None, None
-
-        direction = hlo.ComparisonDirectionAttr(compare_op.comparison_direction).value
-        is_ascending = lhs < rhs and direction == "LT" or lhs > rhs and direction == "GT"
-
-        return lhs // 2, is_ascending
-
-    def match_comparison(op, expected_direction=None):
-        if not isinstance(op, CompareOp):
-            return None
-
-        direction = hlo.ComparisonDirectionAttr(op.comparison_direction).value
-        if expected_direction and direction != expected_direction:
-            return None
-
-        if expected_direction is None and direction not in ("LT", "GT"):
-            return None
-
-        return op
-
-    def match_select_chain(op):
-        # Matches: select(pred, on_true, on_false)
-        # where pred is (k1 == k2) and on_false is (k1 < k2)
-        if not isinstance(op, SelectOp):
-            return None
-
-        pred = get_op(op.pred)
-        on_false = get_op(op.on_false)
-
-        # 1. Check pred: k1 == k2
-        pred_cmp = match_comparison(pred, "EQ")
-        if not pred_cmp:
-            return None
-
-        # 2. Check on_false: k1 < k2 (or >)
-        false_cmp = match_comparison(on_false)
-        if not false_cmp:
-            return None
-
-        # 3. Verify operands match between pred and on_false
-        if {pred_cmp.lhs, pred_cmp.rhs} != {false_cmp.lhs, false_cmp.rhs}:
-            return None
-
-        # 4. Identify key
-        key_info = identify_comparison_args(pred_cmp)
-        if key_info[0] is None:
-            return None
-
-        return key_info, get_op(op.on_true)
-
-    def match_leaf(op):
-        # Matches: k1 < k2
-        cmp = match_comparison(op)
-        if not cmp:
-            return None
-        return identify_comparison_args(cmp)
-
-    # Walk through the operations graph to match the sort pattern
-    sort_keys = []
-    current_op = comparator_root
-    while current_op:
-        # Try to match a chain node (SelectOp)
-        chain_result = match_select_chain(current_op)
-        if chain_result:
-            (key_idx, is_asc), next_op = chain_result
-            sort_keys.append((inputs[key_idx], is_asc))
-            current_op = next_op
-            continue
-
-        # Try to match a leaf node (CompareOp)
-        leaf_result = match_leaf(current_op)
-        if leaf_result:
-            key_idx, is_asc = leaf_result
-            if key_idx is None:
+    remaining, expecting, priorities = None, None, []
+    while tracing:
+        match tracing:
+            case CompareOp():
+                direction = hlo.ComparisonDirectionAttr(tracing.comparison_direction).value
+                lhs, rhs = get_arg_index(tracing.lhs), get_arg_index(tracing.rhs)
+                if lhs is None or rhs is None:
+                    return None
+                if (direction != "EQ" or expecting not in ((lhs, rhs), (rhs, lhs))) if expecting else (
+                        direction not in ("LT", "GT") or lhs // 2 != rhs // 2 or lhs + 1 != rhs):
+                    return None
+                if not expecting:
+                    priorities.append((inputs[lhs // 2], direction == "LT"))
+                expecting = None if expecting else (lhs, rhs)
+                tracing, remaining = remaining, None
+            case OrOp() if not expecting:
+                tracing, remaining = tracing.lhs.owner.opview, tracing.rhs.owner.opview
+            case AndOp() if expecting:
+                tracing, remaining = tracing.lhs.owner.opview, tracing.rhs.owner.opview
+            case _:
                 return None
-            sort_keys.append((inputs[key_idx], is_asc))
-            return sort_keys
-
-        # If neither matched, it's not a valid sort pattern
-        return None
-
-    return sort_keys
+    return priorities
 
 
-def match_nan_and_zero_handling(op, args):
-    """
-    Jax generates nan-checks and +0/-0 merges in the comparator. This function matches this pattern:
-        select(<var> != <var>, NaN, select(<var> == 0, 0, <var>))
-
-    It will extract the argument index of <var> if the pattern matches.
-
-    Notice that this is technically non correct, as MIL does not handle NaN's in the same way as StableHLO.
-    +0/-0 looks to be correctly handled.
-    """
-    def get_op(val):
-        if isinstance(val.owner, ir.Block):
-            return None
-        return val.owner.opview
-
-    def match_constant(val, check_fn):
-        const_op = get_op(val)
-        if not isinstance(const_op, ConstantOp):
-            return False
-        return check_fn(const_op.value)
-
-    def match_isnan(val):
-        # Matches: <var> != <var>
-        compare_op = get_op(val)
-        if not isinstance(compare_op, CompareOp):
-            return None
-        if hlo.ComparisonDirectionAttr(compare_op.comparison_direction).value != "NE":
-            return None
-        if compare_op.lhs != compare_op.rhs:
-            return None
-        return compare_op.lhs
-
-    def match_is_zero(val):
-        # Matches: <var> == 0
-        compare_op = get_op(val)
-        if not isinstance(compare_op, CompareOp):
-            return None
-        if hlo.ComparisonDirectionAttr(compare_op.comparison_direction).value != "EQ":
-            return None
-        if not match_constant(compare_op.rhs, lambda x: np.array(x) == 0):
-            return None
-        return compare_op.lhs
-
-    # 1. Match outer select: select(pred, NaN, on_false)
-    if not isinstance(op, SelectOp):
-        return None
-
-    if not match_constant(op.on_true, np.isnan):
-        return None
-
-    # 2. Match NaN check: pred is (x != x)
-    matched_arg_idx = match_isnan(op.pred)
-    if matched_arg_idx is None:
-        return None
-
-    # 3. Match inner select: select(pred, 0, x)
-    inner_op = get_op(op.on_false)
-    if not isinstance(inner_op, SelectOp):
-        return None
-
-    if not match_constant(inner_op.on_true, lambda x: np.array(x) == 0):
-        return None
-
-    if inner_op.on_false != matched_arg_idx:
-        return None
-
-    # 4. Match Zero check: pred is (x == 0)
-    x_val_zero = match_is_zero(inner_op.pred)
-    if x_val_zero != matched_arg_idx:
-        return None
-
-    # 5. Return index if found in args
-    if matched_arg_idx in args:
-        return args.index(matched_arg_idx)
-
-    return None
+def verify_zero_nan(tracing, args):
+    remaining, idx = None, None
+    selecting, comparing = [lambda x: np.array(x) == 0, np.isnan], ["EQ", "NE"]
+    while tracing:
+        match tracing:
+            case SelectOp():
+                const = tracing.operands[1].owner.opview
+                if not isinstance(const, ConstantOp):
+                    return None
+                if not len(selecting) or not selecting.pop()(const.value):
+                    return None
+                if len(selecting): # select CompareOp %cst_# (=NaN) SelectOp
+                    remaining = tracing.operands[2].owner.opview
+                    tracing = tracing.operands[0].owner.opview
+                else: # select CompareOp %cst_# (=0) %arg#
+                    # we should know the arg index from the popped CompareOp
+                    if idx is None or tracing.operands[2] != args[idx]:
+                        return None
+                    tracing, remaining = tracing.operands[0].owner.opview, None
+            case CompareOp():
+                direction = hlo.ComparisonDirectionAttr(tracing.comparison_direction).value
+                if not len(comparing) or direction != comparing.pop():
+                    return None
+                if len(comparing): # `np.isnan` via `NE %arg# %arg#`
+                    if tracing.lhs != tracing.rhs or tracing.lhs not in args:
+                        return None
+                    # ensure op types are interleaved as expected
+                    # by checking the size of the selection queue
+                    if len(selecting) != 1:
+                        return None
+                    idx = args.index(tracing.lhs)
+                    tracing, remaining = remaining, None
+                else: # merge `-0` and `+0` via `EQ %arg# %cst_# (=0.)`
+                    const = tracing.rhs.owner.opview
+                    if not isinstance(const, ConstantOp):
+                        return None
+                    if np.array(const.value) != 0 or tracing.lhs != args[idx]:
+                        return None
+                    tracing = None
+            case _:
+                return None
+    return idx

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -64,7 +64,7 @@ def bitcast_fp(x):
     e_shifted = mb.select(cond=is_special, a=max_exp, b=e_shifted)
 
     # Inf: mantissa = 0, NaN: mantissa = max (to sort after Inf)
-    mantissa_special = mb.select(cond=is_nan, a=e_offset - 1, b=0)
+    mantissa_special = mb.select(cond=is_nan, a=e_offset - 1, b=np.zeros(is_nan.shape, dtype=np.int32))
     mantissa = mb.select(cond=is_special, a=mantissa_special, b=mantissa)
 
     # Handle Zero (override everything)

--- a/stablehlo_coreml/sort_utils.py
+++ b/stablehlo_coreml/sort_utils.py
@@ -7,6 +7,8 @@ from jax._src.lib.mlir.dialects import hlo
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 
+from .utils import get_mil_type_bit_width
+
 
 def bitcast_fp(x):
     fp_dtype = types.nptype_from_builtin(x.dtype)
@@ -74,7 +76,7 @@ def bitcast_fp(x):
 
 
 def bitcast_int(x):
-    width = x.dtype.width
+    width = get_mil_type_bit_width(x)
     if not types.is_int(x.dtype) or width not in {8, 16, 32}:
         raise ValueError(
             f"Stable argsort recieved unexpected integer dtype width of {width} bits which is unsupported because "
@@ -139,7 +141,7 @@ def stable_argsort(x, axis=-1, ascending=True):
     splits = bitcast_split(x, mask, ascending)
 
     def shifted(x):
-        return mb.add(x=mb.mul(x=x, y=2 ** (x.dtype.width - 1 - mask)), y=arange)
+        return mb.add(x=mb.mul(x=x, y=2 ** (get_mil_type_bit_width(x) - 1 - mask)), y=arange)
 
     indices = mb.argsort(x=shifted(splits[0]), axis=axis, ascending=True)
     for window in splits[1:]:

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -291,6 +291,10 @@ def get_numpy_type(obj):
     return types.nptype_from_builtin(get_mil_type(obj))
 
 
+def get_mil_type_bit_width(obj):
+    return get_numpy_type(obj)().itemsize * 8
+
+
 def dtype_str(type):
     # TODO(knielsen): Add additional types
     return {

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -316,6 +316,7 @@ def clamp_index(index, shape, size):
     index = mb.maximum(x=index, y=0)
     return index
 
+
 def range_along_dim(shape, axis, dtype):
     axis = len(shape) + axis if axis < 0 else axis
     vec_shape = [shape[dim] if dim == axis else 1 for dim in range(len(shape))]

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -317,6 +317,7 @@ def clamp_index(index, shape, size):
     return index
 
 def range_along_dim(shape, axis, dtype):
+    axis = len(shape) + axis if axis < 0 else axis
     vec_shape = [shape[dim] if dim == axis else 1 for dim in range(len(shape))]
     vec_reps = [1 if dim == axis else shape[dim] for dim in range(len(shape))]
     arange = mb.range_1d(start=dtype(0), end=dtype(shape[axis]), step=dtype(1))

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -315,3 +315,9 @@ def clamp_index(index, shape, size):
     index = mb.minimum(x=index, y=max_start_indices)
     index = mb.maximum(x=index, y=0)
     return index
+
+def range_along_dim(shape, axis, dtype):
+    vec_shape = [shape[dim] if dim == axis else 1 for dim in range(len(shape))]
+    vec_reps = [1 if dim == axis else shape[dim] for dim in range(len(shape))]
+    arange = mb.range_1d(start=dtype(0), end=dtype(shape[axis]), step=dtype(1))
+    return mb.tile(x=mb.reshape(x=arange, shape=vec_shape), reps=vec_reps)

--- a/tests/test_hlo.py
+++ b/tests/test_hlo.py
@@ -1,0 +1,22 @@
+import jax
+import jax.numpy as jnp
+from jax.export import export as _jax_export
+from jax._src.lib.mlir import ir
+from jax._src.interpreters import mlir as jax_mlir
+
+from tests.utils import run_and_compare_hlo_module
+
+
+def test_stable_sort_descending():
+    input_shape = (8,)
+    obj = _jax_export(jnp.argsort)(jnp.zeros(input_shape, dtype=jnp.float32))
+    readable = obj.mlir_module()
+    assert readable.count("LT") == 1
+    modified = readable.replace("LT", "GT")
+    context = jax_mlir.make_ir_context()
+    descending = ir.Module.parse(modified, context=context)
+
+    test = jax.random.uniform(jax.random.key(0), shape=input_shape)
+    expected = jnp.argsort(test, descending=True)
+
+    run_and_compare_hlo_module(descending, (test,), expected)

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -659,6 +659,7 @@ def test_clamp():
 
 def test_sort():
     run_and_compare(jnp.sort, (jnp.array([3, 1, 2], dtype=jnp.int32),))
+    run_and_compare(jnp.argsort, (jnp.array([3, 1, 2, 0x8002], dtype=jnp.uint16),))
     run_and_compare(jnp.sort, (jnp.array([[3, 1, 2], [6, 5, 4]], dtype=jnp.float32),))
     run_and_compare(partial(jnp.sort, axis=0), (jnp.array([[3, 1, 2], [6, 5, 4]], dtype=jnp.float32),))
 
@@ -768,7 +769,7 @@ def test_sort_int16_casting():
     def sort_dim_0(k1, k2):
         return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
 
-    def check_size(size=0x100_0000):
+    def check_size(size):
         key = jax.random.PRNGKey(0)
         subkey1, subkey2 = jax.random.split(key)
         k1 = jax.random.randint(subkey1, (size,), 0, 1_000, dtype=jnp.int32)
@@ -777,6 +778,7 @@ def test_sort_int16_casting():
 
     check_size(0x100)
     check_size(0x1_0010)
+    check_size(0x40_0000)
 
 
 def test_case():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 from functools import partial
+import pytest
 
 from tests.utils import run_and_compare, run_and_compare_specific_input, get_model_instruction_types
 

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -683,6 +683,14 @@ def test_sort():
     run_and_compare_specific_input(jnp.sort, (subnormals,))
 
 
+def test_sort_fp16_ln_bitcast():
+    vals = [jnp.float16(2**-11)]
+    for _ in range(7):
+        vals.append(jnp.nextafter(vals[-1], jnp.float16(0.0)))
+    data = jnp.array(vals, dtype=jnp.float16)
+    run_and_compare_specific_input(jnp.argsort, (data,))
+
+
 def test_argsort():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True),
                                    (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -1,7 +1,6 @@
 import jax
 import jax.numpy as jnp
 from functools import partial
-import pytest
 
 from tests.utils import run_and_compare, run_and_compare_specific_input, get_model_instruction_types
 
@@ -362,11 +361,16 @@ def test_sort():
 
 
 def test_argsort():
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
+                                   (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
+                                   (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
+                                   (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array(range(-8, 17), dtype=jnp.float32),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([-2, -1, -0.6, -0.5, -0.3, -0.2, -0.1, 0, 0.1, 0.2, 0.3, 0.5, 0.6, 1], dtype=jnp.float32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
+                                   (jnp.array([-2, -1, -0.6, -0.5, -0.3, -0.2, -0.1, 0, 0.1, 0.2, 0.3, 0.5, 0.6, 1],
+                                              dtype=jnp.float32),))
 
 
 def test_multikey_sort():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -356,7 +356,7 @@ def test_sort():
 
 
 def test_tmp():
-    # run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float16),))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -348,11 +348,7 @@ def test_sort():
     # Test with NaNs and negative zeros to trigger total sort logic
     # Total sort order for floats: -Inf < ... < -0.0 == 0.0 < ... < Inf < NaN
     # Note: CoreML handles NaNs differently than JAX (CoreML puts them at the beginning, JAX at the end)
-    data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf, jnp.nan], dtype=jnp.float32)
-    run_and_compare_specific_input(jnp.sort, (data,))
-    run_and_compare_specific_input(jnp.argsort, (data,))
-
-    data = jnp.array([jnp.nan, 0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf], dtype=jnp.float32)
+    data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.nan, jnp.inf, -jnp.inf, jnp.nan], dtype=jnp.float32)
     run_and_compare_specific_input(jnp.sort, (data,))
     run_and_compare_specific_input(jnp.argsort, (data,))
 

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -360,7 +360,7 @@ def test_tmp():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array(range(-8, 17), dtype=jnp.float32),))
-
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([-2, -1, -0.6, -0.5, -0.3, -0.2, -0.1, 0, 0.1, 0.2, 0.3, 0.5, 0.6, 1], dtype=jnp.float32),))
 
 
 def test_multikey_sort_fails_due_to_stability():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -355,6 +355,14 @@ def test_sort():
     run_and_compare_specific_input(jnp.sort, (data,))
 
 
+def test_tmp():
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float16),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float32),))
+
+
+
 def test_multikey_sort_fails_due_to_stability():
     # Test lexicographical sort with multiple keys
     def sort_dim_0(k1, k2):

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -355,7 +355,7 @@ def test_sort():
     run_and_compare_specific_input(jnp.sort, (data,))
 
 
-def test_tmp():
+def test_argsort():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
@@ -363,25 +363,22 @@ def test_tmp():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([-2, -1, -0.6, -0.5, -0.3, -0.2, -0.1, 0, 0.1, 0.2, 0.3, 0.5, 0.6, 1], dtype=jnp.float32),))
 
 
-def test_multikey_sort_fails_due_to_stability():
+def test_multikey_sort():
     # Test lexicographical sort with multiple keys
     def sort_dim_0(k1, k2):
         return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
 
     k1 = jnp.array([1, 3, 2, 4], dtype=jnp.int32)
     k2 = jnp.array([3, 1, 2, 4], dtype=jnp.int32)
-    with pytest.raises(Exception):
-        run_and_compare_specific_input(sort_dim_0, (k1, k2))
+    run_and_compare_specific_input(sort_dim_0, (k1, k2))
 
     k1 = jnp.array([1, 5, 1, 4, 3, 4, 4], dtype=jnp.int32)
     k2 = jnp.array([9, 4, 0, 4, 0, 2, 1], dtype=jnp.int32)
-    with pytest.raises(Exception):
-        run_and_compare_specific_input(sort_dim_0, (k1, k2))
+    run_and_compare_specific_input(sort_dim_0, (k1, k2))
 
     k1 = jnp.array([1, 3, 1, 4, 3, 5, 4], dtype=jnp.int32)
     k2 = jnp.array([0, 4, 0, 4, 0, -21, -12], dtype=jnp.int32)
-    with pytest.raises(Exception):
-        run_and_compare_specific_input(sort_dim_0, (k1, k2))
+    run_and_compare_specific_input(sort_dim_0, (k1, k2))
 
     k1_2d = jnp.array([[1, 2], [3, 4]], dtype=jnp.int32)
     k2_2d = jnp.array([[3, 1], [2, 4]], dtype=jnp.int32)
@@ -389,17 +386,14 @@ def test_multikey_sort_fails_due_to_stability():
     def sort_dim_1(k1, k2):
         return jax.lax.sort([k1, k2], dimension=1, num_keys=2)
 
-    with pytest.raises(Exception):
-        run_and_compare_specific_input(sort_dim_1, (k1_2d, k2_2d))
+    run_and_compare_specific_input(sort_dim_1, (k1_2d, k2_2d))
 
     # Larger random inputs
     def sort_dim_0_large(k1, k2):
         return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
 
-    with pytest.raises(Exception):
-        run_and_compare(sort_dim_0_large, (jnp.zeros((100, 50), dtype=jnp.int32), jnp.zeros((100, 50), dtype=jnp.int32)))
-    with pytest.raises(Exception):
-        run_and_compare(sort_dim_0_large, (jnp.zeros((100, 50), dtype=jnp.float32), jnp.zeros((100, 50), dtype=jnp.float32)))
+    run_and_compare(sort_dim_0_large, (jnp.zeros((100, 50), dtype=jnp.int32), jnp.zeros((100, 50), dtype=jnp.int32)))
+    run_and_compare(sort_dim_0_large, (jnp.zeros((100, 50), dtype=jnp.float32), jnp.zeros((100, 50), dtype=jnp.float32)))
 
 
 def test_unstable_argsort():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -351,8 +351,14 @@ def test_sort():
     # (or similar, depending on implementation, but it must be total)
     # Note: CoreML handles NaNs differently than JAX (CoreML puts them at the beginning, JAX at the end)
     # So we exclude NaNs from this test to ensure we test the rest of the total sort logic (signed zeros etc)
-    data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf], dtype=jnp.float32)
+    data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf, jnp.nan], dtype=jnp.float32)
     run_and_compare_specific_input(jnp.sort, (data,))
+
+    # Test with subnormals
+    # Smallest normal float32 is 1.17549435e-38
+    # Largest subnormal float32 is 1.17549421e-38
+    subnormals = jnp.array([1.17549435e-38, 1.17549421e-38, -1.17549421e-38, 0.0], dtype=jnp.float32)
+    run_and_compare_specific_input(jnp.sort, (subnormals,))
 
 
 def test_argsort():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -356,7 +356,8 @@ def test_sort():
 
 
 def test_tmp():
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
+    # run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float16),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float32),))

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -439,6 +439,24 @@ def test_multi_input_argsort():
     ))
 
 
+def test_sort_int16_casting():
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
+                                   (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
+
+    def sort_dim_0(k1, k2):
+        return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
+
+    def check_size(size=0x100_0000):
+        key = jax.random.PRNGKey(0)
+        subkey1, subkey2 = jax.random.split(key)
+        k1 = jax.random.randint(subkey1, (size,), 0, 1_000, dtype=jnp.int32)
+        k2 = jax.random.uniform(subkey2, (size,), dtype=jnp.float32)
+        run_and_compare_specific_input(sort_dim_0, (k1, k2))
+
+    check_size(0x100)
+    check_size(0x1_0010)
+
+
 def test_case():
     def switch_fn(index, x):
         return jax.lax.switch(index, [

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -347,8 +347,12 @@ def test_sort():
 
     # Test with NaNs and negative zeros to trigger total sort logic
     # Total sort order for floats: -Inf < ... < -0.0 == 0.0 < ... < Inf < NaN
-    # Note: CoreML handles NaNs differently than JAX (CoreML puts them just after -Inf, JAX at the end)
+    # Note: CoreML handles NaNs differently than JAX (CoreML puts them at the beginning, JAX at the end)
     data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf, jnp.nan], dtype=jnp.float32)
+    run_and_compare_specific_input(jnp.sort, (data,))
+    run_and_compare_specific_input(jnp.argsort, (data,))
+
+    data = jnp.array([jnp.nan, 0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf], dtype=jnp.float32)
     run_and_compare_specific_input(jnp.sort, (data,))
     run_and_compare_specific_input(jnp.argsort, (data,))
 

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -364,8 +364,6 @@ def test_argsort():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True),
                                    (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True),
-                                   (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True),
                                    (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array(range(-8, 17), dtype=jnp.float32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True),
@@ -439,22 +437,6 @@ def test_multi_input_argsort():
         jnp.array([2, 0, 1, 2, 0, 1, 2, 0, 1], dtype=jnp.int32),
         jnp.array([0, 1, 2], dtype=jnp.float32)
     ))
-
-
-def test_massive_sort():
-    def sort_dim_0(k1, k2):
-        return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
-
-    def check_size(size=0x100_0000):
-        key = jax.random.PRNGKey(0)
-        subkey1, subkey2 = jax.random.split(key)
-        k1 = jax.random.randint(subkey1, (size,), 0, 1_000, dtype=jnp.int32)
-        k2 = jax.random.uniform(subkey2, (size,), dtype=jnp.float32)
-        run_and_compare_specific_input(sort_dim_0, (k1, k2))
-
-    check_size(0x100)
-    check_size(0x1_0000)
-    check_size(0x1_0010)
 
 
 def test_case():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -346,12 +346,11 @@ def test_sort():
     run_and_compare(partial(jnp.sort, axis=0, descending=True), (jnp.zeros((100, 50), dtype=jnp.float32),))
 
     # Test with NaNs and negative zeros to trigger total sort logic
-    # Total sort order for floats: NaN < -Inf < ... < -0.0 < 0.0 < ... < Inf
-    # (or similar, depending on implementation, but it must be total)
-    # Note: CoreML handles NaNs differently than JAX (CoreML puts them at the beginning, JAX at the end)
-    # So we exclude NaNs from this test to ensure we test the rest of the total sort logic (signed zeros etc)
+    # Total sort order for floats: -Inf < ... < -0.0 == 0.0 < ... < Inf < NaN
+    # Note: CoreML handles NaNs differently than JAX (CoreML puts them just after -Inf, JAX at the end)
     data = jnp.array([0.0, -0.0, 1.0, -1.0, jnp.inf, -jnp.inf, jnp.nan], dtype=jnp.float32)
     run_and_compare_specific_input(jnp.sort, (data,))
+    run_and_compare_specific_input(jnp.argsort, (data,))
 
     # Test with subnormals
     # Smallest normal float32 is 1.17549435e-38

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -359,8 +359,7 @@ def test_tmp():
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 5, 10, 5, 10, 5, 10, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, 10, 0x1_0010, 10, 0x5_0000, 10, 5, 10, 0x1_0000, 5], dtype=jnp.int32),))
     run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 5, 10, -5, 10, -5, -10, 5], dtype=jnp.int32),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float16),))
-    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array([10, 5, -10, 4.23, 10, -4.3, 10, -5, -10, 5], dtype=jnp.float32),))
+    run_and_compare_specific_input(partial(jnp.argsort, stable=True), (jnp.array(range(-8, 17), dtype=jnp.float32),))
 
 
 

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -441,6 +441,22 @@ def test_multi_input_argsort():
     ))
 
 
+def test_massive_sort():
+    def sort_dim_0(k1, k2):
+        return jax.lax.sort([k1, k2], dimension=0, num_keys=2)
+
+    def check_size(size=0x100_0000):
+        key = jax.random.PRNGKey(0)
+        subkey1, subkey2 = jax.random.split(key)
+        k1 = jax.random.randint(subkey1, (size,), 0, 1_000, dtype=jnp.int32)
+        k2 = jax.random.uniform(subkey2, (size,), dtype=jnp.float32)
+        run_and_compare_specific_input(sort_dim_0, (k1, k2))
+
+    check_size(0x100)
+    check_size(0x1_0000)
+    check_size(0x1_0010)
+
+
 def test_case():
     def switch_fn(index, x):
         return jax.lax.switch(index, [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,8 +119,11 @@ def run_and_compare_hlo_module(
 
     pipeline = DEFAULT_HLO_PIPELINE
     # We temporarily avoid fp16 conversions in tests because of https://github.com/apple/coremltools/issues/2324
+    # We avoid int16 conversions in tests at least until merge/release of https://github.com/apple/coremltools/pull/2626
+    # Removing int16 conversions is prerequisite for `test_sort_int16_casting`
     passes_to_remove = [
-         'common::add_fp16_cast'
+         'common::add_fp16_cast',
+         'common::add_int16_cast',
     ]
     pipeline.remove_passes(passes_to_remove)
 


### PR DESCRIPTION
I rolled back the `match_sort` implementation because of the `AndOp`/`OrOp` thing. Not quite sure where that kind of `SelectOp` is used?