### PR TITLE
Fix packaging metadata and bump stale CI actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.13'
     - name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -45,11 +45,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache Hugging Face and Torch models
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/huggingface

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ StableHLO is the portability layer used by ML frameworks like [JAX](https://gith
 pip install stablehlo-coreml
 ```
 
-Requires Python 3.9+ and targets iOS/macOS 18+.
+Requires Python 3.10–3.13 and targets iOS/macOS 18+.
 
 ## Supported Frameworks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,17 @@ classifiers = [
     "Topic :: Software Development"
 ]
 keywords=[ "stablehlo", "hlo", "xla", "coreml", "machinelearning", "ml", "coremltools", "converter", "neural" ]
-requires-python = ">=3.9"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
-    'coremltools>=9.0; python_version >= "3.10" and python_version <= "3.13"',
+    "coremltools>=9.0",
     "numpy~=2.0",
 
     # Jax is not actually a strict requirement for the main library.
     # However, the code relies on the mlir StableHLO python bindings, and currently they are not published to pip
     # and the only pre-built stand-alone library is only built for linux.
     # Onces https://github.com/openxla/stablehlo/issues/2346 is resolved, this dependency can be switch to stablehlo instead.
-    "jax==0.9.1",
+    "jax>=0.9.1,<0.10",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
## Summary

### Packaging metadata (`pyproject.toml`)
- **`requires-python`: `>=3.9` → `>=3.10,<3.14`.** The declared range was wrong on both ends:
  - On **Python 3.9**, the package installed fine but failed at import with `SyntaxError` — the code uses `match` statements and `X | None` unions (3.10+ syntax, and ruff already targets py312).
  - On **Python 3.14**, the package installed *without coremltools at all*, because the dependency carried the marker `python_version >= "3.10" and python_version <= "3.13"` — silently producing a broken install (coremltools supports at most 3.13).
- **Simplify coremltools dep** to plain `coremltools>=9.0`; the environment marker is redundant now that `requires-python` bounds the supported range.
- **Relax `jax==0.9.1` to `jax>=0.9.1,<0.10`.** The exact pin made the library impossible to co-install with any other jax version, even though jax is only needed for the bundled MLIR/StableHLO python bindings (explanatory comment kept).
- README updated to say Python 3.10–3.13 instead of 3.9+.

### CI staleness (`.github/workflows`)
- `actions/setup-python@v3` (deprecated) → `@v5` in `run-tests.yml` and `publish-to-pypi.yml`.
- `actions/cache@v3` → `@v4` in `run-tests.yml`.

Everything else (runners, hatch usage) unchanged.

## Verification
- `tomllib` parses `pyproject.toml`; `hatch project metadata` reports `"requires-python": "<3.14,>=3.10"` and the simplified deps.
- `ruff check .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)