### PR TITLE
Make register_optimizations idempotent

### DIFF
--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -8,4 +8,6 @@ def register_optimizations():
     custom_passes = [remove_noop_slice_update]
 
     for custom_pass in custom_passes:
-        DEFAULT_HLO_PIPELINE.append_pass(f"common::{custom_pass.__name__}")
+        pass_name = f"common::{custom_pass.__name__}"
+        if pass_name not in DEFAULT_HLO_PIPELINE.passes:
+            DEFAULT_HLO_PIPELINE.append_pass(pass_name)

--- a/tests/passes/test_register_optimizations.py
+++ b/tests/passes/test_register_optimizations.py
@@ -1,0 +1,10 @@
+from stablehlo_coreml import register_optimizations
+from stablehlo_coreml.passes.utils import DEFAULT_HLO_PIPELINE
+
+
+def test_register_optimizations_is_idempotent():
+    register_optimizations()
+    register_optimizations()
+
+    pass_name = "common::remove_noop_slice_update"
+    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1


### PR DESCRIPTION
## Summary
- `register_optimizations()` is called inside every `convert()`, and each call appended `common::remove_noop_slice_update` to the module-level `DEFAULT_HLO_PIPELINE` again. Converting N models in one process caused the pass to be registered (and run) N times.
- Fix: skip appending when the pass name is already present in `DEFAULT_HLO_PIPELINE.passes`, making `register_optimizations()` idempotent.

## Test plan
- New unit test `tests/passes/test_register_optimizations.py` calls `register_optimizations()` twice and asserts the pass appears exactly once in the pipeline.
- `pytest tests/passes -q`: 7 passed.
- `ruff check .`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)