### PR TITLE
chore: small converter cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,9 +108,6 @@ ignore = [
     "SIM102",  # nested if → combined if — can hurt readability
 ]
 
-[tool.ruff.lint.per-file-ignores]
-"tests/**" = ["PLC0415"]  # imports inside test functions are valid for heavy deps
-
 [project.urls]
 Homepage = "https://github.com/kasper0406/stablehlo-coreml"
 Issues = "https://github.com/kasper0406/stablehlo-coreml/issues"

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -634,13 +634,13 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         if sort_keys is None:
             raise ValueError("Unrecognized comparator format")
 
-        # Apply the sort
-        sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
-        indices = mb.argsort(x=key, axis=sort_dim, ascending=ascending)
-
         # Given CoreML's argsort is unstable we are not able to handle multiple sort keys
         if len(sort_keys) > 1:
             raise ValueError("Having more than one sort key is not supported because MIL's argsort is not supported")
+
+        # Apply the sort
+        sort_dim, (key, ascending) = op.dimension.value, sort_keys[-1]
+        indices = mb.argsort(x=key, axis=sort_dim, ascending=ascending)
         # The following code would be used if CoreML had a stable argsort
         # for key, ascending in sort_keys[-2::-1]:
         #     gathered_key = mb.gather_along_axis(x=key, indices=indices, axis=sort_dim)
@@ -725,14 +725,16 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             result_idx = op.broadcast_dimensions[i]
             reshaped_operand_shape[result_idx] = op_shape
 
-        x = mb.reshape(x=x, shape=reshaped_operand_shape)
+        if reshaped_operand_shape != list(op.operand.type.shape):
+            x = mb.reshape(x=x, shape=reshaped_operand_shape)
 
         result_tiling = [1] * result_shape_rank
         for result_dim, current_shape in enumerate(reshaped_operand_shape):
             # Replicate data along dimension `dim` until the result dimension matches
             assert result_shape[result_dim] % current_shape == 0
             result_tiling[result_dim] = result_shape[result_dim] // current_shape
-        x = mb.tile(x=x, reps=result_tiling)
+        if any(rep != 1 for rep in result_tiling):
+            x = mb.tile(x=x, reps=result_tiling)
 
         context.add_result(op.result, x)
 

--- a/stablehlo_coreml/ops_register.py
+++ b/stablehlo_coreml/ops_register.py
@@ -12,7 +12,7 @@ def register_stablehlo_op(func):
     params = params[1:]
 
     error_msg = "HLO op implementations should take parameters of exactly " \
-                "(context: TranscriptionContext, op: <HLO_OP_TYPE>)"
+                "(context: TranslationContext, op: <HLO_OP_TYPE>)"
     if len(params) != 2:
         raise ValueError(error_msg)
 

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -38,9 +38,16 @@ def match_computation(hlo_body):
         AndOp: (None, mb.logical_and, "and"),
     }
 
+    # Ops for which the operand order does not matter
+    commutative_ops = (MaxOp, MinOp, AddOp, MulOp, OrOp, AndOp)
+
     for generic_reduce_op_type, mil_equivalents in simple_matches.items():
         if len(ops) == 2 and isinstance(ops[0], generic_reduce_op_type) and isinstance(ops[1], ReturnOp):
-            if list(ops[0].operands) == args and list(ops[1].operands) == list(ops[0].results):
+            operands = list(ops[0].operands)
+            operands_match = operands == args or (
+                issubclass(generic_reduce_op_type, commutative_ops) and operands == args[::-1]
+            )
+            if operands_match and list(ops[1].operands) == list(ops[0].results):
                 return mil_equivalents
 
     return None, None, None

--- a/tests/pytorch/test_pytorch.py
+++ b/tests/pytorch/test_pytorch.py
@@ -11,6 +11,15 @@ torch = pytest.importorskip("torch")
 torchvision = pytest.importorskip("torchvision")
 tx = pytest.importorskip("torchax")
 tx_export = pytest.importorskip("torchax.export")
+pytest.importorskip("transformers")
+from transformers import (  # noqa: E402
+    AutoConfig,
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForSpeechSeq2Seq,
+    AutoTokenizer,
+    T5Model,
+)
 
 
 def _torchax_workaround_tied_weights(model):
