### PR TITLE
Fix reduce_window ignoring init values in pooling fast path

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1172,11 +1172,25 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         inputs = [context[input.get_name()] for input in op.inputs]
         init_values = [context[init_value.get_name()] for init_value in op.init_values]
 
-        # Pad the inputs if required before attempting simple match
+        # Pad the inputs if required before attempting simple match.
+        # XLA reduces each window over its in-bounds elements only, seeded with the
+        # init value exactly once per window (the seed itself is folded in by the
+        # reduction implementations). Padded elements must therefore act as the
+        # identity of the computation: for idempotent reductions (max/min/or/and)
+        # padding with the init value is equivalent, but for add/mul we must pad
+        # with the actual identity (0/1) to avoid counting the padded elements.
         if op.padding:
+            _, _, mode = match_computation(op.body)
+            identities = {"add": 0, "mul": 1}
             padding = np.reshape(np.array(op.padding, dtype=np.int32), (2 * inputs_rank,))
+
+            def padding_value(input, init_value):
+                if mode in identities:
+                    return np.array(identities[mode], dtype=get_numpy_type(input))
+                return mb.reduce_max(x=init_value)
+
             inputs = [
-                pad_with_cast(x=input, pad=padding, constant_val=mb.reduce_max(x=init_value))
+                pad_with_cast(x=input, pad=padding, constant_val=padding_value(input, init_value))
                 for input, init_value in zip(inputs, init_values)
             ]
 

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -59,6 +59,16 @@ def match_simple_reduce_window(body, inputs, init_values, window_dimensions, win
     x = inputs[0]
     rank = len(window_dimensions)
 
+    # Per the StableHLO spec, the init value participates in every window's reduction:
+    #   result = reduce(window_elements, init_value)
+    # The pooling/conv ops below do not know about the init value, so we fold it in
+    # exactly once after pooling. Note that padded elements are handled separately
+    # (the converter pads the input with the init value before calling this function).
+    mil_init_fold = {"max": mb.maximum, "min": mb.minimum, "add": mb.add}[mode]
+
+    def fold_init_value(res):
+        return mil_init_fold(x=res, y=init_values[0])
+
     # CoreML pool/conv instructions support up to 3 spatial dimensions for sliding windows.
     spatial_rank = 0
     for i in range(rank):
@@ -67,7 +77,8 @@ def match_simple_reduce_window(body, inputs, init_values, window_dimensions, win
             break
 
     if spatial_rank == 0:
-        return x
+        # Even for windows of size 1, the init value still seeds each window's reduction.
+        return fold_init_value(x)
 
     if spatial_rank > 3:
         return None
@@ -118,7 +129,9 @@ def match_simple_reduce_window(body, inputs, init_values, window_dimensions, win
 
     final_res = mb.reshape(x=pool_res, shape=out_shape)
 
-    return final_res
+    # Fold in the init value after any cast back to the original dtype, so that the
+    # init value (which has the original input dtype) is combined in its own dtype.
+    return fold_init_value(final_res)
 
 
 def compute_reduction(converter, context: TranslationContext, inputs, dimensions, body, init_values, result_types):

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -229,6 +229,115 @@ def test_reduce_window():
     )
 
 
+def test_reduce_window_init_value():
+    """
+    Per the StableHLO spec, the init value seeds every window's reduction:
+      result = reduce(window_elements, init_value)
+    """
+    def compare_and_ensure_no_loops(jax_func, inputs):
+        cml_model = run_and_compare_specific_input(jax_func, inputs)
+        assert "while_loop" not in get_model_instruction_types(cml_model)
+        assert "sliding_windows" not in get_model_instruction_types(cml_model)
+
+    # max with init=0 over all-negative inputs must return zeros
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=0.0,
+            computation=jax.lax.max,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((0, 0), (0, 0)),
+        ),
+        (-jnp.arange(1, 17, dtype=jnp.float32).reshape((4, 4)),)
+    )
+    # min with init=0 over all-positive inputs must return zeros
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=0.0,
+            computation=jax.lax.min,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((0, 0), (0, 0)),
+        ),
+        (jnp.arange(1, 17, dtype=jnp.float32).reshape((4, 4)),)
+    )
+    # add with a non-zero init value must add the init exactly once per window
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=5.0,
+            computation=jax.lax.add,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((0, 0), (0, 0)),
+        ),
+        (jnp.arange(16, dtype=jnp.float32).reshape((4, 4)),)
+    )
+    # add with non-zero init and padding: padded elements contribute the init value
+    # once each, and the reduction seed contributes it exactly once more (no double counting)
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=2.0,
+            computation=jax.lax.add,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+        ),
+        (jnp.arange(16, dtype=jnp.float32).reshape((4, 4)),)
+    )
+    # max with init=0, padding, and all-negative inputs (init via both padding and seed)
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=0.0,
+            computation=jax.lax.max,
+            window_dimensions=(3, 3),
+            window_strides=(1, 1),
+            padding=((1, 1), (1, 1)),
+        ),
+        (-jnp.arange(1, 17, dtype=jnp.float32).reshape((4, 4)),)
+    )
+    # add with non-zero int init value
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=3,
+            computation=jax.lax.add,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((0, 0), (0, 0)),
+        ),
+        (jnp.arange(16, dtype=jnp.int32).reshape((4, 4)),)
+    )
+    # add with non-zero int init value and padding
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=3,
+            computation=jax.lax.add,
+            window_dimensions=(2, 2),
+            window_strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+        ),
+        (jnp.arange(16, dtype=jnp.int32).reshape((4, 4)),)
+    )
+    # window of all-ones dimensions still seeds with the init value
+    compare_and_ensure_no_loops(
+        partial(
+            jax.lax.reduce_window,
+            init_value=0.0,
+            computation=jax.lax.max,
+            window_dimensions=(1, 1),
+            window_strides=(1, 1),
+            padding=((0, 0), (0, 0)),
+        ),
+        (-jnp.arange(1, 17, dtype=jnp.float32).reshape((4, 4)),)
+    )
+
+
 def test_complex_reductions():
     """
     These reductions are complicated, and will be handled using while loops (potentially unrolled)


### PR DESCRIPTION
## The bug

`match_simple_reduce_window` (`stablehlo_coreml/reductions.py`) lowers `stablehlo.reduce_window` with a max/min/add body to MIL pooling/conv ops, but it ignored `init_values` entirely. The init value only entered the picture via the padding path in `op_reduce_window`, so for unpadded windows it was dropped on the floor.

Concrete failure (before this fix):

```python
jax.lax.reduce_window(x, init_value=0.0, computation=jax.lax.max,
                      window_dimensions=(2, 2), window_strides=(2, 2))
```

with `x = -arange(1, 17).reshape(4, 4)` (all negative) returned `[[-1, -3], [-9, -11]]` from the converted CoreML model, while JAX returns `[[0, 0], [0, 0]]`. Similarly, an `add` reduce_window with a non-zero init was missing the init contribution in every window.

## Semantics verified

I checked the behavior against the [StableHLO spec](https://github.com/openxla/stablehlo/blob/main/docs/spec.md) (`reduce_window` and `reduce`) and against what JAX/XLA actually computes:

- **Seed**: `reduce_window` is defined as `results[result_index] = reduce(windows, init_values, ...)`. For `reduce`, the spec makes the *number* of init insertions implementation-defined ("interspersed with an implementation-defined amount of `init_values`"), and notes `body` + `init_values` must form a monoid for deterministic results. XLA/JAX (the source of the models this project converts, and the reference our tests compare against) observably folds the init value in **exactly once per window**: e.g. `max` with `init=0` over all-negative inputs returns 0, and `add` with `init=5` adds 5 to every window. This fix matches that behavior, and it also matches what `compute_reduction` in the same file already does for plain `stablehlo.reduce`.
- **Padding**: the spec text says padded elements hold `init_values`, but XLA observably reduces each window over its **in-bounds elements only**, seeded with the init value once. I verified this by exporting `jax.lax.reduce_window(add, init=2.0, padding=((1,1),(1,1)))` to StableHLO (a single `stablehlo.reduce_window` op with `padding = dense<1>`) and inspecting XLA's outputs: a corner window with 3 padded elements and one real element `0` evaluates to `2` (= seed once), not `8` (= 3 pads x init + seed). For idempotent reductions (max/min/or/and) the two readings coincide, but for `add`/`mul` with a non-identity init they differ, so the converter now pads with the identity of the computation (0 for add, 1 for mul) instead of the init value, while the seed is folded in exactly once by the reduction lowering. This also keeps the padding path and the seed fold from double counting: with an identity init (the common case, e.g. `init=0` for add) behavior is unchanged.

## The fix

- `match_simple_reduce_window` now folds the init value into the pooled result exactly once via `mb.maximum` / `mb.minimum` / `mb.add`, after the cast back to the original dtype for integer/bool inputs (the init value has the original input dtype), and also on the `spatial_rank == 0` early-return path — windows of size 1 still seed with the init value per spec.
- `op_reduce_window` (`converter.py`) pads `add`/`mul` reductions with the computation's identity (0/1) instead of the init value; other modes are unchanged.

## Tests

New `test_reduce_window_init_value` in `tests/test_jax.py` (all compared against JAX outputs on exact inputs, and asserted to lower without loops):

- `max` with `init=0.0` over all-negative floats → zeros (failed before this fix)
- `min` with `init=0.0` over all-positive floats → zeros
- `add` with non-zero float init (no padding)
- `add` with non-zero init **and** padding (no double counting; failed with init-value padding)
- `max` with `init=0.0`, padding, all-negative inputs (init via both padding and seed; idempotent)
- `add` with non-zero int32 init, with and without padding (exercises the fp32 cast round-trip)
- size-1 windows (`spatial_rank == 0` early-return path) still seed with the init value

Test results: full suite `tests/` passes — 172 passed, 1 skipped. `ruff check .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)