### PR TITLE
use `mb.const` for `ConstantOp`

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -262,7 +262,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
     def op_constant(self, context: TranslationContext, op: ConstantOp):
         constant = np.array(op.value)
         constant = np.reshape(constant, op.result.type.shape)
-        context.add_result(op.result, constant)
+        context.add_result(op.result, mb.const(val=constant))
 
     @register_stablehlo_op
     def op_dot_general(self, context: TranslationContext, op: DotGeneralOp):


### PR DESCRIPTION
```python
TranslationContext.add_result(self, hlo_result, result: mil.Var)
```
As-is, variables with `np.array` values get added to the context, which resulted in an error at [coremltools/coremltools/converters/mil/mil/block.py](https://github.com/apple/coremltools/blob/37d01e779bca3167c60792c1233f8a141edeb86b/coremltools/converters/mil/mil/block.py#L434)