@@ -126,8 +135,6 @@ def evaluate_pytorch_model(model, inputs, compute_units=ct.ComputeUnit.CPU_ONLY)
 # ==============================================================================
 
 def test_tinyllama():
-    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
-
     model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     config = AutoConfig.from_pretrained(model_name)
@@ -150,8 +157,6 @@ def test_tinyllama():
 
 
 def test_t5_small():
-    from transformers import AutoConfig, AutoTokenizer, T5Model
-
     # Use AutoTokenizer which might fallback to fast tokenizer (no sentencepiece needed if available)
     tokenizer = AutoTokenizer.from_pretrained("t5-small")
     config = AutoConfig.from_pretrained("t5-small")
@@ -174,8 +179,6 @@ def test_t5_small():
 
 
 def test_distilbert():
-    from transformers import AutoConfig, AutoModel, AutoTokenizer
-
     model_name = "distilbert-base-uncased"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     config = AutoConfig.from_pretrained(model_name)
@@ -190,8 +193,6 @@ def test_distilbert():
 
 
 def test_gpt2():
-    from transformers import AutoConfig, AutoModel, AutoTokenizer
-
     model_name = "gpt2"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     config = AutoConfig.from_pretrained(model_name)
@@ -206,8 +207,6 @@ def test_gpt2():
 
 
 def test_bert():
-    from transformers import AutoConfig, AutoModel, AutoTokenizer
-
     model_name = "bert-base-uncased"
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     config = AutoConfig.from_pretrained(model_name)
@@ -226,9 +225,6 @@ def test_bert():
 # ==============================================================================
 
 def test_whisper_tiny():
-    import torch
-    from transformers import AutoConfig, AutoModelForSpeechSeq2Seq
-
     model_name = "openai/whisper-tiny"
     config = AutoConfig.from_pretrained(model_name)
     config.encoder_layers = 2

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -2,9 +2,18 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
+from jax._src.interpreters import mlir as jax_mlir
+from jax._src.lib.mlir import ir
+from jax.lax import GatherDimensionNumbers, ScatterDimensionNumbers
 
-from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_specific_input
+from tests.utils import (
+    get_model_instruction_types,
+    run_and_compare,
+    run_and_compare_hlo_module,
+    run_and_compare_specific_input,
+)
 
 
 def test_addition():
@@ -153,6 +162,34 @@ def test_boolean_reductions():
     compare_and_ensure_no_loops(partial(jnp.any, axis=0), (int_3d,))
     compare_and_ensure_no_loops(partial(jnp.all, axis=0), (int_2d,))
     compare_and_ensure_no_loops(partial(jnp.all, axis=1), (int_3d,))
+
+
+def test_reduce_with_reversed_operands():
+    """A reduce body written as `add(arg1, arg0)` should still match the fast
+    MIL reduction path for commutative ops, instead of falling back to the
+    slow while-loop implementation."""
+    mlir_text = """
+    module {
+      func.func public @main(%arg0: tensor<2x3xf32>) -> tensor<2xf32> {
+        %init = stablehlo.constant dense<0.000000e+00> : tensor<f32>
+        %0 = "stablehlo.reduce"(%arg0, %init) ({
+          ^bb0(%a: tensor<f32>, %b: tensor<f32>):
+            %sum = stablehlo.add %b, %a : tensor<f32>
+            stablehlo.return %sum : tensor<f32>
+        }) {dimensions = array<i64: 1>} : (tensor<2x3xf32>, tensor<f32>) -> tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+    }
+    """
+    context = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(mlir_text, context=context)
+
+    x = np.arange(6, dtype=np.float32).reshape(2, 3)
+    cml_model = run_and_compare_hlo_module(hlo_module, (x,), x.sum(axis=1))
+
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_sum" in ops
+    assert "while_loop" not in ops
 
 
 def test_reduce_window():
@@ -417,8 +454,6 @@ def test_take():
 
 
 def test_gather():
-    from jax.lax import GatherDimensionNumbers
-
     def wrapped_gather(dimension_numbers, slice_sizes):
         @jax.jit
         def internal_gather(operand, start_indices):
@@ -520,8 +555,6 @@ def test_gather():
 
 
 def test_complex_gather():
-    from jax.lax import GatherDimensionNumbers
-
     def wrapped_gather(dimension_numbers, slice_sizes):
         @jax.jit
         def internal_gather(operand, start_indices):
