### PR TITLE
Support padding of integer tensors

### DIFF
--- a/stablehlo_coreml/padding.py
+++ b/stablehlo_coreml/padding.py
@@ -1,0 +1,23 @@
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from .utils import get_mil_type, dtype_str
+
+
+def pad_with_cast(x, pad, mode="constant", constant_val=None):
+    """
+    Helper function to handle padding for integer tensors.
+    mb.pad only supports fp16 and fp32 inputs, so we cast to float, pad, and cast back.
+    """
+    mil_type = get_mil_type(x)
+    is_int_input = types.is_int(mil_type)
+    if is_int_input:
+        x = mb.cast(x=x, dtype="fp32")
+        if constant_val is not None:
+            constant_val = mb.cast(x=constant_val, dtype="fp32")
+
+    padded = mb.pad(x=x, pad=pad, mode=mode, constant_val=constant_val)
+
+    if is_int_input:
+        padded = mb.cast(x=padded, dtype=dtype_str(mil_type))
+
+    return padded

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -313,6 +313,11 @@ def test_pad():
     run_and_compare(partial(jnp.pad, pad_width=((5, 10), (10, 5)), mode="symmetric"), (jnp.zeros((10, 20)),))
 
 
+def test_pad_int32():
+    run_and_compare(partial(jnp.pad, pad_width=((1, 1), (2, 2)), constant_values=10), (jnp.zeros((5, 5), dtype=jnp.int32),))
+    run_and_compare(partial(jnp.pad, pad_width=((1, 1), (2, 2))), (jnp.zeros((5, 5), dtype=jnp.int32),))
+
+
 def test_remainder():
     run_and_compare(jnp.remainder, (
         jnp.array([10, 20, 30], dtype=jnp.int32), jnp.array([3, 7, 11], dtype=jnp.int32)


### PR DESCRIPTION
MIL only supports padding of fp16 and fp32 tensors. We will support padding of int-typed tensors by casting to fp32 prior to padding.