### PR TITLE
Improve op_pad: constant pad vector and negative edge padding support

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -102,6 +102,7 @@ from .utils import (
     range_along_dim,
     safe_cast_to_int32,
     update_tensor_by_slice,
+    zero_tensor,
 )
 
 
@@ -452,24 +453,33 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             raise ValueError("Interior padding is not supported")
 
         operand_rank = len(op.operand.type.shape)
-        indices = np.arange(2 * operand_rank, dtype=np.int32)
-        pad = np.zeros_like(indices)
-        pad = mb.scatter_along_axis(
-            data=pad,
-            indices=indices[::2],
-            mode="update",
-            updates=np.array(op.edge_padding_low, dtype=np.int32)
-        )
-        pad = mb.scatter_along_axis(
-            data=pad,
-            indices=indices[1::2],
-            mode="update",
-            updates=np.array(op.edge_padding_high, dtype=np.int32)
-        )
+        padding_low = safe_cast_to_int32(op.edge_padding_low, "edge_padding_low")
+        padding_high = safe_cast_to_int32(op.edge_padding_high, "edge_padding_high")
 
-        cml_padding_value = context[op.padding_value.get_name()]
-        cml_op = pad_with_cast(x=operand, pad=pad, mode="constant", constant_val=cml_padding_value)
-        context.add_result(op.result, cml_op)
+        # StableHLO allows negative edge padding, which crops elements from the
+        # corresponding edge. `mb.pad` does not support negative values, so we
+        # handle the negative components with a `slice_by_index` crop, and the
+        # non-negative components with a regular pad. Since interior padding is
+        # rejected above, each edge is either cropped or padded (never both),
+        # so the order of the two operations does not matter.
+        result = operand
+        if np.any(padding_low < 0) or np.any(padding_high < 0):
+            begin = np.maximum(-padding_low, 0).tolist()
+            # For dims cropped at the high edge, a negative end index counts
+            # from the end of the dimension. Un-cropped dims are masked out, so
+            # this also works for symbolic shapes.
+            end = np.minimum(padding_high, 0).tolist()
+            end_mask = (padding_high >= 0).tolist()
+            result = mb.slice_by_index(x=result, begin=begin, end=end, end_mask=end_mask)
+
+        pad = np.zeros(2 * operand_rank, dtype=np.int32)
+        pad[0::2] = np.maximum(padding_low, 0)
+        pad[1::2] = np.maximum(padding_high, 0)
+
+        if np.any(pad > 0) or result is operand:
+            cml_padding_value = context[op.padding_value.get_name()]
+            result = pad_with_cast(x=result, pad=pad, mode="constant", constant_val=cml_padding_value)
+        context.add_result(op.result, result)
 
     @register_stablehlo_op
     def op_sqrt(self, context: TranslationContext, op: SqrtOp):
