### PR TITLE
Fix integer division and remainder to match StableHLO semantics

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -352,7 +352,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         if types.is_float(lhs_type):
             cml_op = mb.real_div(x=lhs, y=rhs)
         elif types.is_int(lhs_type):
-            cml_op = mb.floor_div(x=lhs, y=rhs)
+            cml_op = self.__trunc_div(lhs, rhs, lhs_type)
         else:
             raise ValueError(f"Unknown dtype {lhs_type}")
 
@@ -580,7 +580,15 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
     @register_stablehlo_op
     def op_rem(self, context: TranslationContext, op: RemOp):
-        self.__simple_binary_op(context, mb.mod, op)
+        lhs = context[op.lhs.get_name()]
+        rhs = context[op.rhs.get_name()]
+
+        # StableHLO remainder takes the sign of the dividend (C-style), while MIL's
+        # `mod` follows Python semantics (sign of the divisor), so compute
+        # `lhs - trunc_div(lhs, rhs) * rhs` explicitly
+        quotient = self.__trunc_div(lhs, rhs, get_mil_type(lhs))
+        result = mb.sub(x=lhs, y=mb.mul(x=quotient, y=rhs))
+        context.add_result(op.result, result)
 
     @register_stablehlo_op
     def op_floor(self, context: TranslationContext, op: FloorOp):
@@ -1595,6 +1603,20 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         context.pop_function()
 
         return outputs
+
+    def __trunc_div(self, lhs, rhs, operand_type):
+        # Division truncating toward zero, as required by the StableHLO spec.
+        # MIL's `floor_div` rounds toward negative infinity, so divide the magnitudes
+        # and re-apply the sign
+        if types.is_float(operand_type):
+            quotient = mb.real_div(x=lhs, y=rhs)
+            return mb.mul(x=mb.sign(x=quotient), y=mb.floor(x=mb.abs(x=quotient)))
+        elif types.is_int(operand_type):
+            sign = mb.mul(x=mb.sign(x=lhs), y=mb.sign(x=rhs))
+            quotient = mb.floor_div(x=mb.abs(x=lhs), y=mb.abs(x=rhs))
+            return mb.mul(x=sign, y=quotient)
+        else:
+            raise ValueError(f"Unknown dtype {operand_type}")
 
     def __simple_unary_op(self, context: TranslationContext, mil_op, hlo_op):
         operand = context[hlo_op.operand.get_name()]

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -30,6 +30,15 @@ def test_div():
     run_and_compare(jnp.divide, (jnp.int32(1), jnp.zeros((dim_size, dim_size), dtype=jnp.int32)))
 
 
+def test_integer_div_with_negative_values():
+    a = jnp.array([-7, 7, -7, 7], dtype=jnp.int32)
+    b = jnp.array([2, 2, -2, -2], dtype=jnp.int32)
+    # `stablehlo.divide` truncates toward zero for integers
+    run_and_compare_specific_input(jax.lax.div, (a, b))
+    # `//` is floor division, which JAX lowers as trunc-div plus a sign correction
+    run_and_compare_specific_input(lambda x, y: x // y, (a, b))
+
+
 def test_tensor_multiplication():
     def scalar_product(lhs, rhs):
         return jnp.einsum("a,a", lhs, rhs)
@@ -802,6 +811,20 @@ def test_remainder():
     ))
     run_and_compare(jnp.remainder, (
         jnp.array([10.5, 20.2, 30.1], dtype=jnp.float32), jnp.array([3.1, 7.2, 11.3], dtype=jnp.float32)
+    ))
+
+
+def test_remainder_with_negative_values():
+    a = jnp.array([-7, 7, -7, 7], dtype=jnp.int32)
+    b = jnp.array([2, 2, -2, -2], dtype=jnp.int32)
+    # `stablehlo.remainder` takes the sign of the dividend (C-style)
+    run_and_compare_specific_input(jax.lax.rem, (a, b))
+    # `%` is Python-style modulo, which JAX lowers as C-style rem plus a sign correction
+    run_and_compare_specific_input(lambda x, y: x % y, (a, b))
+
+    run_and_compare_specific_input(jax.lax.rem, (
+        jnp.array([-7.5, 7.5, -7.5, 7.5], dtype=jnp.float32),
+        jnp.array([2.0, 2.0, -2.0, -2.0], dtype=jnp.float32),
     ))
 
 


### PR DESCRIPTION
## Problem

### Integer division rounds the wrong way
The [StableHLO spec](https://openxla.org/stablehlo/spec#divide) requires integer `divide` to truncate toward zero (C-style), but `op_div` lowered it to MIL `floor_div`, which rounds toward negative infinity (Python `//`). Verified end-to-end through a compiled CoreML model:

| Expression | CoreML (before) | Expected (JAX) |
|---|---|---|
| `jax.lax.div(-7, 2)` | -4 | -3 |
| `jnp.int32` `-7 // 2` | -5 | -4 |

The second case is particularly subtle: JAX lowers `//` as a trunc-div plus an explicit sign correction, so the floor semantics ended up double-correcting.

### Remainder sign convention
Relatedly, `stablehlo.remainder` is C-style (result takes the sign of the *dividend*), but `op_rem` lowered it to `mb.mod`. While the CoreML runtime happens to produce C-style results for `mod`, coremltools' `mod.value_inference` is Python `operator.mod` (sign of the *divisor*), so any remainder that gets constant-folded during conversion would be wrong.

## Fix
- `op_div` (int path) now emits a truncating division: `sign(lhs) * sign(rhs) * floor_div(|lhs|, |rhs|)`. The float path (`real_div`) is unchanged.
- `op_rem` now emits an explicit C-style remainder, `lhs - trunc_div(lhs, rhs) * rhs`, for both ints and floats.
- Both share a new `__trunc_div` helper.

## Tests
- `test_integer_div_with_negative_values`: `jax.lax.div` and `a // b` on int32 with mixed-sign operands (`a=[-7,7,-7,7]`, `b=[2,2,-2,-2]`). Fails before this fix, passes after.
- `test_remainder_with_negative_values`: `jax.lax.rem` and `a % b` on int32, plus `jax.lax.rem` on float32, all with negative operands.

Full suite: 173 passed, 1 skipped. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)