@@ -586,8 +619,6 @@ def test_complex_gather():
 def test_large_gather():
     # Test gather with large indices to verify if optimization is necessary
     # and if it works correctly.
-    from jax.lax import GatherDimensionNumbers
-
     def wrapped_gather(dimension_numbers, slice_sizes):
         @jax.jit
         def internal_gather(operand, start_indices):
@@ -676,8 +707,6 @@ def test_simple_scatter():
 
 
 def test_scatter_with_dimension_numbers():
-    from jax.lax import ScatterDimensionNumbers
-
     def wrapped_scatter_add(dimension_numbers):
         @jax.jit
         def internal_scatter_add(operand, scatter_indices, updates):

--- a/tests/test_symbolic_shapes.py
+++ b/tests/test_symbolic_shapes.py
@@ -4,12 +4,19 @@ Validates the new StableHLO ops (GetDimensionSizeOp, DynamicIotaOp,
 DynamicBroadcastInDimOp, CustomCallOp/shape_assertion) and `dot_general`
 lowering with symbolic dimensions from JAX symbolic export.
 """
+import coremltools as ct
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from coremltools.converters.mil._deployment_compatibility import AvailableTarget
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import Function, types
 from jax import export
+from jax._src.interpreters import mlir as jax_mlir
+from jax._src.lib.mlir import ir
 
+from stablehlo_coreml.converter import convert
 from stablehlo_coreml.translation_context import DYNAMIC_DIM_SENTINEL, TranslationContext
 from tests.utils import run_and_compare_symbolic
 
@@ -295,16 +302,11 @@ def test_validate_shapes_dynamic_sentinel():
         def get_name(self):
             return self._name
 
-    from coremltools.converters.mil._deployment_compatibility import AvailableTarget
-    from coremltools.converters.mil.mil import Builder as mb
-    from coremltools.converters.mil.mil import Function, types
-
     with Function(
         {"x": mb.placeholder(shape=(1, 4), dtype=types.fp32)},
         opset_version=AvailableTarget.iOS18,
     ):
         # Create a real MIL var (not a Placeholder) via a const
-        import numpy as np
         x = mb.const(val=np.zeros((1, 4), dtype=np.float32))
         scalar = mb.const(val=np.zeros((1,), dtype=np.float32))
 
@@ -334,12 +336,6 @@ def test_validate_shapes_dynamic_sentinel():
 
 def test_custom_call_unsupported_raises():
     """CustomCallOp with unknown target should raise ValueError."""
-    import coremltools as ct
-    from jax._src.interpreters import mlir as jax_mlir
-    from jax._src.lib.mlir import ir
-
-    from stablehlo_coreml.converter import convert
-
     # Craft a minimal MLIR module with an unsupported custom_call
     mlir_text = """
     module {
@@ -378,12 +374,6 @@ def test_symbolic_reshape():
 
 def test_symbolic_dynamic_iota_unsupported_raises():
     """DynamicIotaOp with rank > 1 should raise ValueError."""
-    import coremltools as ct
-    from jax._src.interpreters import mlir as jax_mlir
-    from jax._src.lib.mlir import ir
-
-    from stablehlo_coreml.converter import convert
-
     mlir_text = """
     module {
       func.func public @main(%arg0: tensor<2xi32>) -> tensor<2x3xi64> {


### PR DESCRIPTION
A small batch of independent cleanups in the converter:

- **`op_sort`**: move the "more than one sort key is not supported" check before any MIL ops are emitted, so no `argsort` is built for a module that is rejected anyway.
- **`match_computation` (reductions)**: accept reversed operand order (`add(arg1, arg0)`) for commutative reduce bodies (Max, Min, Add, Mul, Or, And), so they hit the fast native MIL reduction path instead of the slow while-loop fallback. Added a test that parses a handcrafted StableHLO module with a reversed-operand reduce body and asserts `reduce_sum` is used and no `while_loop` is emitted.
- **`op_broadcast_in_dim`**: skip the `reshape` when the reshaped shape already equals the operand shape, and skip the `tile` when all tile reps are 1 (identity broadcast).
- **`ops_register.py`**: fix `TranscriptionContext` → `TranslationContext` typo in an error message.

Tests: `tests/test_jax.py` + `tests/test_symbolic_shapes.py` pass (116 passed), `ruff check .` clean. The new test fails without the commutative-matching fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)