### PR TITLE
Fix operator precedence in _resolve_slice_spec shape computation

### DIFF
--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -98,7 +98,8 @@ def _resolve_slice_spec(tensor, slice_spec) -> ResolvedSliceSpec:
             start_indices.append(spec.start or 0)
             end_indices.append(spec.stop or tensor.shape[dim_counter])
             strides.append(spec.step or 1)
-            shape.append(end_indices[-1] - start_indices[-1] // strides[-1])
+            # A slice [start:end:stride] selects ceil((end - start) / stride) elements
+            shape.append(-(-(end_indices[-1] - start_indices[-1]) // strides[-1]))
             dim_counter += 1
         elif isinstance(spec, type(Ellipsis)):
             if any([isinstance(s, type(Ellipsis)) for s in slice_spec[i+1:]]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,64 @@
+import coremltools as ct
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+
+from stablehlo_coreml.utils import (
+    _resolve_slice_spec,
+    index_by_slices,
+    update_tensor_by_slice,
+)
+
+
+class TestResolveSliceSpec:
+
+    def test_non_trivial_slice(self):
+        """
+        A slice [start:end:stride] selects ceil((end - start) / stride) elements.
+        Previously the shape was computed as `end - start // stride` due to a
+        missing parenthesis, which only worked for start=0, stride=1.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            spec = _resolve_slice_spec(x, [slice(2, 9, 3), slice(5, 20, 1)])
+            # [2:9:3] selects indices 2, 5, 8 -> 3 elements (ceil(7 / 3))
+            assert spec.start_indices == [2, 5]
+            assert spec.end_indices == [9, 20]
+            assert spec.strides == [3, 1]
+            assert spec.shape == [3, 15]
+            return x
+
+    def test_slice_with_defaults(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 6))])
+        def prog(x):
+            spec = _resolve_slice_spec(x, [slice(None), slice(1, None, 2)])
+            assert spec.start_indices == [0, 1]
+            assert spec.end_indices == [4, 6]
+            assert spec.strides == [1, 2]
+            # [1:6:2] selects indices 1, 3, 5 -> 3 elements
+            assert spec.shape == [4, 3]
+            return x
+
+    def test_ellipsis_and_integer_index(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4, 5))])
+        def prog(x):
+            spec = _resolve_slice_spec(x, [Ellipsis, 2])
+            assert spec.start_indices == [0, 0, 2]
+            assert spec.end_indices == [3, 4, 3]
+            assert spec.strides == [1, 1, 1]
+            assert spec.shape == [3, 4, 1]
+            return x
+
+    def test_index_by_slices_output_shape(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            result = index_by_slices(x, [slice(2, 9, 3), slice(5, 20, 1)])
+            assert tuple(result.shape) == (3, 15)
+            return result
+
+    def test_update_tensor_by_slice_with_non_trivial_slice(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 15))], opset_version=ct.target.iOS18)
+        def prog(x):
+            buffer = np.zeros((10, 20), dtype=np.float32)
+            result = update_tensor_by_slice(buffer, [slice(2, 9, 3), slice(5, 20, 1)], x)
+            assert tuple(result.shape) == (10, 20)
+            return result


### PR DESCRIPTION
## Summary

`_resolve_slice_spec` in `stablehlo_coreml/utils.py` computed the resolved shape for a `slice` spec as:

```python
shape.append(end_indices[-1] - start_indices[-1] // strides[-1])
```

Due to Python operator precedence this evaluates as `end - (start // stride)`, not the intended number of elements selected by the slice. A slice `[start:end:stride]` selects `ceil((end - start) / stride)` elements, so the branch now uses ceiling division:

```python
shape.append(-(-(end_indices[-1] - start_indices[-1]) // strides[-1]))
```

This also makes the `slice` branch consistent with the `Ellipsis` branch a few lines below, which already computes `(end - start) // stride`. The `Ellipsis` branch was left as plain floor division since its strides are always 1, so ceiling vs. floor makes no difference there.

## Why this is latent

All current call sites pass `slice(None)` (i.e. start=0, stride=1), for which `end - (start // stride) == end - start`, so nothing is broken today. However, any future caller using a non-trivial slice (nonzero start or stride > 1) would silently get a wrong `shape`, which `update_tensor_by_slice` uses as the reshape target for the update value — producing an incorrect reshape (or a confusing failure) far from the actual bug.

## Tests

Added `tests/test_utils.py` exercising `_resolve_slice_spec`, `index_by_slices` and `update_tensor_by_slice` with non-trivial slices (nonzero start, stride > 1) inside minimal `mb.program` contexts, asserting on the resolved spec and MIL var shapes directly (no model compilation needed).

- `tests/test_utils.py`: 5 passed
- `tests/passes`: 6 passed
- `pytest -k "gather or scatter or reduce" tests/test_jax.py`: 63 passed
- `ruff check .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)