@@ -1314,7 +1324,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         result_types = [result.type for result in op.results]
         reduction_results = [
             mb.transpose(
-                x=np.zeros(result_type.shape, dtype=get_numpy_type(result_type.element_type)),
+                x=zero_tensor(result_type.shape, get_numpy_type(result_type.element_type)),
                 perm=permutation,
             )
             for result_type in result_types

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -5,7 +5,7 @@ from coremltools.converters.mil.mil import types
 from jaxlib.mlir.dialects.stablehlo import AddOp, AndOp, DivOp, MaxOp, MinOp, MulOp, OrOp, ReturnOp, SubtractOp
 
 from .translation_context import TranslationContext
-from .utils import dtype_str, get_numpy_type, index_by_slices, iterate_indexes_in_shapes, update_tensor_by_slice
+from .utils import dtype_str, get_numpy_type, index_by_slices, iterate_indexes_in_shapes, update_tensor_by_slice, zero_tensor
 
 
 def match_computation(hlo_body):
@@ -199,12 +199,7 @@ def compute_reduction(converter, context: TranslationContext, inputs, dimensions
             for acc, result in zip(partial_results, reduction_results)
         ]
 
-    mil_results = [
-        np.zeros(result_type.shape, dtype=get_numpy_type(result_type))
-        if len(result_type.shape) == 0 else
-        mb.tile(x=np.zeros((1,) * len(result_type.shape), dtype=get_numpy_type(result_type)), reps=result_type.shape)
-        for result_type in result_types
-    ]
+    mil_results = [zero_tensor(result_type.shape, get_numpy_type(result_type)) for result_type in result_types]
     mil_results = iterate_indexes_in_shapes(compute_reduction_loop, [result_shape], mil_results, unroll_limit=5)
     return mil_results
 

--- a/stablehlo_coreml/utils.py
+++ b/stablehlo_coreml/utils.py
@@ -54,6 +54,13 @@ def fix_scalar_tensor(tensor):
     return tensor
 
 
+def zero_tensor(shape, dtype):
+    """Create a zero tensor without embedding a dense zero constant."""
+    if len(shape) == 0:
+        return np.zeros(shape, dtype=dtype)
+    return mb.tile(x=np.zeros((1,) * len(shape), dtype=dtype), reps=shape)
+
+
 def _flatten_list(lst):
     flat_list = []
     for item in lst:

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -943,6 +943,44 @@ def test_pad_int32():
     run_and_compare(partial(jnp.pad, pad_width=((1, 1), (2, 2))), (jnp.zeros((5, 5), dtype=jnp.int32),))
 
 
+def test_pad_no_runtime_pad_construction():
+    # The pad amounts are compile-time constants, so no scatter ops should be
+    # emitted to construct the pad vector at runtime
+    cml_model = run_and_compare(partial(jnp.pad, pad_width=((1, 2), (3, 4))), (jnp.zeros((5, 5)),))
+    assert "scatter_along_axis" not in get_model_instruction_types(cml_model)
+
+
+def test_pad_negative():
+    def pad_fn(padding_config, padding_value=0.0, dtype=jnp.float32):
+        return partial(jax.lax.pad, padding_value=dtype(padding_value), padding_config=padding_config)
+
+    # Negative (crop) on some dims, positive (pad) on others
+    run_and_compare_specific_input(
+        pad_fn(((-2, 3, 0), (4, -5, 0))),
+        (jnp.arange(10 * 20, dtype=jnp.float32).reshape(10, 20),),
+    )
+    # Negative on both edges of the same dim
+    run_and_compare_specific_input(
+        pad_fn(((-1, -2, 0), (2, 2, 0)), padding_value=1.5),
+        (jnp.arange(8 * 6, dtype=jnp.float32).reshape(8, 6),),
+    )
+    # Pure crop (all edges negative or zero)
+    run_and_compare_specific_input(
+        pad_fn(((-3, -1, 0), (0, -4, 0))),
+        (jnp.arange(10 * 12, dtype=jnp.float32).reshape(10, 12),),
+    )
+    # Rank 3 mixing negative, zero and positive edges
+    run_and_compare_specific_input(
+        pad_fn(((-1, 2, 0), (0, 0, 0), (3, -2, 0)), padding_value=-7.25),
+        (jnp.arange(4 * 5 * 6, dtype=jnp.float32).reshape(4, 5, 6),),
+    )
+    # int32 with negative padding
+    run_and_compare_specific_input(
+        pad_fn(((-2, 2, 0), (1, -3, 0)), padding_value=7, dtype=jnp.int32),
+        (jnp.arange(6 * 9, dtype=jnp.int32).reshape(6, 9),),
+    )
+
+
 def test_remainder():
     run_and_compare(jnp.remainder, (
         jnp.array([10, 20, 30], dtype=jnp.int32), jnp.array([3, 7, 11], dtype=jnp.int32)
@@ -1246,10 +1284,6 @@ def test_round_nearest_even():
 
 
 def test_logistic():
-    import numpy as np
-    from jax._src.interpreters import mlir as jax_mlir
-    from jax._src.lib.mlir import ir
-
     # Current JAX decomposes `jax.lax.logistic` into primitive ops instead of
     # emitting `stablehlo.logistic`, so handcraft a module to exercise the op,
     # since other StableHLO producers emit it directly.

--- a/tests/test_symbolic_shapes.py
+++ b/tests/test_symbolic_shapes.py
@@ -249,6 +249,24 @@ def test_symbolic_multi_dim():
     run_and_compare_symbolic(f, specs, test_shapes)
 
 
+def test_symbolic_negative_pad():
+    """Negative padding crops correctly when an input axis is symbolic."""
+    def f(x):
+        return jax.lax.pad(
+            x,
+            padding_value=jnp.array(1.5, dtype=x.dtype),
+            padding_config=((2, 3, 0), (1, -2, 0)),
+        )
+
+    (n,) = _sym("n")
+    specs = [jax.ShapeDtypeStruct((n, 5), jnp.float32)]
+    test_shapes = [
+        (np.arange(2 * 5, dtype=np.float32).reshape(2, 5),),
+        (np.arange(7 * 5, dtype=np.float32).reshape(7, 5),),
+    ]
+    run_and_compare_symbolic(f, specs, test_shapes)
+
+
 # ---------------------------------------------------------------------------
 # Attention-like pattern (the motivating use case)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two improvements to `op_pad` in `stablehlo_coreml/converter.py`:

1. **Build the pad vector at compile time.** The pad vector was previously constructed at runtime with two `mb.scatter_along_axis` ops, even though `edge_padding_low`/`edge_padding_high` are compile-time constants. It is now built with pure numpy interleaving, using `safe_cast_to_int32` for overflow checking (consistent with `op_slice`/`op_dynamic_slice`).

2. **Support negative edge padding.** StableHLO `pad` permits negative edge padding, which crops elements from the corresponding edge. `mb.pad` does not support negative values, so previously this would fail downstream. The negative components are now lowered to an `mb.slice_by_index` crop and the non-negative components to the regular `pad_with_cast`.

### Ordering of crop vs. pad

Per the StableHLO spec, negative low/high padding removes elements from the respective edge *after* interior padding is applied. Interior padding is already rejected by this converter, so each edge of each dimension carries a single value that is either a pad (positive) or a crop (negative) — never both on the same edge, and edges/dimensions don't interact. The crop and pad steps therefore commute; the implementation crops first, which also keeps the intermediate tensor smaller.

The crop uses negative `end` indices with an `end_mask` for un-cropped dims, so it never needs to materialize the operand shape and remains compatible with symbolic shapes.

Additionally, when the effective pad is all zeros (pure crop), the `mb.pad` call (and the int cast round-trip in `pad_with_cast`) is skipped.

## Tests

* `test_pad_negative`: `jax.lax.pad` with negative edge padding — mixed negative/positive across dims, both edges negative on the same dim, pure crop, rank-3 mix, and int32 with negative padding — validated against JAX.
* `test_pad_no_runtime_pad_construction`: asserts no `scatter_along_axis` ops are emitted for a constant positive pad.
* Full `tests/test_jax.py` suite passes (101 passed), including the existing `test_pad`/`test_pad_int32`. `ruff check .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)