### PR TITLE
Add cbrt, logistic, and round_nearest_even op support

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -22,6 +22,7 @@ from jaxlib.mlir.dialects.stablehlo import (
     Atan2Op,
     BroadcastInDimOp,
     CaseOp,
+    CbrtOp,
     CeilOp,
     ClampOp,
     CompareOp,
@@ -47,6 +48,7 @@ from jaxlib.mlir.dialects.stablehlo import (
     IotaOp,
     IsFiniteOp,
     Log1pOp,
+    LogisticOp,
     LogOp,
     MaxOp,
     MinOp,
@@ -62,6 +64,7 @@ from jaxlib.mlir.dialects.stablehlo import (
     ReshapeOp,
     ReturnOp,
     ReverseOp,
+    RoundNearestEvenOp,
     RoundOp,
     RsqrtOp,
     ScatterOp,
@@ -367,9 +370,19 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             rounded_magnitude = mb.floor(x=shifted)
             result = mb.mul(x=rounded_magnitude, y=mb.sign(x=operand))
             context.add_result(op.result, result)
-        # elif op.OPERATION_NAME == 'stablehlo.round_nearest_even':
+        elif op.OPERATION_NAME == 'stablehlo.round_nearest_even':
+            # MIL's `round` rounds half-way cases to the nearest even integer
+            # (verified against the CoreML CPU runtime), matching the
+            # `stablehlo.round_nearest_even` semantics.
+            context.add_result(op.result, mb.round(x=operand))
         else:
             raise ValueError(f"Unsupported RoundOp type of {op.OPERATION_NAME}")
+
+    @register_stablehlo_op
+    def op_round_nearest_even(self, context: TranslationContext, op: RoundNearestEvenOp):
+        # `RoundNearestEvenOp` is a distinct op class from `RoundOp`, but the
+        # handling is shared in `op_round`, dispatching on `OPERATION_NAME`.
+        self.op_round(context, op)
 
     @register_stablehlo_op
     def op_neg(self, context: TranslationContext, op: NegOp):
@@ -461,6 +474,19 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
     @register_stablehlo_op
     def op_sqrt(self, context: TranslationContext, op: SqrtOp):
         self.__simple_unary_op(context, mb.sqrt, op)
+
+    @register_stablehlo_op
+    def op_cbrt(self, context: TranslationContext, op: CbrtOp):
+        # cbrt(x) = sign(x) * |x|^(1/3)
+        # A plain `pow(x, 1/3)` would produce NaN for negative x.
+        operand = context[op.operand.get_name()]
+        magnitude = mb.pow(x=mb.abs(x=operand), y=1.0 / 3.0)
+        result = mb.mul(x=magnitude, y=mb.sign(x=operand))
+        context.add_result(op.result, result)
+
+    @register_stablehlo_op
+    def op_logistic(self, context: TranslationContext, op: LogisticOp):
+        self.__simple_unary_op(context, mb.sigmoid, op)
 
     @register_stablehlo_op
     def op_constant(self, context: TranslationContext, op: ConstantOp):

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -4,7 +4,12 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_specific_input
+from tests.utils import (
+    get_model_instruction_types,
+    run_and_compare,
+    run_and_compare_hlo_module,
+    run_and_compare_specific_input,
+)
 
 
 def test_addition():
@@ -1068,6 +1073,44 @@ def test_afz():
         return jax.lax.round(x)
 
     run_and_compare_specific_input(ties, (jnp.array([-0.5, 0.5, 5.5, -4.5]),))
+
+
+def test_cbrt():
+    x = jnp.array([-27.0, -8.0, -1.0, -0.3, 0.0, 0.5, 1.0, 8.0, 27.0])
+    assert "stablehlo.cbrt" in jax.jit(jnp.cbrt).lower(x).as_text()
+    run_and_compare_specific_input(jnp.cbrt, (x,))
+
+
+def test_round_nearest_even():
+    # `jnp.round` lowers to `stablehlo.round_nearest_even`, which rounds
+    # half-way cases to the nearest even integer (banker's rounding)
+    x = jnp.array([0.5, 1.5, 2.5, -0.5, -1.5, 3.5, -2.5, 0.4999, -1.5001, 7.0])
+    assert "stablehlo.round_nearest_even" in jax.jit(jnp.round).lower(x).as_text()
+    run_and_compare_specific_input(jnp.round, (x,))
+
+
+def test_logistic():
+    import numpy as np
+    from jax._src.interpreters import mlir as jax_mlir
+    from jax._src.lib.mlir import ir
+
+    # Current JAX decomposes `jax.lax.logistic` into primitive ops instead of
+    # emitting `stablehlo.logistic`, so handcraft a module to exercise the op,
+    # since other StableHLO producers emit it directly.
+    mlir_text = """
+    module {
+      func.func public @main(%arg0: tensor<6xf32>) -> tensor<6xf32> {
+        %0 = stablehlo.logistic %arg0 : tensor<6xf32>
+        return %0 : tensor<6xf32>
+      }
+    }
+    """
+    context = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(mlir_text, context=context)
+
+    x = np.array([-10.0, -2.0, -0.5, 0.0, 1.0, 8.0], dtype=np.float32)
+    expected = np.asarray(jax.nn.sigmoid(x))
+    run_and_compare_hlo_module(hlo_module, (x,), (expected,))
 
 
 def test_xor():


### PR DESCRIPTION
Adds handlers for three previously unsupported StableHLO ops.

## `stablehlo.cbrt` (`CbrtOp`)
Implemented as `sign(x) * |x|^(1/3)`. A plain `mb.pow(x, 1/3)` returns NaN for negative inputs, so the magnitude/sign decomposition is required for full-domain correctness. Tested via `jnp.cbrt` (which exports `stablehlo.cbrt` directly) on inputs including negative values, zero, and non-integer cube roots.

## `stablehlo.logistic` (`LogisticOp`)
Maps 1:1 to `mb.sigmoid` via the existing `__simple_unary_op` helper. Current JAX decomposes `jax.lax.logistic` into `negate`/`exponential`/`add`/`divide` instead of emitting `stablehlo.logistic` (verified by inspecting the exported module), so the test handcrafts a minimal MLIR module containing the op, parses it, and compares against `jax.nn.sigmoid` through `run_and_compare_hlo_module`.

## `stablehlo.round_nearest_even` (`RoundNearestEvenOp`)
Maps to `mb.round`. **Runtime-semantics finding:** the CoreML CPU runtime's `round` was verified empirically (standalone MIL program with non-constant input on `ComputeUnit.CPU_ONLY`) to round half-way cases to the nearest even integer — `[0.5, 1.5, 2.5, -0.5, -1.5, 3.5] -> [0., 2., 2., -0., -2., 4.]` — exactly matching numpy/banker's rounding and the StableHLO spec, so no manual half-to-even correction is needed. Since `RoundNearestEvenOp` is a distinct op class from `RoundOp` (registration is keyed by op type), a separate `@register_stablehlo_op` method is added which delegates to `op_round`, whose existing `OPERATION_NAME` dispatch now handles both `round_nearest_afz` and `round_nearest_even`. Tested via `jnp.round` (which lowers to `round_nearest_even`) on half-value ties including negatives.

## Testing
- `tests/test_jax.py -k "cbrt or logistic or round or afz"`: 4 passed
- Full suite `tests/`: 174 passed, 1 skipped
- `ruff check .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)