### PR TITLE
Add explicit Core ML state mapping to convert()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ hlo_module = ir.Module.parse(jax_exported.mlir_module(), context=context)
 
 For the JAX example to work, you will additionally need to install `absl-py` and `flatbuffers` as dependencies.
 
+### Input names
+
+> **Breaking change.** Converted model inputs are no longer named `_arg0`,
+> `_arg1`, ... as in previous releases.
+
+An input takes its name from the StableHLO argument's MLIR name location, which
+is where JAX records the traced Python argument name (including the pytree path
+for nested arguments, e.g. `params['w']`). Arguments without such a location —
+typical for modules that were parsed from text or exported by other frontends —
+fall back to their MLIR SSA name without the leading `%`, i.e. `arg0`, `arg1`,
+... . All names are sanitized into valid Core ML identifiers, so the name on the
+final model may differ from the StableHLO one.
+
+Anywhere you refer to inputs by name — `ct.TensorType(name=...)`, the `predict`
+dictionary, `states={...}` keys — use the new names. Read them off the converted
+program rather than hardcoding them:
+
+```python
+mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+for func in mil_program.functions.values():
+    print(list(func.inputs))
+```
+
 ## Stateful models
 
 Core ML can keep tensors across `predict` calls as *state* instead of passing
@@ -131,7 +154,9 @@ jax_exported = export(jax.jit(jax_function))(
 ```
 
 When converting to a CoreML model, specify `RangeDim` for each symbolic
-dimension so the model accepts a range of sizes at inference time:
+dimension so the model accepts a range of sizes at inference time. Note that a
+symbolic export carries no argument name locations, so the inputs fall back to
+`arg0`, `arg1`, ... (see [Input names](#input-names)):
 
 ```python
 cml_model = ct.convert(
@@ -140,8 +165,8 @@ cml_model = ct.convert(
     minimum_deployment_target=ct.target.iOS18,
     pass_pipeline=DEFAULT_HLO_PIPELINE,
     inputs=[
-        ct.TensorType(name="_arg0", shape=(ct.RangeDim(1, 2048, 1), 4)),
-        ct.TensorType(name="_arg1", shape=(4, 3)),
+        ct.TensorType(name="arg0", shape=(ct.RangeDim(1, 2048, 1), 4)),
+        ct.TensorType(name="arg1", shape=(4, 3)),
     ],
 )
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@ be an output index, an exact JAX `result_info` name such as
 read-only state, and `name=...` to override its Core ML name. A flat
 `{input: output}` mapping remains supported for single-function modules.
 
+Core ML only accepts names of the form `[a-zA-Z_][a-zA-Z0-9_]*` and reserves a
+few words (`state`, `tensor`, `bool`, ...). Derived names are sanitized to that
+form up front, so a JAX pytree argument such as `params['w']` is exposed as
+`params__w__`. An explicit `name=...` that would need sanitizing is rejected at
+conversion time, telling you the valid alternative.
+
+A module with a single public StableHLO function is always exported as the
+Core ML `main` function, whatever the StableHLO function is named; the keys of
+the state mapping still use the StableHLO name. Modules with several public
+functions are exported as a Core ML multifunction model.
+
 State tensors must have a static shape and a floating-point dtype (Core ML
 stores them as fp16). They do not appear in the model's regular inputs, and the
 outputs holding their updated values are always dropped. If every result updates

--- a/README.md
+++ b/README.md
@@ -62,6 +62,43 @@ hlo_module = ir.Module.parse(jax_exported.mlir_module(), context=context)
 
 For the JAX example to work, you will additionally need to install `absl-py` and `flatbuffers` as dependencies.
 
+## Stateful models
+
+Core ML can keep tensors across `predict` calls as *state* instead of passing
+them in and out every time. Mark those tensors when converting by mapping each
+state input to the output that holds its updated value:
+
+```python
+def step(cache, x):
+    new_cache = cache + x
+    return new_cache * x, new_cache
+
+mil_program = convert(
+    hlo_module,
+    minimum_deployment_target=ct.target.iOS18,
+    states={0: 1},  # input 0 is updated by output 1
+)
+cml_model = ct.convert(
+    mil_program,
+    source="milinternal",
+    minimum_deployment_target=ct.target.iOS18,
+    pass_pipeline=DEFAULT_HLO_PIPELINE,
+)
+
+state = cml_model.make_state()
+# Remaining tensor inputs keep their StableHLO argument names.
+x_name = list(cml_model.input_description)[0]
+y = cml_model.predict({x_name: x}, state=state)
+# `cache` is updated in place; inspect or reset it with
+# state.read_state(...) / state.write_state(...)
+```
+
+Keys may be input indices or argument names. State tensors must have a static
+shape and a floating-point dtype (Core ML stores them as fp16). They do not
+appear in the model's regular inputs or outputs.
+
+See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
+
 ## Dynamic / symbolic shapes
 
 JAX models exported with symbolic dimensions are supported. Symbolic dims flow

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ To convert a StableHLO module:
 
 ```python
 import coremltools as ct
-from stablehlo_coreml.converter import convert
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec, convert
 
 mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
 cml_model = ct.convert(
@@ -76,7 +75,11 @@ def step(cache, x):
 mil_program = convert(
     hlo_module,
     minimum_deployment_target=ct.target.iOS18,
-    states={0: 1},  # input 0 is updated by output 1
+    states={
+        "main": {
+            "cache": StateSpec(output=1),
+        },
+    },
 )
 cml_model = ct.convert(
     mil_program,
@@ -93,11 +96,18 @@ y = cml_model.predict({x_name: x}, state=state)
 # state.read_state(...) / state.write_state(...)
 ```
 
-Keys may be input indices or argument names. State tensors must have a static
-shape and a floating-point dtype (Core ML stores them as fp16). They do not
-appear in the model's regular inputs. Mapped outputs are omitted unless every
-result updates state; Core ML requires at least one output, so those updated
-values are then kept as results.
+The outer keys are public StableHLO function names. Inner keys may be input
+indices or argument names; JAX argument names are preserved when available.
+`StateSpec.output` identifies the function output that updates the state. It may
+be an output index, an exact JAX `result_info` name such as
+`"result['cache']"`, or the unique leaf name `"cache"`. Use `output=None` for
+read-only state, and `name=...` to override its Core ML name. A flat
+`{input: output}` mapping remains supported for single-function modules.
+
+State tensors must have a static shape and a floating-point dtype (Core ML
+stores them as fp16). They do not appear in the model's regular inputs. Updated
+outputs are omitted unless every result updates state; Core ML requires at least
+one output, so those updated values are then kept as results.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ read-only state, and `name=...` to override its Core ML name. A flat
 `{input: output}` mapping remains supported for single-function modules.
 
 State tensors must have a static shape and a floating-point dtype (Core ML
-stores them as fp16). They do not appear in the model's regular inputs. Updated
-outputs are omitted unless every result updates state; Core ML requires at least
-one output, so those updated values are then kept as results.
+stores them as fp16). They do not appear in the model's regular inputs, and the
+outputs holding their updated values are always dropped. If every result updates
+state, the model instead returns a single fixed one-element fp16 output named
+`state_update_token`, as Core ML requires at least one output.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ form up front, so a JAX pytree argument such as `params['w']` is exposed as
 `params__w__`. An explicit `name=...` that would need sanitizing is rejected at
 conversion time, telling you the valid alternative.
 
-A module with a single public StableHLO function is always exported as the
-Core ML `main` function, whatever the StableHLO function is named; the keys of
-the state mapping still use the StableHLO name. Modules with several public
-functions are exported as a Core ML multifunction model.
+Public StableHLO function names are preserved. A module whose only public
+function is `main` becomes an ordinary Core ML model; anything else (several
+public functions, or a single function with another name) is exported as a
+Core ML multifunction model, since Core ML requires the entry point of an
+ordinary model to be called `main`.
 
 State tensors must have a static shape and a floating-point dtype (Core ML
 stores them as fp16). They do not appear in the model's regular inputs, and the

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For the JAX example to work, you will additionally need to install `absl-py` and
 
 ## Stateful models
 
-Core ML can keep tensors across `predict` calls as *state* instead of passing
+Core ML can keep tensors across model invocations as *state* instead of passing
 them in and out every time. Mark those tensors when converting by mapping each
 state input to the output that holds its updated value:
 

--- a/README.md
+++ b/README.md
@@ -61,29 +61,6 @@ hlo_module = ir.Module.parse(jax_exported.mlir_module(), context=context)
 
 For the JAX example to work, you will additionally need to install `absl-py` and `flatbuffers` as dependencies.
 
-### Input names
-
-> **Breaking change.** Converted model inputs are no longer named `_arg0`,
-> `_arg1`, ... as in previous releases.
-
-An input takes its name from the StableHLO argument's MLIR name location, which
-is where JAX records the traced Python argument name (including the pytree path
-for nested arguments, e.g. `params['w']`). Arguments without such a location —
-typical for modules that were parsed from text or exported by other frontends —
-fall back to their MLIR SSA name without the leading `%`, i.e. `arg0`, `arg1`,
-... . All names are sanitized into valid Core ML identifiers, so the name on the
-final model may differ from the StableHLO one.
-
-Anywhere you refer to inputs by name — `ct.TensorType(name=...)`, the `predict`
-dictionary, `states={...}` keys — use the new names. Read them off the converted
-program rather than hardcoding them:
-
-```python
-mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
-for func in mil_program.functions.values():
-    print(list(func.inputs))
-```
-
 ## Stateful models
 
 Core ML can keep tensors across `predict` calls as *state* instead of passing
@@ -166,9 +143,7 @@ jax_exported = export(jax.jit(jax_function))(
 ```
 
 When converting to a CoreML model, specify `RangeDim` for each symbolic
-dimension so the model accepts a range of sizes at inference time. Note that a
-symbolic export carries no argument name locations, so the inputs fall back to
-`arg0`, `arg1`, ... (see [Input names](#input-names)):
+dimension so the model accepts a range of sizes at inference time:
 
 ```python
 cml_model = ct.convert(

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ y = cml_model.predict({x_name: x}, state=state)
 
 Keys may be input indices or argument names. State tensors must have a static
 shape and a floating-point dtype (Core ML stores them as fp16). They do not
-appear in the model's regular inputs or outputs.
+appear in the model's regular inputs. Mapped outputs are omitted unless every
+result updates state; Core ML requires at least one output, so those updated
+values are then kept as results.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 

--- a/README.md
+++ b/README.md
@@ -89,38 +89,19 @@ cml_model = ct.convert(
 )
 
 state = cml_model.make_state()
-# Remaining tensor inputs keep their StableHLO argument names.
-x_name = list(cml_model.input_description)[0]
-y = cml_model.predict({x_name: x}, state=state)
+y = cml_model.predict({"x": x}, state=state)
 # `cache` is updated in place; inspect or reset it with
 # state.read_state(...) / state.write_state(...)
 ```
 
-The outer keys are public StableHLO function names. Inner keys may be input
-indices or argument names; JAX argument names are preserved when available.
-`StateSpec.output` identifies the function output that updates the state. It may
-be an output index, an exact JAX `result_info` name such as
-`"result['cache']"`, or the unique leaf name `"cache"`. Use `output=None` for
-read-only state, and `name=...` to override its Core ML name. A flat
-`{input: output}` mapping remains supported for single-function modules.
+Inner keys may be argument indices or names, and `StateSpec.output` an output
+index or JAX result name. Use `output=None` for read-only state and `name=...`
+to override the Core ML state name. A flat `{input: output}` mapping works for
+single-function modules.
 
-Core ML only accepts names of the form `[a-zA-Z_][a-zA-Z0-9_]*` and reserves a
-few words (`state`, `tensor`, `bool`, ...). Derived names are sanitized to that
-form up front, so a JAX pytree argument such as `params['w']` is exposed as
-`params__w__`. An explicit `name=...` that would need sanitizing is rejected at
-conversion time, telling you the valid alternative.
-
-Public StableHLO function names are preserved. A module whose only public
-function is `main` becomes an ordinary Core ML model; anything else (several
-public functions, or a single function with another name) is exported as a
-Core ML multifunction model, since Core ML requires the entry point of an
-ordinary model to be called `main`.
-
-State tensors must have a static shape and a floating-point dtype (Core ML
-stores them as fp16). They do not appear in the model's regular inputs, and the
-outputs holding their updated values are always dropped. If every result updates
-state, the model instead returns a single fixed one-element fp16 output named
-`state_update_token`, as Core ML requires at least one output.
+State tensors must have a static shape and a floating-point dtype (stored as
+fp16). They are removed from the model's inputs, and the outputs that update
+them are dropped.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,5 +1,6 @@
-from .converter import StateSpec, convert
+from .converter import convert
 from .passes.utils import DEFAULT_HLO_PIPELINE, register_optimizations
+from .state import StateSpec
 
 __version__ = "0.0.0"
 __all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'convert', 'register_optimizations']

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,5 +1,5 @@
-from .converter import convert
+from .converter import StateSpec, convert
 from .passes.utils import DEFAULT_HLO_PIPELINE, register_optimizations
 
 __version__ = "0.0.0"
-__all__ = ['DEFAULT_HLO_PIPELINE', 'convert', 'register_optimizations']
+__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'convert', 'register_optimizations']

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -122,8 +122,11 @@ def convert(
     tensors onto the output that holds the updated value. Keys are input
     indices or argument names; values are output indices. Those outputs
     are written back with ``coreml_update_state`` and omitted from the
-    function results. State is stored as fp16 (a Core ML requirement);
-    fp32 values are cast around the read/write.
+    function results, except when every result is a state write: Core ML
+    requires at least one output, so the updated state values are then
+    kept as results (cast back to the computation dtype). State is stored
+    as fp16 (a Core ML requirement); fp32 values are cast around the
+    read/write.
     """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
@@ -277,6 +280,11 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         sym_counter = 0
         for in_idx, arg in enumerate(hlo_func.arguments):
             shape = arg.type.shape
+            name = arg.get_name()
+            # Reject dynamic state before constructing MIL Symbols — Symbol
+            # names are process-global and would leak if we raise afterwards.
+            if in_idx in state_map and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
+                raise ValueError(f"State input {name} must have a static shape, got {shape}")
             if shape == []:
                 shape = [1]
             else:
@@ -290,11 +298,8 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
                         new_shape.append(d)
                 shape = new_shape
 
-            name = arg.get_name()
             dtype = get_mil_type_from_ir(arg.type.element_type)
             if in_idx in state_map:
-                if any(is_symbolic(d) for d in shape):
-                    raise ValueError(f"State input {name} must have a static shape, got {shape}")
                 if dtype not in _STATE_VALUE_DTYPES:
                     raise ValueError(
                         f"State input {name} has dtype {dtype_str(dtype)}, "
@@ -338,9 +343,16 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
             # Core ML requires at least one output, so keep the updated
             # state values if every result was consumed by a state write.
+            # coreml_update_state returns the fp16 storage value; cast
+            # back to the computation dtype so the result matches HLO.
             final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
             if not final_outputs:
-                final_outputs = updated_states
+                final_outputs = []
+                for updated, name in zip(updated_states, state_output_index):
+                    compute_dtype = state_compute_dtype[name]
+                    if compute_dtype != types.fp16:
+                        updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))
+                    final_outputs.append(updated)
             ssa_func.set_outputs(final_outputs)
             self.prog.add_function(hlo_func.name.value, ssa_func)
 

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -196,24 +196,21 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         public_function_names = [func.name.value for func in public_functions]
         self.function_states = normalize_function_state_maps(self.states, public_function_names)
 
-        # A module with a single public function is exported as an ordinary
-        # (non-multifunction) model, whose entry point Core ML requires to be
-        # called "main". State mappings stay keyed by the HLO function name.
-        single_function = len(public_functions) == 1
-
         for func in public_functions:
-            self.build_func(func, "main" if single_function else func.name.value)
+            self.build_func(func)
 
+        # Core ML requires the entry point of an ordinary (single-function)
+        # model to be called "main". Anything else — several public functions,
+        # or a lone function with another name — is exported as a multifunction
+        # model, which keeps the StableHLO function names.
         if public_function_names:
             self.prog.default_function_name = (
-                "main"
-                if single_function or "main" in public_function_names
-                else public_function_names[0]
+                "main" if "main" in public_function_names else public_function_names[0]
             )
-        self.prog.export_as_multifunction = len(public_function_names) > 1
+        self.prog.export_as_multifunction = public_function_names != ["main"]
         return self.prog
 
-    def build_func(self, hlo_func: FuncOp, mil_func_name: str | None = None):
+    def build_func(self, hlo_func: FuncOp):
         context = TranslationContext()  # Map from results to created variables
 
         function_states = self.function_states.get(hlo_func.name.value, {})
@@ -224,7 +221,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             state_bindings = interface.bind_arguments(context, hlo_func, ssa_func)
             outputs = self.process_block(context, hlo_func.body.blocks[0])
             ssa_func.set_outputs(interface.finalize_outputs(outputs or [], state_bindings))
-            self.prog.add_function(mil_func_name or hlo_func.name.value, ssa_func)
+            self.prog.add_function(hlo_func.name.value, ssa_func)
 
     def process_block(self, context: TranslationContext, block: ir.Block):
         outputs = None

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -196,17 +196,24 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         public_function_names = [func.name.value for func in public_functions]
         self.function_states = normalize_function_state_maps(self.states, public_function_names)
 
+        # A module with a single public function is exported as an ordinary
+        # (non-multifunction) model, whose entry point Core ML requires to be
+        # called "main". State mappings stay keyed by the HLO function name.
+        single_function = len(public_functions) == 1
+
         for func in public_functions:
-            self.build_func(func)
+            self.build_func(func, "main" if single_function else func.name.value)
 
         if public_function_names:
             self.prog.default_function_name = (
-                "main" if "main" in public_function_names else public_function_names[0]
+                "main"
+                if single_function or "main" in public_function_names
+                else public_function_names[0]
             )
         self.prog.export_as_multifunction = len(public_function_names) > 1
         return self.prog
 
-    def build_func(self, hlo_func: FuncOp):
+    def build_func(self, hlo_func: FuncOp, mil_func_name: str | None = None):
         context = TranslationContext()  # Map from results to created variables
 
         function_states = self.function_states.get(hlo_func.name.value, {})
@@ -214,10 +221,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         interface = _FunctionInterface.from_hlo(hlo_func, state_map)
 
         with Function(interface.inputs, opset_version=self.opset_version) as ssa_func:
-            state_vars = interface.bind_arguments(context, hlo_func, ssa_func)
+            state_bindings = interface.bind_arguments(context, hlo_func, ssa_func)
             outputs = self.process_block(context, hlo_func.body.blocks[0])
-            ssa_func.set_outputs(interface.finalize_outputs(outputs or [], state_vars))
-            self.prog.add_function(hlo_func.name.value, ssa_func)
+            ssa_func.set_outputs(interface.finalize_outputs(outputs or [], state_bindings))
+            self.prog.add_function(mil_func_name or hlo_func.name.value, ssa_func)
 
     def process_block(self, context: TranslationContext, block: ir.Block):
         outputs = None

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,4 +1,6 @@
+import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import partial, reduce
 
 import numpy as np
@@ -111,22 +113,36 @@ from .utils import (
 _STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
 
 
+@dataclass(frozen=True)
+class StateSpec:
+    """Describe how a StableHLO function argument is exposed as Core ML state."""
+
+    output: int | str | None
+    name: str | None = None
+
+
+StateMapping = Mapping[int | str, int | StateSpec]
+FunctionStateMapping = Mapping[str, StateMapping]
+
+
 def convert(
     module,
     minimum_deployment_target: AvailableTarget,
-    states: Mapping[int | str, int] | None = None,
+    states: StateMapping | FunctionStateMapping | None = None,
 ):
     """Convert a StableHLO module to a MIL program.
 
-    ``states`` maps function inputs that should become Core ML state
-    tensors onto the output that holds the updated value. Keys are input
-    indices or argument names; values are output indices. Those outputs
-    are written back with ``coreml_update_state`` and omitted from the
-    function results, except when every result is a state write: Core ML
-    requires at least one output, so the updated state values are then
-    kept as results (cast back to the computation dtype). State is stored
-    as fp16 (a Core ML requirement); fp32 values are cast around the
-    read/write.
+    ``states`` maps public function names to their state arguments. Each
+    argument maps to a :class:`StateSpec` identifying the output that
+    updates it, or ``None`` for read-only state. A flat argument mapping
+    and integer output values remain supported for single-function
+    modules.
+
+    State arguments may be identified by index or by their JAX/MLIR name.
+    Updated outputs are omitted from the function results, except when
+    every result is a state write: Core ML requires at least one output,
+    so the updated values are then kept as results. State is stored as
+    fp16; fp32 values are cast around the read/write.
     """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
@@ -147,11 +163,20 @@ def _argument_name_aliases(arg) -> list[str]:
         if raw.startswith("%"):
             names.append(raw[1:])
 
-    loc = getattr(arg, "location", None)
-    loc_name = getattr(loc, "name", None) if loc is not None else None
+    loc_name = _argument_location_name(arg)
     if loc_name:
-        names.append(str(loc_name))
+        names.append(loc_name)
     return names
+
+
+def _argument_location_name(arg) -> str | None:
+    loc = getattr(arg, "location", None)
+    name = getattr(loc, "name_str", None) if loc is not None else None
+    return name if isinstance(name, str) and name else None
+
+
+def _preferred_argument_name(arg) -> str:
+    return _argument_location_name(arg) or arg.get_name().lstrip("%")
 
 
 def _function_outputs(hlo_func: FuncOp):
@@ -165,7 +190,53 @@ def _function_outputs(hlo_func: FuncOp):
     return None
 
 
-def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dict[int, int]:
+def _result_info_aliases(result_info: str) -> set[str]:
+    aliases = {result_info}
+    leaf_match = re.search(r"""\[['"]([^'"]+)['"]\]$""", result_info)
+    if leaf_match is not None:
+        aliases.add(leaf_match.group(1))
+    return aliases
+
+
+def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | None:
+    if output is None or isinstance(output, int):
+        return output
+
+    matches: dict[str, list[int]] = {}
+    result_attrs = getattr(hlo_func, "result_attrs", ())
+    for index, attrs in enumerate(result_attrs):
+        try:
+            result_info = attrs["jax.result_info"].value
+        except KeyError:
+            continue
+        for alias in _result_info_aliases(result_info):
+            matches.setdefault(alias, []).append(index)
+
+    indices = matches.get(output, [])
+    if len(indices) > 1:
+        raise ValueError(f"State output name {output!r} is ambiguous")
+    if not indices:
+        known = ", ".join(repr(name) for name in sorted(matches)) or "<none>"
+        raise ValueError(f"Unknown state output {output!r}. Known output names: {known}")
+    return indices[0]
+
+
+def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
+    if isinstance(value, StateSpec):
+        spec = value
+    elif isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"State specification must be a StateSpec or output index, got {value!r}")
+    else:
+        spec = StateSpec(output=value)
+
+    if isinstance(spec.output, bool) or not isinstance(spec.output, (int, str, type(None))):
+        raise TypeError(f"State output must be an int, str, or None, got {spec.output!r}")
+    if spec.name is not None and (not isinstance(spec.name, str) or not spec.name):
+        raise TypeError(f"State name must be a non-empty str or None, got {spec.name!r}")
+    return spec
+
+
+def _resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, StateSpec]:
     args = list(hlo_func.arguments)
     name_to_idx: dict[str, int] = {}
     for i, arg in enumerate(args):
@@ -175,11 +246,13 @@ def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dic
     results = _function_outputs(hlo_func)
     num_outputs = len(results) if results is not None else None
 
-    resolved: dict[int, int] = {}
+    resolved: dict[int, StateSpec] = {}
     output_owners: dict[int, int] = {}
-    for key, out_idx in states.items():
-        if isinstance(out_idx, bool) or not isinstance(out_idx, int):
-            raise TypeError(f"State output index must be an int, got {out_idx!r}")
+    state_names: set[str] = set()
+    for key, value in states.items():
+        spec = _coerce_state_spec(value)
+        out_idx = _resolve_state_output(hlo_func, spec.output)
+        spec = StateSpec(output=out_idx, name=spec.name)
         if isinstance(key, bool) or not isinstance(key, (int, str)):
             raise TypeError(f"State input must be an int index or str name, got {key!r}")
 
@@ -197,26 +270,66 @@ def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dic
             )
         if in_idx in resolved:
             raise ValueError(f"Function argument {in_idx} is mapped as state more than once")
-        if out_idx < 0:
-            raise ValueError(f"State output index {out_idx} is invalid")
-        if num_outputs is not None and out_idx >= num_outputs:
+        if spec.name is not None and spec.name in state_names:
+            raise ValueError(f"Core ML state name {spec.name!r} is used more than once")
+        if spec.output is not None and spec.output < 0:
+            raise ValueError(f"State output index {spec.output} is invalid")
+        if spec.output is not None and num_outputs is not None and spec.output >= num_outputs:
             raise ValueError(
-                f"State output index {out_idx} is out of range for a function with {num_outputs} outputs"
+                f"State output index {spec.output} is out of range for a function with {num_outputs} outputs"
             )
-        if out_idx in output_owners:
+        if spec.output is not None and spec.output in output_owners:
             raise ValueError(
-                f"Output {out_idx} cannot update both argument {output_owners[out_idx]} and {in_idx}"
+                f"Output {spec.output} cannot update both argument "
+                f"{output_owners[spec.output]} and {in_idx}"
             )
-        if results is not None and args[in_idx].type != results[out_idx]:
+        if spec.output is not None and results is not None and args[in_idx].type != results[spec.output]:
             raise ValueError(
                 f"State input {in_idx} has type {args[in_idx].type}, but output "
-                f"{out_idx} has type {results[out_idx]}"
+                f"{spec.output} has type {results[spec.output]}"
             )
 
-        resolved[in_idx] = out_idx
-        output_owners[out_idx] = in_idx
+        resolved[in_idx] = spec
+        if spec.name is not None:
+            state_names.add(spec.name)
+        if spec.output is not None:
+            output_owners[spec.output] = in_idx
 
     return resolved
+
+
+def _normalize_function_state_maps(
+    states: StateMapping | FunctionStateMapping | None,
+    public_function_names: list[str],
+) -> dict[str, StateMapping]:
+    if not states:
+        return {}
+
+    values = list(states.values())
+    has_nested_values = any(isinstance(value, Mapping) for value in values)
+    if has_nested_values:
+        if not all(isinstance(value, Mapping) for value in values):
+            raise TypeError("State mappings cannot mix function mappings with state specifications")
+        invalid_names = [name for name in states if not isinstance(name, str)]
+        if invalid_names:
+            raise TypeError(
+                f"Function names in a state mapping must be strings, got {invalid_names[0]!r}"
+            )
+        unknown = set(states) - set(public_function_names)
+        if unknown:
+            known = ", ".join(public_function_names) or "<none>"
+            raise ValueError(
+                f"Unknown public function(s) in state mapping: {', '.join(sorted(unknown))}. "
+                f"Known public functions: {known}"
+            )
+        return {name: mapping for name, mapping in states.items()}
+
+    if len(public_function_names) != 1:
+        raise ValueError(
+            "A flat state mapping is only supported for single-function modules; "
+            "map each public function name to its states"
+        )
+    return {public_function_names[0]: states}
 
 
 def _normalize_module(module: ir.Module) -> None:
@@ -249,12 +362,13 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
     def __init__(
         self,
         opset_version: int | None = None,
-        states: Mapping[int | str, int] | None = None,
+        states: StateMapping | FunctionStateMapping | None = None,
     ):
         self.opset_version = AvailableTarget(opset_version) if opset_version is not None else None
         self.prog = mil.Program()
         self.func_index = {}
         self.states = dict(states) if states else {}
+        self.function_states: dict[str, StateMapping] = {}
 
     def convert(self, module: ir.Module) -> Program:
         logger.info("Converting graph.")
@@ -263,24 +377,63 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         for func in module.body:
             self.func_index[func.name.value] = func
 
-        for func in module.body:
-            if func.sym_visibility is None or func.sym_visibility.value == "public":
-                self.build_func(func)
+        public_functions = [
+            func
+            for func in module.body
+            if func.sym_visibility is None or func.sym_visibility.value == "public"
+        ]
+        public_function_names = [func.name.value for func in public_functions]
+        self.function_states = _normalize_function_state_maps(self.states, public_function_names)
 
+        for func in public_functions:
+            self.build_func(func)
+
+        if public_function_names:
+            self.prog.default_function_name = (
+                "main" if "main" in public_function_names else public_function_names[0]
+            )
+        self.prog.export_as_multifunction = len(public_function_names) > 1
         return self.prog
 
     def build_func(self, hlo_func: FuncOp):
         context = TranslationContext()  # Map from results to created variables
 
-        state_map = _resolve_state_map(hlo_func, self.states) if self.states else {}
+        function_states = self.function_states.get(hlo_func.name.value, {})
+        state_map = _resolve_state_map(hlo_func, function_states) if function_states else {}
 
         func_inputs = {}
-        state_output_index: dict[str, int] = {}
+        state_specs: dict[str, StateSpec] = {}
         state_compute_dtype: dict[str, object] = {}
+        argument_input_names: dict[int, str] = {}
+        used_input_names: set[str] = set()
+        explicit_state_names = {
+            spec.name: in_idx
+            for in_idx, spec in state_map.items()
+            if spec.name is not None
+        }
         sym_counter = 0
         for in_idx, arg in enumerate(hlo_func.arguments):
             shape = arg.type.shape
-            name = arg.get_name()
+            context_name = arg.get_name()
+            state_spec = state_map.get(in_idx)
+            explicit_name = state_spec.name if state_spec is not None else None
+            name = explicit_name or _preferred_argument_name(arg)
+            if explicit_name is not None:
+                if name in used_input_names:
+                    raise ValueError(
+                        f"Core ML state name {name!r} conflicts with another function input"
+                    )
+            else:
+                if name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = context_name.lstrip("%")
+                while name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = f"{name}_input"
+            used_input_names.add(name)
+            argument_input_names[in_idx] = name
             # Reject dynamic state before constructing MIL Symbols — Symbol
             # names are process-global and would leak if we raise afterwards.
             if in_idx in state_map and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
@@ -306,22 +459,23 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
                         "but Core ML states must be floating point (stored as fp16)"
                     )
                 func_inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
-                state_output_index[name] = state_map[in_idx]
+                state_specs[name] = state_map[in_idx]
                 state_compute_dtype[name] = dtype
             else:
                 func_inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
 
         with Function(func_inputs, opset_version=self.opset_version) as ssa_func:
             state_vars = {}
-            for name in func_inputs:
+            for in_idx, arg in enumerate(hlo_func.arguments):
+                name = argument_input_names[in_idx]
                 var = ssa_func.inputs[name]
-                if name in state_output_index:
+                if name in state_specs:
                     state_vars[name] = var
                     var = mb.read_state(input=var)
                     compute_dtype = state_compute_dtype[name]
                     if compute_dtype != types.fp16:
                         var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
-                context.add_variable(name, var)
+                context.add_variable(arg.get_name(), var)
 
             outputs = self.process_block(context, hlo_func.body.blocks[0])
             if outputs is None:
@@ -329,7 +483,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
             consumed = set()
             updated_states = []
-            for name, out_idx in state_output_index.items():
+            for name, spec in state_specs.items():
+                if spec.output is None:
+                    continue
+                out_idx = spec.output
                 if not 0 <= out_idx < len(outputs):
                     raise ValueError(
                         f"State output index {out_idx} is out of range for a function "
@@ -346,9 +503,12 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             # coreml_update_state returns the fp16 storage value; cast
             # back to the computation dtype so the result matches HLO.
             final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
-            if not final_outputs:
+            if not final_outputs and updated_states:
                 final_outputs = []
-                for updated, name in zip(updated_states, state_output_index):
+                updated_state_names = [
+                    name for name, spec in state_specs.items() if spec.output is not None
+                ]
+                for updated, name in zip(updated_states, updated_state_names):
                     compute_dtype = state_compute_dtype[name]
                     if compute_dtype != types.fp16:
                         updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from functools import partial, reduce
 
 import numpy as np
@@ -105,8 +106,25 @@ from .utils import (
     zero_tensor,
 )
 
+# Core ML can only serialize state tensors as fp16. fp32 HLO state is
+# stored as fp16 and cast to/from the computation dtype around read/write.
+_STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
 
-def convert(module, minimum_deployment_target: AvailableTarget):
+
+def convert(
+    module,
+    minimum_deployment_target: AvailableTarget,
+    states: Mapping[int | str, int] | None = None,
+):
+    """Convert a StableHLO module to a MIL program.
+
+    ``states`` maps function inputs that should become Core ML state
+    tensors onto the output that holds the updated value. Keys are input
+    indices or argument names; values are output indices. Those outputs
+    are written back with ``coreml_update_state`` and omitted from the
+    function results. State is stored as fp16 (a Core ML requirement);
+    fp32 values are cast around the read/write.
+    """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
 
@@ -114,8 +132,88 @@ def convert(module, minimum_deployment_target: AvailableTarget):
 
     _normalize_module(module)
 
-    converter = StableHloConverter(opset_version=minimum_deployment_target)
+    converter = StableHloConverter(opset_version=minimum_deployment_target, states=states)
     return converter.convert(module)
+
+
+def _argument_name_aliases(arg) -> list[str]:
+    names: list[str] = []
+    raw = arg.get_name()
+    if raw:
+        names.append(raw)
+        if raw.startswith("%"):
+            names.append(raw[1:])
+
+    loc = getattr(arg, "location", None)
+    loc_name = getattr(loc, "name", None) if loc is not None else None
+    if loc_name:
+        names.append(str(loc_name))
+    return names
+
+
+def _function_outputs(hlo_func: FuncOp):
+    func_type = getattr(hlo_func, "type", None)
+    if func_type is None:
+        return None
+    for attr in ("results", "outputs"):
+        values = getattr(func_type, attr, None)
+        if values is not None:
+            return values
+    return None
+
+
+def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dict[int, int]:
+    args = list(hlo_func.arguments)
+    name_to_idx: dict[str, int] = {}
+    for i, arg in enumerate(args):
+        for alias in _argument_name_aliases(arg):
+            name_to_idx.setdefault(alias, i)
+
+    results = _function_outputs(hlo_func)
+    num_outputs = len(results) if results is not None else None
+
+    resolved: dict[int, int] = {}
+    output_owners: dict[int, int] = {}
+    for key, out_idx in states.items():
+        if isinstance(out_idx, bool) or not isinstance(out_idx, int):
+            raise TypeError(f"State output index must be an int, got {out_idx!r}")
+        if isinstance(key, bool) or not isinstance(key, (int, str)):
+            raise TypeError(f"State input must be an int index or str name, got {key!r}")
+
+        if isinstance(key, int):
+            in_idx = key
+        elif key not in name_to_idx:
+            known = ", ".join(sorted(name_to_idx)) or "<none>"
+            raise ValueError(f"Unknown state input {key!r}. Known argument names: {known}")
+        else:
+            in_idx = name_to_idx[key]
+
+        if not 0 <= in_idx < len(args):
+            raise ValueError(
+                f"State input index {in_idx} is out of range for a function with {len(args)} arguments"
+            )
+        if in_idx in resolved:
+            raise ValueError(f"Function argument {in_idx} is mapped as state more than once")
+        if out_idx < 0:
+            raise ValueError(f"State output index {out_idx} is invalid")
+        if num_outputs is not None and out_idx >= num_outputs:
+            raise ValueError(
+                f"State output index {out_idx} is out of range for a function with {num_outputs} outputs"
+            )
+        if out_idx in output_owners:
+            raise ValueError(
+                f"Output {out_idx} cannot update both argument {output_owners[out_idx]} and {in_idx}"
+            )
+        if results is not None and args[in_idx].type != results[out_idx]:
+            raise ValueError(
+                f"State input {in_idx} has type {args[in_idx].type}, but output "
+                f"{out_idx} has type {results[out_idx]}"
+            )
+
+        resolved[in_idx] = out_idx
+        output_owners[out_idx] = in_idx
+
+    return resolved
 
 
 def _normalize_module(module: ir.Module) -> None:
@@ -145,10 +243,15 @@ def _normalize_module(module: ir.Module) -> None:
 
 class StableHloConverter(metaclass=StableHloOpsRegistry):
 
-    def __init__(self, opset_version: int | None = None):
+    def __init__(
+        self,
+        opset_version: int | None = None,
+        states: Mapping[int | str, int] | None = None,
+    ):
         self.opset_version = AvailableTarget(opset_version) if opset_version is not None else None
         self.prog = mil.Program()
         self.func_index = {}
+        self.states = dict(states) if states else {}
 
     def convert(self, module: ir.Module) -> Program:
         logger.info("Converting graph.")
@@ -166,9 +269,13 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
     def build_func(self, hlo_func: FuncOp):
         context = TranslationContext()  # Map from results to created variables
 
+        state_map = _resolve_state_map(hlo_func, self.states) if self.states else {}
+
         func_inputs = {}
+        state_output_index: dict[str, int] = {}
+        state_compute_dtype: dict[str, object] = {}
         sym_counter = 0
-        for arg in hlo_func.arguments:
+        for in_idx, arg in enumerate(hlo_func.arguments):
             shape = arg.type.shape
             if shape == []:
                 shape = [1]
@@ -183,15 +290,58 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
                         new_shape.append(d)
                 shape = new_shape
 
-            func_inputs[arg.get_name()] = mb.placeholder(
-                shape=shape, dtype=get_mil_type_from_ir(arg.type.element_type)
-            )
+            name = arg.get_name()
+            dtype = get_mil_type_from_ir(arg.type.element_type)
+            if in_idx in state_map:
+                if any(is_symbolic(d) for d in shape):
+                    raise ValueError(f"State input {name} must have a static shape, got {shape}")
+                if dtype not in _STATE_VALUE_DTYPES:
+                    raise ValueError(
+                        f"State input {name} has dtype {dtype_str(dtype)}, "
+                        "but Core ML states must be floating point (stored as fp16)"
+                    )
+                func_inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
+                state_output_index[name] = state_map[in_idx]
+                state_compute_dtype[name] = dtype
+            else:
+                func_inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
 
         with Function(func_inputs, opset_version=self.opset_version) as ssa_func:
+            state_vars = {}
             for name in func_inputs:
-                context.add_variable(name, ssa_func.inputs[name])
+                var = ssa_func.inputs[name]
+                if name in state_output_index:
+                    state_vars[name] = var
+                    var = mb.read_state(input=var)
+                    compute_dtype = state_compute_dtype[name]
+                    if compute_dtype != types.fp16:
+                        var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
+                context.add_variable(name, var)
 
-            ssa_func.set_outputs(self.process_block(context, hlo_func.body.blocks[0]))
+            outputs = self.process_block(context, hlo_func.body.blocks[0])
+            if outputs is None:
+                outputs = []
+
+            consumed = set()
+            updated_states = []
+            for name, out_idx in state_output_index.items():
+                if not 0 <= out_idx < len(outputs):
+                    raise ValueError(
+                        f"State output index {out_idx} is out of range for a function "
+                        f"with {len(outputs)} outputs"
+                    )
+                value = outputs[out_idx]
+                if state_compute_dtype[name] != types.fp16:
+                    value = mb.cast(x=value, dtype="fp16")
+                updated_states.append(mb.coreml_update_state(state=state_vars[name], value=value))
+                consumed.add(out_idx)
+
+            # Core ML requires at least one output, so keep the updated
+            # state values if every result was consumed by a state write.
+            final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
+            if not final_outputs:
+                final_outputs = updated_states
+            ssa_func.set_outputs(final_outputs)
             self.prog.add_function(hlo_func.name.value, ssa_func)
 
     def process_block(self, context: TranslationContext, block: ir.Block):

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from functools import partial, reduce
 
 import numpy as np
@@ -6,7 +5,7 @@ from coremltools import _logger as logger
 from coremltools.converters.mil import mil
 from coremltools.converters.mil._deployment_compatibility import AvailableTarget
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil import Function, Placeholder, Program, Symbol, Var, types
+from coremltools.converters.mil.mil import Function, Program, types
 from coremltools.converters.mil.mil.ops.defs._utils import (
     promote_input_dtypes,
 )
@@ -83,6 +82,7 @@ from jaxlib.mlir.dialects.stablehlo import (
     XorOp,
 )
 
+from .function_interface import _FunctionInterface
 from .ops_register import StableHloOpsRegistry, register_composite_op, register_stablehlo_op
 from .padding import pad_with_cast
 from .passes.utils import register_optimizations
@@ -91,9 +91,7 @@ from .sort_utils import match_sort
 from .state import (
     FunctionStateMapping,
     StateMapping,
-    StateSpec,
     normalize_function_state_maps,
-    preferred_argument_name,
     resolve_state_map,
 )
 from .translation_context import DYNAMIC_DIM_SENTINEL, TranslationContext
@@ -114,10 +112,6 @@ from .utils import (
     zero_tensor,
 )
 
-# Core ML can only serialize state tensors as fp16. fp32 HLO state is
-# stored as fp16 and cast to/from the computation dtype around read/write.
-_STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
-
 
 def convert(
     module,
@@ -133,10 +127,10 @@ def convert(
     modules.
 
     State arguments may be identified by index or by their JAX/MLIR name.
-    Updated outputs are omitted from the function results, except when
-    every result is a state write: Core ML requires at least one output,
-    so the updated values are then kept as results. State is stored as
-    fp16; fp32 values are cast around the read/write.
+    Updated outputs are omitted from the function results. When every result
+    is a state write, a one-element token is returned because Core ML requires
+    at least one tensor output. State is stored as fp16; fp32 values are cast
+    around the read/write.
     """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
@@ -172,145 +166,6 @@ def _normalize_module(module: ir.Module) -> None:
         context=module.context,
     )
     pm.run(module.operation)
-
-
-@dataclass
-class _FunctionInterface:
-    inputs: dict[str, Placeholder]
-    argument_names: dict[int, str]
-    state_specs: dict[str, StateSpec]
-    state_compute_dtypes: dict[str, object]
-
-    @classmethod
-    def from_hlo(
-        cls,
-        hlo_func: FuncOp,
-        state_map: dict[int, StateSpec],
-    ) -> "_FunctionInterface":
-        inputs = {}
-        state_specs: dict[str, StateSpec] = {}
-        state_compute_dtypes: dict[str, object] = {}
-        argument_names: dict[int, str] = {}
-        used_input_names: set[str] = set()
-        explicit_state_names = {
-            spec.name: in_idx
-            for in_idx, spec in state_map.items()
-            if spec.name is not None
-        }
-        sym_counter = 0
-
-        for in_idx, arg in enumerate(hlo_func.arguments):
-            shape = arg.type.shape
-            context_name = arg.get_name()
-            state_spec = state_map.get(in_idx)
-            explicit_name = state_spec.name if state_spec is not None else None
-            name = explicit_name or preferred_argument_name(arg)
-            if explicit_name is not None:
-                if name in used_input_names:
-                    raise ValueError(
-                        f"Core ML state name {name!r} conflicts with another function input"
-                    )
-            else:
-                if name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = context_name.lstrip("%")
-                while name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = f"{name}_input"
-            used_input_names.add(name)
-            argument_names[in_idx] = name
-
-            # Reject dynamic state before constructing MIL Symbols — Symbol
-            # names are process-global and would leak if we raise afterwards.
-            if state_spec is not None and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
-                raise ValueError(f"State input {name} must have a static shape, got {shape}")
-            if shape == []:
-                shape = [1]
-            else:
-                new_shape = []
-                for dim in shape:
-                    if dim == DYNAMIC_DIM_SENTINEL:
-                        new_shape.append(Symbol(f"dim_{sym_counter}"))
-                        sym_counter += 1
-                    else:
-                        new_shape.append(dim)
-                shape = new_shape
-
-            dtype = get_mil_type_from_ir(arg.type.element_type)
-            if state_spec is None:
-                inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
-                continue
-            if dtype not in _STATE_VALUE_DTYPES:
-                raise ValueError(
-                    f"State input {name} has dtype {dtype_str(dtype)}, "
-                    "but Core ML states must be floating point (stored as fp16)"
-                )
-            inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
-            state_specs[name] = state_spec
-            state_compute_dtypes[name] = dtype
-
-        return cls(
-            inputs=inputs,
-            argument_names=argument_names,
-            state_specs=state_specs,
-            state_compute_dtypes=state_compute_dtypes,
-        )
-
-    def bind_arguments(
-        self,
-        context: TranslationContext,
-        hlo_func: FuncOp,
-        ssa_func: Function,
-    ) -> dict[str, Var]:
-        state_vars = {}
-        for in_idx, arg in enumerate(hlo_func.arguments):
-            name = self.argument_names[in_idx]
-            var = ssa_func.inputs[name]
-            if name in self.state_specs:
-                state_vars[name] = var
-                var = mb.read_state(input=var)
-                compute_dtype = self.state_compute_dtypes[name]
-                if compute_dtype != types.fp16:
-                    var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
-            context.add_variable(arg.get_name(), var)
-        return state_vars
-
-    def finalize_outputs(
-        self,
-        outputs: list[Var],
-        state_vars: dict[str, Var],
-    ) -> list[Var]:
-        consumed = set()
-        updated_states = []
-        for name, spec in self.state_specs.items():
-            if spec.output is None:
-                continue
-            out_idx = spec.output
-            if not 0 <= out_idx < len(outputs):
-                raise ValueError(
-                    f"State output index {out_idx} is out of range for a function "
-                    f"with {len(outputs)} outputs"
-                )
-            value = outputs[out_idx]
-            if self.state_compute_dtypes[name] != types.fp16:
-                value = mb.cast(x=value, dtype="fp16")
-            updated = mb.coreml_update_state(state=state_vars[name], value=value)
-            updated_states.append((updated, name))
-            consumed.add(out_idx)
-
-        final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
-        if final_outputs or not updated_states:
-            return final_outputs
-
-        # Core ML requires at least one output, so retain state-only results.
-        for updated, name in updated_states:
-            compute_dtype = self.state_compute_dtypes[name]
-            if compute_dtype != types.fp16:
-                updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))
-            final_outputs.append(updated)
-        return final_outputs
 
 
 class StableHloConverter(metaclass=StableHloOpsRegistry):

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,5 +1,3 @@
-import re
-from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial, reduce
 
@@ -8,7 +6,7 @@ from coremltools import _logger as logger
 from coremltools.converters.mil import mil
 from coremltools.converters.mil._deployment_compatibility import AvailableTarget
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil import Function, Program, Symbol, types
+from coremltools.converters.mil.mil import Function, Placeholder, Program, Symbol, Var, types
 from coremltools.converters.mil.mil.ops.defs._utils import (
     promote_input_dtypes,
 )
@@ -90,6 +88,14 @@ from .padding import pad_with_cast
 from .passes.utils import register_optimizations
 from .reductions import compute_reduction, compute_windowed_reduction, match_computation, match_simple_reduce_window
 from .sort_utils import match_sort
+from .state import (
+    FunctionStateMapping,
+    StateMapping,
+    StateSpec,
+    normalize_function_state_maps,
+    preferred_argument_name,
+    resolve_state_map,
+)
 from .translation_context import DYNAMIC_DIM_SENTINEL, TranslationContext
 from .utils import (
     auto_cast_bool,
@@ -111,18 +117,6 @@ from .utils import (
 # Core ML can only serialize state tensors as fp16. fp32 HLO state is
 # stored as fp16 and cast to/from the computation dtype around read/write.
 _STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
-
-
-@dataclass(frozen=True)
-class StateSpec:
-    """Describe how a StableHLO function argument is exposed as Core ML state."""
-
-    output: int | str | None
-    name: str | None = None
-
-
-StateMapping = Mapping[int | str, int | StateSpec]
-FunctionStateMapping = Mapping[str, StateMapping]
 
 
 def convert(
@@ -155,183 +149,6 @@ def convert(
     return converter.convert(module)
 
 
-def _argument_name_aliases(arg) -> list[str]:
-    names: list[str] = []
-    raw = arg.get_name()
-    if raw:
-        names.append(raw)
-        if raw.startswith("%"):
-            names.append(raw[1:])
-
-    loc_name = _argument_location_name(arg)
-    if loc_name:
-        names.append(loc_name)
-    return names
-
-
-def _argument_location_name(arg) -> str | None:
-    loc = getattr(arg, "location", None)
-    name = getattr(loc, "name_str", None) if loc is not None else None
-    return name if isinstance(name, str) and name else None
-
-
-def _preferred_argument_name(arg) -> str:
-    return _argument_location_name(arg) or arg.get_name().lstrip("%")
-
-
-def _function_outputs(hlo_func: FuncOp):
-    func_type = getattr(hlo_func, "type", None)
-    if func_type is None:
-        return None
-    for attr in ("results", "outputs"):
-        values = getattr(func_type, attr, None)
-        if values is not None:
-            return values
-    return None
-
-
-def _result_info_aliases(result_info: str) -> set[str]:
-    aliases = {result_info}
-    leaf_match = re.search(r"""\[['"]([^'"]+)['"]\]$""", result_info)
-    if leaf_match is not None:
-        aliases.add(leaf_match.group(1))
-    return aliases
-
-
-def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | None:
-    if output is None or isinstance(output, int):
-        return output
-
-    matches: dict[str, list[int]] = {}
-    result_attrs = getattr(hlo_func, "result_attrs", ())
-    for index, attrs in enumerate(result_attrs):
-        try:
-            result_info = attrs["jax.result_info"].value
-        except KeyError:
-            continue
-        for alias in _result_info_aliases(result_info):
-            matches.setdefault(alias, []).append(index)
-
-    indices = matches.get(output, [])
-    if len(indices) > 1:
-        raise ValueError(f"State output name {output!r} is ambiguous")
-    if not indices:
-        known = ", ".join(repr(name) for name in sorted(matches)) or "<none>"
-        raise ValueError(f"Unknown state output {output!r}. Known output names: {known}")
-    return indices[0]
-
-
-def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
-    if isinstance(value, StateSpec):
-        spec = value
-    elif isinstance(value, bool) or not isinstance(value, int):
-        raise TypeError(f"State specification must be a StateSpec or output index, got {value!r}")
-    else:
-        spec = StateSpec(output=value)
-
-    if isinstance(spec.output, bool) or not isinstance(spec.output, (int, str, type(None))):
-        raise TypeError(f"State output must be an int, str, or None, got {spec.output!r}")
-    if spec.name is not None and (not isinstance(spec.name, str) or not spec.name):
-        raise TypeError(f"State name must be a non-empty str or None, got {spec.name!r}")
-    return spec
-
-
-def _resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, StateSpec]:
-    args = list(hlo_func.arguments)
-    name_to_idx: dict[str, int] = {}
-    for i, arg in enumerate(args):
-        for alias in _argument_name_aliases(arg):
-            name_to_idx.setdefault(alias, i)
-
-    results = _function_outputs(hlo_func)
-    num_outputs = len(results) if results is not None else None
-
-    resolved: dict[int, StateSpec] = {}
-    output_owners: dict[int, int] = {}
-    state_names: set[str] = set()
-    for key, value in states.items():
-        spec = _coerce_state_spec(value)
-        out_idx = _resolve_state_output(hlo_func, spec.output)
-        spec = StateSpec(output=out_idx, name=spec.name)
-        if isinstance(key, bool) or not isinstance(key, (int, str)):
-            raise TypeError(f"State input must be an int index or str name, got {key!r}")
-
-        if isinstance(key, int):
-            in_idx = key
-        elif key not in name_to_idx:
-            known = ", ".join(sorted(name_to_idx)) or "<none>"
-            raise ValueError(f"Unknown state input {key!r}. Known argument names: {known}")
-        else:
-            in_idx = name_to_idx[key]
-
-        if not 0 <= in_idx < len(args):
-            raise ValueError(
-                f"State input index {in_idx} is out of range for a function with {len(args)} arguments"
-            )
-        if in_idx in resolved:
-            raise ValueError(f"Function argument {in_idx} is mapped as state more than once")
-        if spec.name is not None and spec.name in state_names:
-            raise ValueError(f"Core ML state name {spec.name!r} is used more than once")
-        if spec.output is not None and spec.output < 0:
-            raise ValueError(f"State output index {spec.output} is invalid")
-        if spec.output is not None and num_outputs is not None and spec.output >= num_outputs:
-            raise ValueError(
-                f"State output index {spec.output} is out of range for a function with {num_outputs} outputs"
-            )
-        if spec.output is not None and spec.output in output_owners:
-            raise ValueError(
-                f"Output {spec.output} cannot update both argument "
-                f"{output_owners[spec.output]} and {in_idx}"
-            )
-        if spec.output is not None and results is not None and args[in_idx].type != results[spec.output]:
-            raise ValueError(
-                f"State input {in_idx} has type {args[in_idx].type}, but output "
-                f"{spec.output} has type {results[spec.output]}"
-            )
-
-        resolved[in_idx] = spec
-        if spec.name is not None:
-            state_names.add(spec.name)
-        if spec.output is not None:
-            output_owners[spec.output] = in_idx
-
-    return resolved
-
-
-def _normalize_function_state_maps(
-    states: StateMapping | FunctionStateMapping | None,
-    public_function_names: list[str],
-) -> dict[str, StateMapping]:
-    if not states:
-        return {}
-
-    values = list(states.values())
-    has_nested_values = any(isinstance(value, Mapping) for value in values)
-    if has_nested_values:
-        if not all(isinstance(value, Mapping) for value in values):
-            raise TypeError("State mappings cannot mix function mappings with state specifications")
-        invalid_names = [name for name in states if not isinstance(name, str)]
-        if invalid_names:
-            raise TypeError(
-                f"Function names in a state mapping must be strings, got {invalid_names[0]!r}"
-            )
-        unknown = set(states) - set(public_function_names)
-        if unknown:
-            known = ", ".join(public_function_names) or "<none>"
-            raise ValueError(
-                f"Unknown public function(s) in state mapping: {', '.join(sorted(unknown))}. "
-                f"Known public functions: {known}"
-            )
-        return {name: mapping for name, mapping in states.items()}
-
-    if len(public_function_names) != 1:
-        raise ValueError(
-            "A flat state mapping is only supported for single-function modules; "
-            "map each public function name to its states"
-        )
-    return {public_function_names[0]: states}
-
-
 def _normalize_module(module: ir.Module) -> None:
     """Normalize an incoming StableHLO module in-place before conversion.
 
@@ -355,6 +172,145 @@ def _normalize_module(module: ir.Module) -> None:
         context=module.context,
     )
     pm.run(module.operation)
+
+
+@dataclass
+class _FunctionInterface:
+    inputs: dict[str, Placeholder]
+    argument_names: dict[int, str]
+    state_specs: dict[str, StateSpec]
+    state_compute_dtypes: dict[str, object]
+
+    @classmethod
+    def from_hlo(
+        cls,
+        hlo_func: FuncOp,
+        state_map: dict[int, StateSpec],
+    ) -> "_FunctionInterface":
+        inputs = {}
+        state_specs: dict[str, StateSpec] = {}
+        state_compute_dtypes: dict[str, object] = {}
+        argument_names: dict[int, str] = {}
+        used_input_names: set[str] = set()
+        explicit_state_names = {
+            spec.name: in_idx
+            for in_idx, spec in state_map.items()
+            if spec.name is not None
+        }
+        sym_counter = 0
+
+        for in_idx, arg in enumerate(hlo_func.arguments):
+            shape = arg.type.shape
+            context_name = arg.get_name()
+            state_spec = state_map.get(in_idx)
+            explicit_name = state_spec.name if state_spec is not None else None
+            name = explicit_name or preferred_argument_name(arg)
+            if explicit_name is not None:
+                if name in used_input_names:
+                    raise ValueError(
+                        f"Core ML state name {name!r} conflicts with another function input"
+                    )
+            else:
+                if name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = context_name.lstrip("%")
+                while name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = f"{name}_input"
+            used_input_names.add(name)
+            argument_names[in_idx] = name
+
+            # Reject dynamic state before constructing MIL Symbols — Symbol
+            # names are process-global and would leak if we raise afterwards.
+            if state_spec is not None and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
+                raise ValueError(f"State input {name} must have a static shape, got {shape}")
+            if shape == []:
+                shape = [1]
+            else:
+                new_shape = []
+                for dim in shape:
+                    if dim == DYNAMIC_DIM_SENTINEL:
+                        new_shape.append(Symbol(f"dim_{sym_counter}"))
+                        sym_counter += 1
+                    else:
+                        new_shape.append(dim)
+                shape = new_shape
+
+            dtype = get_mil_type_from_ir(arg.type.element_type)
+            if state_spec is None:
+                inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
+                continue
+            if dtype not in _STATE_VALUE_DTYPES:
+                raise ValueError(
+                    f"State input {name} has dtype {dtype_str(dtype)}, "
+                    "but Core ML states must be floating point (stored as fp16)"
+                )
+            inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
+            state_specs[name] = state_spec
+            state_compute_dtypes[name] = dtype
+
+        return cls(
+            inputs=inputs,
+            argument_names=argument_names,
+            state_specs=state_specs,
+            state_compute_dtypes=state_compute_dtypes,
+        )
+
+    def bind_arguments(
+        self,
+        context: TranslationContext,
+        hlo_func: FuncOp,
+        ssa_func: Function,
+    ) -> dict[str, Var]:
+        state_vars = {}
+        for in_idx, arg in enumerate(hlo_func.arguments):
+            name = self.argument_names[in_idx]
+            var = ssa_func.inputs[name]
+            if name in self.state_specs:
+                state_vars[name] = var
+                var = mb.read_state(input=var)
+                compute_dtype = self.state_compute_dtypes[name]
+                if compute_dtype != types.fp16:
+                    var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
+            context.add_variable(arg.get_name(), var)
+        return state_vars
+
+    def finalize_outputs(
+        self,
+        outputs: list[Var],
+        state_vars: dict[str, Var],
+    ) -> list[Var]:
+        consumed = set()
+        updated_states = []
+        for name, spec in self.state_specs.items():
+            if spec.output is None:
+                continue
+            out_idx = spec.output
+            if not 0 <= out_idx < len(outputs):
+                raise ValueError(
+                    f"State output index {out_idx} is out of range for a function "
+                    f"with {len(outputs)} outputs"
+                )
+            value = outputs[out_idx]
+            if self.state_compute_dtypes[name] != types.fp16:
+                value = mb.cast(x=value, dtype="fp16")
+            updated = mb.coreml_update_state(state=state_vars[name], value=value)
+            updated_states.append((updated, name))
+            consumed.add(out_idx)
+
+        final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
+        if final_outputs or not updated_states:
+            return final_outputs
+
+        # Core ML requires at least one output, so retain state-only results.
+        for updated, name in updated_states:
+            compute_dtype = self.state_compute_dtypes[name]
+            if compute_dtype != types.fp16:
+                updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))
+            final_outputs.append(updated)
+        return final_outputs
 
 
 class StableHloConverter(metaclass=StableHloOpsRegistry):
@@ -383,7 +339,7 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             if func.sym_visibility is None or func.sym_visibility.value == "public"
         ]
         public_function_names = [func.name.value for func in public_functions]
-        self.function_states = _normalize_function_state_maps(self.states, public_function_names)
+        self.function_states = normalize_function_state_maps(self.states, public_function_names)
 
         for func in public_functions:
             self.build_func(func)
@@ -399,121 +355,13 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         context = TranslationContext()  # Map from results to created variables
 
         function_states = self.function_states.get(hlo_func.name.value, {})
-        state_map = _resolve_state_map(hlo_func, function_states) if function_states else {}
+        state_map = resolve_state_map(hlo_func, function_states) if function_states else {}
+        interface = _FunctionInterface.from_hlo(hlo_func, state_map)
 
-        func_inputs = {}
-        state_specs: dict[str, StateSpec] = {}
-        state_compute_dtype: dict[str, object] = {}
-        argument_input_names: dict[int, str] = {}
-        used_input_names: set[str] = set()
-        explicit_state_names = {
-            spec.name: in_idx
-            for in_idx, spec in state_map.items()
-            if spec.name is not None
-        }
-        sym_counter = 0
-        for in_idx, arg in enumerate(hlo_func.arguments):
-            shape = arg.type.shape
-            context_name = arg.get_name()
-            state_spec = state_map.get(in_idx)
-            explicit_name = state_spec.name if state_spec is not None else None
-            name = explicit_name or _preferred_argument_name(arg)
-            if explicit_name is not None:
-                if name in used_input_names:
-                    raise ValueError(
-                        f"Core ML state name {name!r} conflicts with another function input"
-                    )
-            else:
-                if name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = context_name.lstrip("%")
-                while name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = f"{name}_input"
-            used_input_names.add(name)
-            argument_input_names[in_idx] = name
-            # Reject dynamic state before constructing MIL Symbols — Symbol
-            # names are process-global and would leak if we raise afterwards.
-            if in_idx in state_map and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
-                raise ValueError(f"State input {name} must have a static shape, got {shape}")
-            if shape == []:
-                shape = [1]
-            else:
-                # Replace dynamic dims with MIL Symbols for flexible shapes
-                new_shape = []
-                for d in shape:
-                    if d == DYNAMIC_DIM_SENTINEL:
-                        new_shape.append(Symbol(f'dim_{sym_counter}'))
-                        sym_counter += 1
-                    else:
-                        new_shape.append(d)
-                shape = new_shape
-
-            dtype = get_mil_type_from_ir(arg.type.element_type)
-            if in_idx in state_map:
-                if dtype not in _STATE_VALUE_DTYPES:
-                    raise ValueError(
-                        f"State input {name} has dtype {dtype_str(dtype)}, "
-                        "but Core ML states must be floating point (stored as fp16)"
-                    )
-                func_inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
-                state_specs[name] = state_map[in_idx]
-                state_compute_dtype[name] = dtype
-            else:
-                func_inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
-
-        with Function(func_inputs, opset_version=self.opset_version) as ssa_func:
-            state_vars = {}
-            for in_idx, arg in enumerate(hlo_func.arguments):
-                name = argument_input_names[in_idx]
-                var = ssa_func.inputs[name]
-                if name in state_specs:
-                    state_vars[name] = var
-                    var = mb.read_state(input=var)
-                    compute_dtype = state_compute_dtype[name]
-                    if compute_dtype != types.fp16:
-                        var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
-                context.add_variable(arg.get_name(), var)
-
+        with Function(interface.inputs, opset_version=self.opset_version) as ssa_func:
+            state_vars = interface.bind_arguments(context, hlo_func, ssa_func)
             outputs = self.process_block(context, hlo_func.body.blocks[0])
-            if outputs is None:
-                outputs = []
-
-            consumed = set()
-            updated_states = []
-            for name, spec in state_specs.items():
-                if spec.output is None:
-                    continue
-                out_idx = spec.output
-                if not 0 <= out_idx < len(outputs):
-                    raise ValueError(
-                        f"State output index {out_idx} is out of range for a function "
-                        f"with {len(outputs)} outputs"
-                    )
-                value = outputs[out_idx]
-                if state_compute_dtype[name] != types.fp16:
-                    value = mb.cast(x=value, dtype="fp16")
-                updated_states.append(mb.coreml_update_state(state=state_vars[name], value=value))
-                consumed.add(out_idx)
-
-            # Core ML requires at least one output, so keep the updated
-            # state values if every result was consumed by a state write.
-            # coreml_update_state returns the fp16 storage value; cast
-            # back to the computation dtype so the result matches HLO.
-            final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
-            if not final_outputs and updated_states:
-                final_outputs = []
-                updated_state_names = [
-                    name for name, spec in state_specs.items() if spec.output is not None
-                ]
-                for updated, name in zip(updated_states, updated_state_names):
-                    compute_dtype = state_compute_dtype[name]
-                    if compute_dtype != types.fp16:
-                        updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))
-                    final_outputs.append(updated)
-            ssa_func.set_outputs(final_outputs)
+            ssa_func.set_outputs(interface.finalize_outputs(outputs or [], state_vars))
             self.prog.add_function(hlo_func.name.value, ssa_func)
 
     def process_block(self, context: TranslationContext, block: ir.Block):

--- a/stablehlo_coreml/function_interface.py
+++ b/stablehlo_coreml/function_interface.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import Function, Placeholder, Symbol, Var, types
+from jaxlib.mlir.dialects.func import FuncOp
+
+from .state import StateSpec, preferred_argument_name
+from .translation_context import DYNAMIC_DIM_SENTINEL, TranslationContext
+from .utils import dtype_str, get_mil_type_from_ir
+
+# Core ML can only serialize state tensors as fp16. fp32 HLO state is
+# stored as fp16 and cast to/from the computation dtype around read/write.
+_STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
+
+
+@dataclass
+class _FunctionInterface:
+    inputs: dict[str, Placeholder]
+    argument_names: dict[int, str]
+    state_specs: dict[str, StateSpec]
+    state_compute_dtypes: dict[str, object]
+
+    @classmethod
+    def from_hlo(
+        cls,
+        hlo_func: FuncOp,
+        state_map: dict[int, StateSpec],
+    ) -> "_FunctionInterface":
+        inputs = {}
+        state_specs: dict[str, StateSpec] = {}
+        state_compute_dtypes: dict[str, object] = {}
+        argument_names: dict[int, str] = {}
+        used_input_names: set[str] = set()
+        explicit_state_names = {
+            spec.name: in_idx
+            for in_idx, spec in state_map.items()
+            if spec.name is not None
+        }
+        sym_counter = 0
+
+        for in_idx, arg in enumerate(hlo_func.arguments):
+            shape = arg.type.shape
+            context_name = arg.get_name()
+            state_spec = state_map.get(in_idx)
+            explicit_name = state_spec.name if state_spec is not None else None
+            name = explicit_name or preferred_argument_name(arg)
+            if explicit_name is not None:
+                if name in used_input_names:
+                    raise ValueError(
+                        f"Core ML state name {name!r} conflicts with another function input"
+                    )
+            else:
+                if name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = context_name.lstrip("%")
+                while name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = f"{name}_input"
+            used_input_names.add(name)
+            argument_names[in_idx] = name
+
+            # Reject dynamic state before constructing MIL Symbols — Symbol
+            # names are process-global and would leak if we raise afterwards.
+            if state_spec is not None and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
+                raise ValueError(f"State input {name} must have a static shape, got {shape}")
+            if shape == []:
+                shape = [1]
+            else:
+                new_shape = []
+                for dim in shape:
+                    if dim == DYNAMIC_DIM_SENTINEL:
+                        new_shape.append(Symbol(f"dim_{sym_counter}"))
+                        sym_counter += 1
+                    else:
+                        new_shape.append(dim)
+                shape = new_shape
+
+            dtype = get_mil_type_from_ir(arg.type.element_type)
+            if state_spec is None:
+                inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
+                continue
+            if dtype not in _STATE_VALUE_DTYPES:
+                raise ValueError(
+                    f"State input {name} has dtype {dtype_str(dtype)}, "
+                    "but Core ML states must be floating point (stored as fp16)"
+                )
+            inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
+            state_specs[name] = state_spec
+            state_compute_dtypes[name] = dtype
+
+        return cls(
+            inputs=inputs,
+            argument_names=argument_names,
+            state_specs=state_specs,
+            state_compute_dtypes=state_compute_dtypes,
+        )
+
+    def bind_arguments(
+        self,
+        context: TranslationContext,
+        hlo_func: FuncOp,
+        ssa_func: Function,
+    ) -> dict[str, Var]:
+        state_vars = {}
+        for in_idx, arg in enumerate(hlo_func.arguments):
+            name = self.argument_names[in_idx]
+            var = ssa_func.inputs[name]
+            if name in self.state_specs:
+                state_vars[name] = var
+                var = mb.read_state(input=var)
+                compute_dtype = self.state_compute_dtypes[name]
+                if compute_dtype != types.fp16:
+                    var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
+            context.add_variable(arg.get_name(), var)
+        return state_vars
+
+    def finalize_outputs(
+        self,
+        outputs: list[Var],
+        state_vars: dict[str, Var],
+    ) -> list[Var]:
+        consumed = set()
+        for name, spec in self.state_specs.items():
+            if spec.output is None:
+                continue
+            out_idx = spec.output
+            if not 0 <= out_idx < len(outputs):
+                raise ValueError(
+                    f"State output index {out_idx} is out of range for a function "
+                    f"with {len(outputs)} outputs"
+                )
+            value = outputs[out_idx]
+            if self.state_compute_dtypes[name] != types.fp16:
+                value = mb.cast(x=value, dtype="fp16")
+            mb.coreml_update_state(state=state_vars[name], value=value)
+            consumed.add(out_idx)
+
+        final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
+        if final_outputs or not consumed:
+            return final_outputs
+
+        # Core ML requires at least one tensor output. Keep state values private
+        # and expose a fixed token rather than duplicating every updated state.
+        token = mb.const(
+            val=np.zeros((1,), dtype=np.float16),
+            name="state_update_token",
+        )
+        return [token]

--- a/stablehlo_coreml/function_interface.py
+++ b/stablehlo_coreml/function_interface.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import Function, Placeholder, Symbol, Var, types
+from coremltools.converters.mil.mil.passes.defs.preprocess import NameSanitizer
 from jaxlib.mlir.dialects.func import FuncOp
 
 from .state import StateSpec, preferred_argument_name
@@ -14,6 +15,28 @@ from .utils import dtype_str, get_mil_type_from_ir
 _STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
 
 
+def sanitize_name(name: str) -> str:
+    """Return ``name`` the way Core ML would name it.
+
+    Core ML only accepts names matching ``[a-zA-Z_][a-zA-Z0-9_]*`` and reserves
+    a handful of words (``state``, ``tensor``, ...). coremltools rewrites
+    offending names, but only for the ``main`` function and without telling the
+    caller. We apply the same rewrite up front, so the names we hand to Core ML
+    are already final and identical across all functions.
+    """
+    # A fresh sanitizer keeps this a pure function; uniqueness of the resulting
+    # names is handled by the caller.
+    return NameSanitizer(prefix="var_").sanitize_name(name)
+
+
+@dataclass
+class _StateBinding:
+    """The MIL vars backing one Core ML state input."""
+
+    state: Var  # the state placeholder itself
+    read: Var  # the fp16 tensor read out of the state
+
+
 @dataclass
 class _FunctionInterface:
     inputs: dict[str, Placeholder]
@@ -21,51 +44,83 @@ class _FunctionInterface:
     state_specs: dict[str, StateSpec]
     state_compute_dtypes: dict[str, object]
 
+    @staticmethod
+    def _assign_argument_names(
+        hlo_func: FuncOp,
+        state_map: dict[int, StateSpec],
+    ) -> dict[int, str]:
+        explicit_state_names: dict[str, int] = {}
+        for in_idx, spec in state_map.items():
+            if spec.name is None:
+                continue
+            sanitized = sanitize_name(spec.name)
+            if sanitized != spec.name:
+                raise ValueError(
+                    f"Core ML state name {spec.name!r} is not a valid Core ML name "
+                    f"(Core ML would rename it to {sanitized!r}); "
+                    f"use name={sanitized!r} instead"
+                )
+            explicit_state_names[spec.name] = in_idx
+
+        argument_names: dict[int, str] = {}
+        used_input_names: set[str] = set()
+
+        def is_taken(name: str, in_idx: int) -> bool:
+            return name in used_input_names or explicit_state_names.get(name, in_idx) != in_idx
+
+        for in_idx, arg in enumerate(hlo_func.arguments):
+            state_spec = state_map.get(in_idx)
+            explicit_name = state_spec.name if state_spec is not None else None
+            if explicit_name is not None:
+                name = explicit_name
+                if name in used_input_names:
+                    raise ValueError(
+                        f"Core ML state name {name!r} conflicts with another function input"
+                    )
+            else:
+                name = sanitize_name(preferred_argument_name(arg))
+                if is_taken(name, in_idx):
+                    name = sanitize_name(arg.get_name().lstrip("%"))
+                while is_taken(name, in_idx):
+                    name = f"{name}_input"
+            used_input_names.add(name)
+            argument_names[in_idx] = name
+
+        return argument_names
+
     @classmethod
     def from_hlo(
         cls,
         hlo_func: FuncOp,
         state_map: dict[int, StateSpec],
     ) -> "_FunctionInterface":
+        argument_names = cls._assign_argument_names(hlo_func, state_map)
+
+        # Validate every state argument before constructing any MIL Symbol —
+        # Symbol names are process global, so symbols created for earlier
+        # arguments would leak if we raised part-way through the build below.
+        for in_idx in sorted(state_map):
+            arg = hlo_func.arguments[in_idx]
+            name = argument_names[in_idx]
+            shape = arg.type.shape
+            if any(d == DYNAMIC_DIM_SENTINEL for d in shape):
+                raise ValueError(f"State input {name} must have a static shape, got {shape}")
+            dtype = get_mil_type_from_ir(arg.type.element_type)
+            if dtype not in _STATE_VALUE_DTYPES:
+                raise ValueError(
+                    f"State input {name} has dtype {dtype_str(dtype)}, "
+                    "but Core ML states must be floating point (stored as fp16)"
+                )
+
         inputs = {}
         state_specs: dict[str, StateSpec] = {}
         state_compute_dtypes: dict[str, object] = {}
-        argument_names: dict[int, str] = {}
-        used_input_names: set[str] = set()
-        explicit_state_names = {
-            spec.name: in_idx
-            for in_idx, spec in state_map.items()
-            if spec.name is not None
-        }
         sym_counter = 0
 
         for in_idx, arg in enumerate(hlo_func.arguments):
-            shape = arg.type.shape
-            context_name = arg.get_name()
+            name = argument_names[in_idx]
             state_spec = state_map.get(in_idx)
-            explicit_name = state_spec.name if state_spec is not None else None
-            name = explicit_name or preferred_argument_name(arg)
-            if explicit_name is not None:
-                if name in used_input_names:
-                    raise ValueError(
-                        f"Core ML state name {name!r} conflicts with another function input"
-                    )
-            else:
-                if name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = context_name.lstrip("%")
-                while name in used_input_names or (
-                    name in explicit_state_names and explicit_state_names[name] != in_idx
-                ):
-                    name = f"{name}_input"
-            used_input_names.add(name)
-            argument_names[in_idx] = name
-
-            # Reject dynamic state before constructing MIL Symbols — Symbol
-            # names are process-global and would leak if we raise afterwards.
-            if state_spec is not None and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
-                raise ValueError(f"State input {name} must have a static shape, got {shape}")
+            shape = arg.type.shape
             if shape == []:
                 shape = [1]
             else:
@@ -82,11 +137,6 @@ class _FunctionInterface:
             if state_spec is None:
                 inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
                 continue
-            if dtype not in _STATE_VALUE_DTYPES:
-                raise ValueError(
-                    f"State input {name} has dtype {dtype_str(dtype)}, "
-                    "but Core ML states must be floating point (stored as fp16)"
-                )
             inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
             state_specs[name] = state_spec
             state_compute_dtypes[name] = dtype
@@ -103,24 +153,24 @@ class _FunctionInterface:
         context: TranslationContext,
         hlo_func: FuncOp,
         ssa_func: Function,
-    ) -> dict[str, Var]:
-        state_vars = {}
+    ) -> dict[str, _StateBinding]:
+        state_bindings = {}
         for in_idx, arg in enumerate(hlo_func.arguments):
             name = self.argument_names[in_idx]
             var = ssa_func.inputs[name]
             if name in self.state_specs:
-                state_vars[name] = var
                 var = mb.read_state(input=var)
+                state_bindings[name] = _StateBinding(state=ssa_func.inputs[name], read=var)
                 compute_dtype = self.state_compute_dtypes[name]
                 if compute_dtype != types.fp16:
                     var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
             context.add_variable(arg.get_name(), var)
-        return state_vars
+        return state_bindings
 
     def finalize_outputs(
         self,
         outputs: list[Var],
-        state_vars: dict[str, Var],
+        state_bindings: dict[str, _StateBinding],
     ) -> list[Var]:
         consumed = set()
         for name, spec in self.state_specs.items():
@@ -132,10 +182,19 @@ class _FunctionInterface:
                     f"State output index {out_idx} is out of range for a function "
                     f"with {len(outputs)} outputs"
                 )
+            binding = state_bindings[name]
             value = outputs[out_idx]
             if self.state_compute_dtypes[name] != types.fp16:
                 value = mb.cast(x=value, dtype="fp16")
-            mb.coreml_update_state(state=state_vars[name], value=value)
+            if value.val is not None:
+                # Core ML segfaults while loading a model that writes a compile
+                # time constant into a state. Make the written value depend on
+                # the state itself, so it survives constant folding. Adding a
+                # zero tensor (rather than multiplying the state by zero) keeps
+                # NaN/inf already stored in the state out of the update.
+                zeros = mb.fill_like(ref_tensor=binding.read, value=np.float16(0))
+                value = mb.add(x=zeros, y=value)
+            mb.coreml_update_state(state=binding.state, value=value)
             consumed.add(out_idx)
 
         final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]

--- a/stablehlo_coreml/state.py
+++ b/stablehlo_coreml/state.py
@@ -1,6 +1,8 @@
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from jaxlib.mlir import ir
 from jaxlib.mlir.dialects.func import FuncOp
 
 
@@ -12,8 +14,13 @@ class StateSpec:
     name: str | None = None
 
 
-StateMapping = Mapping[int | str, int | StateSpec]
+StateMapping = Mapping[int | str, int | StateSpec | None]
 FunctionStateMapping = Mapping[str, StateMapping]
+
+# A `NameLoc` renders as `loc("name")`, or `loc("name"(<child location>))` when it
+# wraps a child location. Other kinds render differently: `loc("file":line:col)`
+# for a file location and `loc(fused[...])` / `loc(callsite(...))` for the rest.
+_NAME_LOCATION_RE = re.compile(r'^loc\("([^"\\]*)"(?:\(.*\))?\)$', re.DOTALL)
 
 
 def _argument_name_aliases(arg) -> list[str]:
@@ -30,25 +37,47 @@ def _argument_name_aliases(arg) -> list[str]:
     return names
 
 
+def _is_name_location(loc) -> bool | None:
+    """Whether ``loc`` is a ``NameLoc``, or ``None`` if it cannot be determined.
+
+    The location kind *must* be checked before reading ``name_str``: on
+    jaxlib 0.9.x (our minimum supported version) reading ``name_str`` off a
+    non-``NameLoc`` segfaults the interpreter rather than raising.
+    """
+    # jaxlib 0.9.x exposes a single `Location` type with `is_a_*` predicates.
+    is_a_name = getattr(loc, "is_a_name", None)
+    if is_a_name is not None:
+        return bool(is_a_name())
+
+    # jaxlib 0.10+ dropped the predicates and instead returns concrete
+    # `Location` subclasses such as `ir.NameLoc` and `ir.FileLineColLoc`.
+    name_loc_cls = getattr(ir, "NameLoc", None)
+    if name_loc_cls is not None:
+        return isinstance(loc, name_loc_cls)
+
+    return None
+
+
 def _argument_location_name(arg) -> str | None:
     loc = getattr(arg, "location", None)
-    name = getattr(loc, "name_str", None) if loc is not None else None
+    if loc is None:
+        return None
+
+    is_name = _is_name_location(loc)
+    if is_name is False:
+        return None
+    if is_name is None:
+        # Unknown binding: fall back to the (stable) textual form rather than
+        # risk reading `name_str` off a location that does not have one.
+        match = _NAME_LOCATION_RE.match(str(loc))
+        name = match.group(1) if match else None
+    else:
+        name = getattr(loc, "name_str", None)
     return name if isinstance(name, str) and name else None
 
 
 def preferred_argument_name(arg) -> str:
     return _argument_location_name(arg) or arg.get_name().lstrip("%")
-
-
-def _function_outputs(hlo_func: FuncOp):
-    func_type = getattr(hlo_func, "type", None)
-    if func_type is None:
-        return None
-    for attr in ("results", "outputs"):
-        values = getattr(func_type, attr, None)
-        if values is not None:
-            return values
-    return None
 
 
 def _result_info_aliases(result_info: str) -> set[str]:
@@ -74,7 +103,12 @@ def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | N
         return output
 
     matches: dict[str, list[int]] = {}
-    result_attrs = getattr(hlo_func, "result_attrs", ())
+    try:
+        # `FuncOp.result_attrs` raises `KeyError` when the function carries no
+        # `res_attrs` at all, which is the case for hand-written modules.
+        result_attrs = hlo_func.result_attrs
+    except KeyError:
+        result_attrs = ()
     for index, attrs in enumerate(result_attrs):
         try:
             result_info = attrs["jax.result_info"].value
@@ -92,19 +126,23 @@ def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | N
     return indices[0]
 
 
-def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
+def _coerce_state_spec(value: int | StateSpec | None) -> StateSpec:
     match value:
         case StateSpec():
             spec = value
+        case None:
+            # Read-only state: the argument is exposed as state, but no output
+            # writes back to it.
+            spec = StateSpec(output=None)
         case bool():
             raise TypeError(
-                f"State specification must be a StateSpec or output index, got {value!r}"
+                f"State specification must be a StateSpec, output index, or None, got {value!r}"
             )
         case int():
             spec = StateSpec(output=value)
         case _:
             raise TypeError(
-                f"State specification must be a StateSpec or output index, got {value!r}"
+                f"State specification must be a StateSpec, output index, or None, got {value!r}"
             )
 
     if isinstance(spec.output, bool) or not isinstance(spec.output, (int, str, type(None))):
@@ -121,8 +159,8 @@ def resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, State
         for alias in _argument_name_aliases(arg):
             name_to_idx.setdefault(alias, i)
 
-    results = _function_outputs(hlo_func)
-    num_outputs = len(results) if results is not None else None
+    results = hlo_func.type.results
+    num_outputs = len(results)
 
     resolved: dict[int, StateSpec] = {}
     output_owners: dict[int, int] = {}
@@ -152,7 +190,7 @@ def resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, State
             raise ValueError(f"Core ML state name {spec.name!r} is used more than once")
         if spec.output is not None and spec.output < 0:
             raise ValueError(f"State output index {spec.output} is invalid")
-        if spec.output is not None and num_outputs is not None and spec.output >= num_outputs:
+        if spec.output is not None and spec.output >= num_outputs:
             raise ValueError(
                 f"State output index {spec.output} is out of range for a function with {num_outputs} outputs"
             )
@@ -161,7 +199,7 @@ def resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, State
                 f"Output {spec.output} cannot update both argument "
                 f"{output_owners[spec.output]} and {in_idx}"
             )
-        if spec.output is not None and results is not None and args[in_idx].type != results[spec.output]:
+        if spec.output is not None and args[in_idx].type != results[spec.output]:
             raise ValueError(
                 f"State input {in_idx} has type {args[in_idx].type}, but output "
                 f"{spec.output} has type {results[spec.output]}"

--- a/stablehlo_coreml/state.py
+++ b/stablehlo_coreml/state.py
@@ -1,0 +1,210 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from jaxlib.mlir.dialects.func import FuncOp
+
+
+@dataclass(frozen=True)
+class StateSpec:
+    """Describe how a StableHLO function argument is exposed as Core ML state."""
+
+    output: int | str | None
+    name: str | None = None
+
+
+StateMapping = Mapping[int | str, int | StateSpec]
+FunctionStateMapping = Mapping[str, StateMapping]
+
+
+def _argument_name_aliases(arg) -> list[str]:
+    names: list[str] = []
+    raw = arg.get_name()
+    if raw:
+        names.append(raw)
+        if raw.startswith("%"):
+            names.append(raw[1:])
+
+    loc_name = _argument_location_name(arg)
+    if loc_name:
+        names.append(loc_name)
+    return names
+
+
+def _argument_location_name(arg) -> str | None:
+    loc = getattr(arg, "location", None)
+    name = getattr(loc, "name_str", None) if loc is not None else None
+    return name if isinstance(name, str) and name else None
+
+
+def preferred_argument_name(arg) -> str:
+    return _argument_location_name(arg) or arg.get_name().lstrip("%")
+
+
+def _function_outputs(hlo_func: FuncOp):
+    func_type = getattr(hlo_func, "type", None)
+    if func_type is None:
+        return None
+    for attr in ("results", "outputs"):
+        values = getattr(func_type, attr, None)
+        if values is not None:
+            return values
+    return None
+
+
+def _result_info_aliases(result_info: str) -> set[str]:
+    aliases = {result_info}
+    _, separator, suffix = result_info.rpartition("[")
+    if not separator or not suffix.endswith("]"):
+        return aliases
+
+    quoted_leaf = suffix[:-1]
+    if (
+        len(quoted_leaf) >= 2
+        and quoted_leaf[0] in {"'", '"'}
+        and quoted_leaf[-1] == quoted_leaf[0]
+    ):
+        leaf = quoted_leaf[1:-1]
+        if leaf and "'" not in leaf and '"' not in leaf:
+            aliases.add(leaf)
+    return aliases
+
+
+def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | None:
+    if output is None or isinstance(output, int):
+        return output
+
+    matches: dict[str, list[int]] = {}
+    result_attrs = getattr(hlo_func, "result_attrs", ())
+    for index, attrs in enumerate(result_attrs):
+        try:
+            result_info = attrs["jax.result_info"].value
+        except KeyError:
+            continue
+        for alias in _result_info_aliases(result_info):
+            matches.setdefault(alias, []).append(index)
+
+    indices = matches.get(output, [])
+    if len(indices) > 1:
+        raise ValueError(f"State output name {output!r} is ambiguous")
+    if not indices:
+        known = ", ".join(repr(name) for name in sorted(matches)) or "<none>"
+        raise ValueError(f"Unknown state output {output!r}. Known output names: {known}")
+    return indices[0]
+
+
+def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
+    match value:
+        case StateSpec():
+            spec = value
+        case bool():
+            raise TypeError(
+                f"State specification must be a StateSpec or output index, got {value!r}"
+            )
+        case int():
+            spec = StateSpec(output=value)
+        case _:
+            raise TypeError(
+                f"State specification must be a StateSpec or output index, got {value!r}"
+            )
+
+    if isinstance(spec.output, bool) or not isinstance(spec.output, (int, str, type(None))):
+        raise TypeError(f"State output must be an int, str, or None, got {spec.output!r}")
+    if spec.name is not None and (not isinstance(spec.name, str) or not spec.name):
+        raise TypeError(f"State name must be a non-empty str or None, got {spec.name!r}")
+    return spec
+
+
+def resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, StateSpec]:
+    args = list(hlo_func.arguments)
+    name_to_idx: dict[str, int] = {}
+    for i, arg in enumerate(args):
+        for alias in _argument_name_aliases(arg):
+            name_to_idx.setdefault(alias, i)
+
+    results = _function_outputs(hlo_func)
+    num_outputs = len(results) if results is not None else None
+
+    resolved: dict[int, StateSpec] = {}
+    output_owners: dict[int, int] = {}
+    state_names: set[str] = set()
+    for key, value in states.items():
+        spec = _coerce_state_spec(value)
+        out_idx = _resolve_state_output(hlo_func, spec.output)
+        spec = StateSpec(output=out_idx, name=spec.name)
+        if isinstance(key, bool) or not isinstance(key, (int, str)):
+            raise TypeError(f"State input must be an int index or str name, got {key!r}")
+
+        if isinstance(key, int):
+            in_idx = key
+        elif key not in name_to_idx:
+            known = ", ".join(sorted(name_to_idx)) or "<none>"
+            raise ValueError(f"Unknown state input {key!r}. Known argument names: {known}")
+        else:
+            in_idx = name_to_idx[key]
+
+        if not 0 <= in_idx < len(args):
+            raise ValueError(
+                f"State input index {in_idx} is out of range for a function with {len(args)} arguments"
+            )
+        if in_idx in resolved:
+            raise ValueError(f"Function argument {in_idx} is mapped as state more than once")
+        if spec.name is not None and spec.name in state_names:
+            raise ValueError(f"Core ML state name {spec.name!r} is used more than once")
+        if spec.output is not None and spec.output < 0:
+            raise ValueError(f"State output index {spec.output} is invalid")
+        if spec.output is not None and num_outputs is not None and spec.output >= num_outputs:
+            raise ValueError(
+                f"State output index {spec.output} is out of range for a function with {num_outputs} outputs"
+            )
+        if spec.output is not None and spec.output in output_owners:
+            raise ValueError(
+                f"Output {spec.output} cannot update both argument "
+                f"{output_owners[spec.output]} and {in_idx}"
+            )
+        if spec.output is not None and results is not None and args[in_idx].type != results[spec.output]:
+            raise ValueError(
+                f"State input {in_idx} has type {args[in_idx].type}, but output "
+                f"{spec.output} has type {results[spec.output]}"
+            )
+
+        resolved[in_idx] = spec
+        if spec.name is not None:
+            state_names.add(spec.name)
+        if spec.output is not None:
+            output_owners[spec.output] = in_idx
+
+    return resolved
+
+
+def normalize_function_state_maps(
+    states: StateMapping | FunctionStateMapping | None,
+    public_function_names: list[str],
+) -> dict[str, StateMapping]:
+    if not states:
+        return {}
+
+    values = list(states.values())
+    has_nested_values = any(isinstance(value, Mapping) for value in values)
+    if has_nested_values:
+        if not all(isinstance(value, Mapping) for value in values):
+            raise TypeError("State mappings cannot mix function mappings with state specifications")
+        invalid_names = [name for name in states if not isinstance(name, str)]
+        if invalid_names:
+            raise TypeError(
+                f"Function names in a state mapping must be strings, got {invalid_names[0]!r}"
+            )
+        unknown = set(states) - set(public_function_names)
+        if unknown:
+            known = ", ".join(public_function_names) or "<none>"
+            raise ValueError(
+                f"Unknown public function(s) in state mapping: {', '.join(sorted(unknown))}. "
+                f"Known public functions: {known}"
+            )
+        return {name: mapping for name, mapping in states.items()}
+
+    if len(public_function_names) != 1:
+        raise ValueError(
+            "A flat state mapping is only supported for single-function modules; "
+            "map each public function name to its states"
+        )
+    return {public_function_names[0]: states}

--- a/tests/test_state_spec.py
+++ b/tests/test_state_spec.py
@@ -1,0 +1,146 @@
+"""Unit tests for `stablehlo_coreml.state` helpers.
+
+These cover the cases that only show up for modules that were *not* produced by
+`jax.export` (hand-written MLIR, torchax exports, symbolic-shape exports), which
+carry different argument locations and no `jax.result_info` attributes.
+"""
+
+import coremltools as ct
+import jax.numpy as jnp
+import pytest
+from jax._src.interpreters import mlir as jax_mlir
+from jax._src.lib.mlir import ir
+
+from stablehlo_coreml import StateSpec
+from stablehlo_coreml.converter import convert
+from stablehlo_coreml.state import (
+    _NAME_LOCATION_RE,
+    preferred_argument_name,
+    resolve_state_map,
+)
+from tests.utils import export_hlo_module
+
+# Argument locations here mimic what `ir.Module.parse` and non-JAX frontends
+# produce: file/line/column locations rather than the `NameLoc`s that
+# `jax.export` emits.
+_PARSED_MODULE = """
+module {
+  func.func public @main(%arg0: tensor<2xf32> loc("-":1:33), %arg1: tensor<2xf32>)
+      -> (tensor<2xf32>, tensor<2xf32>) {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+    return %0, %0 : tensor<2xf32>, tensor<2xf32>
+  }
+}
+"""
+
+
+def _main(hlo_module):
+    """The ``@main`` function of ``hlo_module``.
+
+    The caller must keep ``hlo_module`` alive for as long as the returned
+    ``FuncOp`` is used, otherwise the underlying MLIR storage is freed.
+    """
+    return next(func for func in hlo_module.body if func.name.value == "main")
+
+
+@pytest.fixture
+def parse():
+    """Parse MLIR text into a module, keeping every parsed module alive."""
+    modules = []
+
+    def parse_module(mlir_text: str):
+        module = ir.Module.parse(mlir_text, context=jax_mlir.make_ir_context())
+        modules.append(module)
+        return module
+
+    return parse_module
+
+
+def _instruction_types(mil_program) -> list[str]:
+    return [
+        op.op_type
+        for func in mil_program.functions.values()
+        for op in func.operations
+    ]
+
+
+def _stateful_module(states):
+    def step(state, x):
+        new_state = state + x
+        return new_state * x, new_state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(step, inputs)
+    return convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states=states)
+
+
+def test_non_name_locations_fall_back_to_ssa_names(parse):
+    """Reading `name_str` off a non-`NameLoc` segfaults on jaxlib 0.9.x."""
+    hlo_func = _main(parse(_PARSED_MODULE))
+    assert [preferred_argument_name(arg) for arg in hlo_func.arguments] == ["arg0", "arg1"]
+
+
+@pytest.mark.parametrize(
+    "location",
+    ['loc("-":1:33)', 'loc(fused["a", "b"])', "loc(unknown)", "loc(callsite(\"a\" at \"b\"))"],
+)
+def test_argument_names_for_every_location_kind(parse, location):
+    hlo_func = _main(parse(f"""
+    module {{
+      func.func public @main(%arg0: tensor<2xf32> {location}) -> tensor<2xf32> {{
+        return %arg0 : tensor<2xf32>
+      }}
+    }}
+    """))
+    assert preferred_argument_name(hlo_func.arguments[0]) == "arg0"
+
+
+def test_jax_exported_arguments_keep_their_python_names():
+    def step(cache, x):
+        return cache + x
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(step, inputs)
+    hlo_func = _main(hlo_module)
+    assert [preferred_argument_name(arg) for arg in hlo_func.arguments] == ["cache", "x"]
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        ('loc("cache")', "cache"),
+        ('loc("cache"(unknown))', "cache"),
+        ('loc("-":1:33)', None),
+        ('loc(fused["a", "b"])', None),
+        ("loc(unknown)", None),
+    ],
+)
+def test_name_location_regex(location, expected):
+    """The textual fallback used when no location-kind predicate is available."""
+    match = _NAME_LOCATION_RE.match(location)
+    assert (match.group(1) if match else None) == expected
+
+
+def test_named_output_on_module_without_result_attrs_raises_value_error(parse):
+    """`FuncOp.result_attrs` raises `KeyError` when there are no `res_attrs`."""
+    hlo_func = _main(parse(_PARSED_MODULE))
+    with pytest.raises(ValueError, match="Unknown state output 'cache'"):
+        resolve_state_map(hlo_func, {0: StateSpec(output="cache")})
+
+
+def test_none_is_accepted_as_a_read_only_state_spec(parse):
+    hlo_func = _main(parse(_PARSED_MODULE))
+    assert resolve_state_map(hlo_func, {0: None}) == resolve_state_map(
+        hlo_func, {0: StateSpec(output=None)}
+    )
+    assert resolve_state_map(hlo_func, {0: None}) == {0: StateSpec(output=None)}
+
+
+def test_none_state_converts_to_a_read_only_state():
+    from_none = _stateful_module({"main": {"state": None}})
+    from_spec = _stateful_module({"main": {"state": StateSpec(output=None)}})
+
+    op_types = _instruction_types(from_none)
+    assert "read_state" in op_types
+    assert "coreml_update_state" not in op_types
+    assert op_types == _instruction_types(from_spec)

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -475,7 +475,7 @@ def test_pytree_state_name_is_sanitized():
     )
 
 
-def test_single_public_function_is_exported_as_main():
+def test_single_non_main_function_is_exported_as_multifunction():
     ctx = jax_mlir.make_ir_context()
     hlo_module = ir.Module.parse(
         """
@@ -490,9 +490,11 @@ def test_single_public_function_is_exported_as_main():
     )
     mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
 
-    assert list(mil_program.functions) == ["main"]
-    assert mil_program.default_function_name == "main"
-    assert not mil_program.export_as_multifunction
+    # Only a lone "main" can be an ordinary Core ML model; any other function
+    # name is kept by exporting a multifunction model.
+    assert list(mil_program.functions) == ["forward"]
+    assert mil_program.default_function_name == "forward"
+    assert mil_program.export_as_multifunction
 
     cml_model = ct.convert(
         mil_program,
@@ -509,7 +511,7 @@ def test_single_public_function_is_exported_as_main():
     np.testing.assert_allclose(outputs[output_names[0]], [4.0, 6.0], atol=1e-3)
 
 
-def test_single_public_function_with_state_is_exported_as_main():
+def test_single_non_main_function_with_state_keeps_its_name():
     ctx = jax_mlir.make_ir_context()
     hlo_module = ir.Module.parse(
         """
@@ -529,7 +531,8 @@ def test_single_public_function_with_state_is_exported_as_main():
         states={"forward": {"arg0": StateSpec(output=1, name="cache")}},
     )
 
-    assert list(mil_program.functions) == ["main"]
+    assert list(mil_program.functions) == ["forward"]
+    assert mil_program.export_as_multifunction
     cml_model = ct.convert(
         mil_program,
         source="milinternal",

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -1,0 +1,172 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import pytest
+from jax._src.interpreters import mlir as jax_mlir
+from jax._src.lib.mlir import ir
+from jax.export import export, symbolic_shape
+
+from stablehlo_coreml.converter import convert
+from tests.utils import export_hlo_module, run_and_compare_stateful
+
+
+def _instruction_types(mil_program) -> list[str]:
+    return [
+        op.op_type
+        for func in mil_program.functions.values()
+        for op in func.operations
+    ]
+
+
+def _accumulator(state, x):
+    new_state = state + x
+    return new_state * new_state, new_state
+
+
+def test_accumulator_persists_across_calls():
+    initial_state = jnp.zeros((3,), dtype=jnp.float32)
+    run_and_compare_stateful(
+        _accumulator,
+        initial_inputs=(initial_state, jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)),
+        states={0: 1},
+        extra_nonstate_steps=[
+            (jnp.array([0.5, -1.0, 2.0], dtype=jnp.float32),),
+            (jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32),),
+        ],
+    )
+
+
+def test_state_inputs_are_omitted_from_model_io():
+    inputs = (jnp.zeros((2, 2), dtype=jnp.float32), jnp.ones((2, 2), dtype=jnp.float32))
+    hlo_module = export_hlo_module(_accumulator, inputs)
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+
+    mil_func = next(iter(mil_program.functions.values()))
+    assert len(mil_func.inputs) == 2
+    assert len(mil_func.outputs) == 1
+    op_types = _instruction_types(mil_program)
+    assert "read_state" in op_types
+    assert "coreml_update_state" in op_types
+
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+    )
+    assert len(list(cml_model.input_description)) == 1
+    assert len(list(cml_model.output_description)) == 1
+
+
+def test_multiple_states():
+    def step(k, v, x):
+        new_k = k + x
+        new_v = v * 2.0 + x
+        return new_k + new_v, new_k, new_v
+
+    zeros = jnp.zeros((2, 3), dtype=jnp.float32)
+    x0 = jnp.ones((2, 3), dtype=jnp.float32)
+    run_and_compare_stateful(
+        step,
+        initial_inputs=(zeros, zeros + 1.0, x0),
+        states={0: 1, 1: 2},
+        extra_nonstate_steps=[
+            (jnp.full((2, 3), 0.5, dtype=jnp.float32),),
+        ],
+    )
+
+
+def test_state_only_output():
+    def add_into(state, x):
+        return state + x
+
+    run_and_compare_stateful(
+        add_into,
+        initial_inputs=(jnp.zeros((4,), dtype=jnp.float32), jnp.arange(4, dtype=jnp.float32)),
+        states={0: 0},
+        extra_nonstate_steps=[
+            (jnp.ones((4,), dtype=jnp.float32),),
+        ],
+    )
+
+
+def test_state_by_argument_name():
+    def step(state, x):
+        new_state = state + x
+        return x * new_state, new_state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(step, inputs)
+    mil_by_index = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+    # `%arg0` is also accepted without the leading `%`.
+    mil_by_name = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={"arg0": 1})
+    assert _instruction_types(mil_by_index) == _instruction_types(mil_by_name)
+
+
+def test_unknown_state_name():
+    hlo_module = export_hlo_module(
+        _accumulator,
+        (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32)),
+    )
+    with pytest.raises(ValueError, match="Unknown state input"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={"not_an_arg": 1})
+
+
+def test_invalid_state_index():
+    hlo_module = export_hlo_module(
+        _accumulator,
+        (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32)),
+    )
+    with pytest.raises(ValueError, match="out of range"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={4: 0})
+
+
+def test_invalid_state_output_index():
+    hlo_module = export_hlo_module(
+        _accumulator,
+        (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32)),
+    )
+    with pytest.raises(ValueError, match="out of range"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 5})
+
+
+def test_duplicate_state_output():
+    def step(k, v, x):
+        return x, k + x, v + x
+
+    hlo_module = export_hlo_module(
+        step,
+        (
+            jnp.zeros((2,), dtype=jnp.float32),
+            jnp.zeros((2,), dtype=jnp.float32),
+            jnp.ones((2,), dtype=jnp.float32),
+        ),
+    )
+    with pytest.raises(ValueError, match="cannot update both"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1, 1: 1})
+
+
+def test_state_type_mismatch():
+    def step(state, x):
+        return x, state[:1] + x[:1]
+
+    hlo_module = export_hlo_module(
+        step,
+        (jnp.zeros((4,), dtype=jnp.float32), jnp.ones((4,), dtype=jnp.float32)),
+    )
+    with pytest.raises(ValueError, match="has type"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+
+
+def test_symbolic_state_is_rejected():
+    def step(state, x):
+        return x + state, state + 1.0
+
+    (n,) = symbolic_shape("n")
+    exported = export(jax.jit(step))(
+        jax.ShapeDtypeStruct((n, 2), jnp.float32),
+        jax.ShapeDtypeStruct((n, 2), jnp.float32),
+    )
+    context = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
+    with pytest.raises(ValueError, match="static shape"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -1,6 +1,7 @@
 import coremltools as ct
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from coremltools.converters.mil.mil import types
 from jax._src.interpreters import mlir as jax_mlir
@@ -9,7 +10,12 @@ from jax.export import export, symbolic_shape
 
 from stablehlo_coreml import StateSpec
 from stablehlo_coreml.converter import convert
-from tests.utils import export_hlo_module, run_and_compare_stateful
+from tests.utils import (
+    export_hlo_module,
+    model_for_function,
+    model_io_names,
+    run_and_compare_stateful,
+)
 
 
 def _instruction_types(mil_program) -> list[str]:
@@ -20,9 +26,9 @@ def _instruction_types(mil_program) -> list[str]:
     ]
 
 
-def _accumulator(state, x):
-    new_state = state + x
-    return new_state * new_state, new_state
+def _accumulator(cache, x):
+    new_cache = cache + x
+    return new_cache * new_cache, new_cache
 
 
 def test_accumulator_persists_across_calls():
@@ -30,7 +36,7 @@ def test_accumulator_persists_across_calls():
     run_and_compare_stateful(
         _accumulator,
         initial_inputs=(initial_state, jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)),
-        states={"main": {"state": StateSpec(output=1)}},
+        states={"main": {"cache": StateSpec(output=1)}},
         subsequent_inputs=[
             (jnp.array([0.5, -1.0, 2.0], dtype=jnp.float32),),
             (jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32),),
@@ -78,8 +84,8 @@ def test_multiple_states():
 
 
 def test_state_only_output():
-    def add_into(state, x):
-        return state + x
+    def add_into(cache, x):
+        return cache + x
 
     inputs = (jnp.zeros((4,), dtype=jnp.float32), jnp.arange(4, dtype=jnp.float32))
     hlo_module = export_hlo_module(add_into, inputs)
@@ -101,9 +107,9 @@ def test_state_only_output():
 
 
 def test_state_by_argument_name():
-    def step(state, x):
-        new_state = state + x
-        return x * new_state, new_state
+    def step(cache, x):
+        new_cache = cache + x
+        return x * new_cache, new_cache
 
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     hlo_module = export_hlo_module(step, inputs)
@@ -111,22 +117,22 @@ def test_state_by_argument_name():
     mil_by_name = convert(
         hlo_module,
         minimum_deployment_target=ct.target.iOS18,
-        states={"main": {"state": StateSpec(output=1)}},
+        states={"main": {"cache": StateSpec(output=1)}},
     )
     assert _instruction_types(mil_by_index) == _instruction_types(mil_by_name)
-    assert list(mil_by_name.functions["main"].inputs) == ["state", "x"]
+    assert list(mil_by_name.functions["main"].inputs) == ["cache", "x"]
 
 
 def test_read_only_state():
-    def inspect(state, x):
-        return state + x
+    def inspect(cache, x):
+        return cache + x
 
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     hlo_module = export_hlo_module(inspect, inputs)
     mil_program = convert(
         hlo_module,
         minimum_deployment_target=ct.target.iOS18,
-        states={"main": {"state": StateSpec(output=None)}},
+        states={"main": {"cache": StateSpec(output=None)}},
     )
 
     op_types = _instruction_types(mil_program)
@@ -136,16 +142,16 @@ def test_read_only_state():
 
 
 def test_state_name_override():
-    def step(state, x):
-        new_state = state + x
-        return new_state, new_state
+    def step(cache, x):
+        new_cache = cache + x
+        return new_cache, new_cache
 
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     hlo_module = export_hlo_module(step, inputs)
     mil_program = convert(
         hlo_module,
         minimum_deployment_target=ct.target.iOS18,
-        states={"main": {"state": StateSpec(output=1, name="accumulator")}},
+        states={"main": {"cache": StateSpec(output=1, name="accumulator")}},
     )
 
     assert list(mil_program.functions["main"].inputs) == ["accumulator", "x"]
@@ -168,20 +174,20 @@ def test_state_name_override_takes_precedence_over_jax_argument_name():
 
 @pytest.mark.parametrize("output", ["cache", "result['cache']"])
 def test_state_output_by_jax_result_name(output):
-    def step(state, x):
-        new_state = state + x
-        return {"prediction": new_state * x, "cache": new_state}
+    def step(carry, x):
+        new_carry = carry + x
+        return {"prediction": new_carry * x, "cache": new_carry}
 
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     named_program = convert(
         export_hlo_module(step, inputs),
         minimum_deployment_target=ct.target.iOS18,
-        states={"main": {"state": StateSpec(output=output)}},
+        states={"main": {"carry": StateSpec(output=output)}},
     )
     indexed_program = convert(
         export_hlo_module(step, inputs),
         minimum_deployment_target=ct.target.iOS18,
-        states={"main": {"state": StateSpec(output=0)}},
+        states={"main": {"carry": StateSpec(output=0)}},
     )
 
     assert _instruction_types(named_program) == _instruction_types(indexed_program)
@@ -225,12 +231,40 @@ def test_function_scoped_states_export_as_multifunction():
         mil_program,
         source="milinternal",
         minimum_deployment_target=ct.target.iOS18,
-        skip_model_load=True,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
     )
     descriptions = {desc.name: desc for desc in cml_model.get_spec().description.functions}
     assert set(descriptions) == {"update", "inspect"}
     assert [state.name for state in descriptions["update"].state] == ["cache"]
     assert [state.name for state in descriptions["inspect"].state] == ["cache"]
+
+    # Both functions must actually load and run with their own state
+    update_model = model_for_function(cml_model, "update")
+    update_inputs, update_outputs, update_states = model_io_names(update_model)
+    assert (update_inputs, update_states) == (["arg1"], ["cache"])
+    update_state = update_model.make_state()
+    update_state.write_state(name="cache", value=np.array([1.0, 2.0], dtype=np.float32))
+    update_out = update_model.predict(
+        {"arg1": np.array([3.0, 4.0], dtype=np.float32)}, state=update_state
+    )
+    np.testing.assert_allclose(update_out[update_outputs[0]], [4.0, 6.0], atol=1e-3)
+    np.testing.assert_allclose(
+        np.asarray(update_state.read_state(name="cache")), [4.0, 6.0], atol=1e-3
+    )
+
+    inspect_model = model_for_function(cml_model, "inspect")
+    inspect_inputs, inspect_outputs, inspect_states = model_io_names(inspect_model)
+    assert (inspect_inputs, inspect_states) == (["arg0"], ["cache"])
+    inspect_state = inspect_model.make_state()
+    inspect_state.write_state(name="cache", value=np.array([1.0, 2.0], dtype=np.float32))
+    inspect_out = inspect_model.predict(
+        {"arg0": np.array([3.0, 4.0], dtype=np.float32)}, state=inspect_state
+    )
+    np.testing.assert_allclose(inspect_out[inspect_outputs[0]], [4.0, 6.0], atol=1e-3)
+    # The read-only state is unchanged
+    np.testing.assert_allclose(
+        np.asarray(inspect_state.read_state(name="cache")), [1.0, 2.0], atol=1e-3
+    )
 
 
 def test_flat_state_mapping_rejected_for_multiple_functions():
@@ -308,9 +342,9 @@ def test_state_type_mismatch():
         convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
 
 
-def test_symbolic_state_is_rejected():
-    def step(state, x):
-        return x + state, state + 1.0
+def _symbolic_step_module():
+    def step(x, cache):
+        return x + cache, cache + 1.0
 
     (n,) = symbolic_shape("n")
     exported = export(jax.jit(step))(
@@ -318,6 +352,200 @@ def test_symbolic_state_is_rejected():
         jax.ShapeDtypeStruct((n, 2), jnp.float32),
     )
     context = jax_mlir.make_ir_context()
-    hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
+    return ir.Module.parse(exported.mlir_module(), context=context)
+
+
+def test_symbolic_state_is_rejected():
     with pytest.raises(ValueError, match="static shape"):
-        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+        convert(
+            _symbolic_step_module(),
+            minimum_deployment_target=ct.target.iOS18,
+            states={1: 1},
+        )
+
+
+def test_symbolic_conversion_works_after_rejected_symbolic_state():
+    # Rejecting a state must not leave MIL Symbols behind for the earlier,
+    # non-state arguments; they are registered process wide and a later
+    # conversion would fail with "Symbol `dim_0` is used already".
+    with pytest.raises(ValueError, match="static shape"):
+        convert(
+            _symbolic_step_module(),
+            minimum_deployment_target=ct.target.iOS18,
+            states={1: 1},
+        )
+
+    mil_program = convert(_symbolic_step_module(), minimum_deployment_target=ct.target.iOS18)
+    assert len(mil_program.functions["main"].inputs) == 2
+
+
+def test_constant_state_update_loads_and_predicts():
+    # A state update that const-folds (here: resetting a cache to zeros) used
+    # to produce a model that segfaults Core ML at load time.
+    def reset(cache, x):
+        return jnp.zeros_like(cache), x + cache
+
+    inputs = (jnp.zeros((4,), dtype=jnp.float32), jnp.ones((4,), dtype=jnp.float32))
+    mil_program = convert(
+        export_hlo_module(reset, inputs),
+        minimum_deployment_target=ct.target.iOS18,
+        states={0: 0},
+    )
+    update_value = next(
+        op for op in mil_program.functions["main"].operations
+        if op.op_type == "coreml_update_state"
+    ).value
+    assert update_value.val is None, "the state update value must not be a constant"
+
+    run_and_compare_stateful(
+        reset,
+        initial_inputs=inputs,
+        states={0: 0},
+        subsequent_inputs=[
+            (jnp.array([1.0, 2.0, 3.0, 4.0], dtype=jnp.float32),),
+        ],
+    )
+
+
+def test_nonzero_constant_state_update_loads_and_predicts():
+    def reset(cache, x):
+        return jnp.full_like(cache, 2.5), x * cache
+
+    inputs = (jnp.ones((3,), dtype=jnp.float32), jnp.full((3,), 4.0, dtype=jnp.float32))
+    run_and_compare_stateful(
+        reset,
+        initial_inputs=inputs,
+        states={0: 0},
+        subsequent_inputs=[
+            (jnp.full((3,), 3.0, dtype=jnp.float32),),
+        ],
+    )
+
+
+def test_reserved_explicit_state_name_is_rejected():
+    def step(cache, x):
+        new_cache = cache + x
+        return new_cache, new_cache
+
+    hlo_module = export_hlo_module(
+        step,
+        (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32)),
+    )
+    with pytest.raises(ValueError, match="state_workaround"):
+        convert(
+            hlo_module,
+            minimum_deployment_target=ct.target.iOS18,
+            states={"main": {"cache": StateSpec(output=1, name="state")}},
+        )
+
+
+def test_pytree_state_name_is_sanitized():
+    def step(params, x):
+        return x * params["w"], params["w"] + x
+
+    spec = (
+        {"w": jax.ShapeDtypeStruct((2,), jnp.float32)},
+        jax.ShapeDtypeStruct((2,), jnp.float32),
+    )
+    exported = export(jax.jit(step))(*spec)
+    context = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
+
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"params['w']": StateSpec(output=1)}},
+    )
+    assert list(mil_program.functions["main"].inputs) == ["params__w__", "x"]
+
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+    )
+    _, _, state_names = model_io_names(cml_model)
+    assert state_names == ["params__w__"]
+
+    cml_state = cml_model.make_state()
+    cml_state.write_state(name="params__w__", value=np.array([1.0, 2.0], dtype=np.float32))
+    cml_model.predict({"x": np.array([3.0, 4.0], dtype=np.float32)}, state=cml_state)
+    np.testing.assert_allclose(
+        np.asarray(cml_state.read_state(name="params__w__")), [4.0, 6.0], atol=1e-3
+    )
+
+
+def test_single_public_function_is_exported_as_main():
+    ctx = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(
+        """
+        module {
+          func.func public @forward(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+            %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+            return %0 : tensor<2xf32>
+          }
+        }
+        """,
+        context=ctx,
+    )
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+
+    assert list(mil_program.functions) == ["main"]
+    assert mil_program.default_function_name == "main"
+    assert not mil_program.export_as_multifunction
+
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+    )
+    input_names, output_names, _ = model_io_names(cml_model)
+    assert input_names == ["arg0", "arg1"]
+    outputs = cml_model.predict({
+        "arg0": np.array([1.0, 2.0], dtype=np.float32),
+        "arg1": np.array([3.0, 4.0], dtype=np.float32),
+    })
+    np.testing.assert_allclose(outputs[output_names[0]], [4.0, 6.0], atol=1e-3)
+
+
+def test_single_public_function_with_state_is_exported_as_main():
+    ctx = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(
+        """
+        module {
+          func.func public @forward(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+            %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+            return %0, %0 : tensor<2xf32>, tensor<2xf32>
+          }
+        }
+        """,
+        context=ctx,
+    )
+    # The state mapping stays keyed by the HLO function name
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"forward": {"arg0": StateSpec(output=1, name="cache")}},
+    )
+
+    assert list(mil_program.functions) == ["main"]
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+    )
+    input_names, output_names, state_names = model_io_names(cml_model)
+    assert input_names == ["arg1"]
+    assert state_names == ["cache"]
+
+    cml_state = cml_model.make_state()
+    cml_state.write_state(name="cache", value=np.array([1.0, 2.0], dtype=np.float32))
+    outputs = cml_model.predict(
+        {"arg1": np.array([3.0, 4.0], dtype=np.float32)}, state=cml_state
+    )
+    np.testing.assert_allclose(outputs[output_names[0]], [4.0, 6.0], atol=1e-3)
+    np.testing.assert_allclose(
+        np.asarray(cml_state.read_state(name="cache")), [4.0, 6.0], atol=1e-3
+    )

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -7,6 +7,7 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export, symbolic_shape
 
+from stablehlo_coreml import StateSpec
 from stablehlo_coreml.converter import convert
 from tests.utils import export_hlo_module, run_and_compare_stateful
 
@@ -29,7 +30,7 @@ def test_accumulator_persists_across_calls():
     run_and_compare_stateful(
         _accumulator,
         initial_inputs=(initial_state, jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)),
-        states={0: 1},
+        states={"main": {"state": StateSpec(output=1)}},
         extra_nonstate_steps=[
             (jnp.array([0.5, -1.0, 2.0], dtype=jnp.float32),),
             (jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32),),
@@ -105,9 +106,149 @@ def test_state_by_argument_name():
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     hlo_module = export_hlo_module(step, inputs)
     mil_by_index = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
-    # `%arg0` is also accepted without the leading `%`.
-    mil_by_name = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={"arg0": 1})
+    mil_by_name = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=1)}},
+    )
     assert _instruction_types(mil_by_index) == _instruction_types(mil_by_name)
+    assert list(mil_by_name.functions["main"].inputs) == ["state", "x"]
+
+
+def test_read_only_state():
+    def inspect(state, x):
+        return state + x
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(inspect, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=None)}},
+    )
+
+    op_types = _instruction_types(mil_program)
+    assert "read_state" in op_types
+    assert "coreml_update_state" not in op_types
+    assert len(mil_program.functions["main"].outputs) == 1
+
+
+def test_state_name_override():
+    def step(state, x):
+        new_state = state + x
+        return new_state, new_state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(step, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=1, name="accumulator")}},
+    )
+
+    assert list(mil_program.functions["main"].inputs) == ["accumulator", "x"]
+
+
+def test_state_name_override_takes_precedence_over_jax_argument_name():
+    def inspect(cache, state):
+        return cache + state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(inspect, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=None, name="cache")}},
+    )
+
+    assert list(mil_program.functions["main"].inputs) == ["arg0", "cache"]
+
+
+@pytest.mark.parametrize("output", ["cache", "result['cache']"])
+def test_state_output_by_jax_result_name(output):
+    def step(state, x):
+        new_state = state + x
+        return {"prediction": new_state * x, "cache": new_state}
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    named_program = convert(
+        export_hlo_module(step, inputs),
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=output)}},
+    )
+    indexed_program = convert(
+        export_hlo_module(step, inputs),
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=0)}},
+    )
+
+    assert _instruction_types(named_program) == _instruction_types(indexed_program)
+    assert len(named_program.functions["main"].outputs) == 1
+
+
+def test_function_scoped_states_export_as_multifunction():
+    ctx = jax_mlir.make_ir_context()
+    mlir_text = """
+    module {
+      func.func public @update(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0, %0 : tensor<2xf32>, tensor<2xf32>
+      }
+      func.func public @inspect(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+    }
+    """
+    hlo_module = ir.Module.parse(mlir_text, context=ctx)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={
+            "update": {"arg0": StateSpec(output=1, name="cache")},
+            "inspect": {"arg1": StateSpec(output=None, name="cache")},
+        },
+    )
+
+    assert mil_program.export_as_multifunction
+    assert mil_program.default_function_name == "update"
+    assert "coreml_update_state" in [
+        op.op_type for op in mil_program.functions["update"].operations
+    ]
+    assert "coreml_update_state" not in [
+        op.op_type for op in mil_program.functions["inspect"].operations
+    ]
+
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        skip_model_load=True,
+    )
+    descriptions = {desc.name: desc for desc in cml_model.get_spec().description.functions}
+    assert set(descriptions) == {"update", "inspect"}
+    assert [state.name for state in descriptions["update"].state] == ["cache"]
+    assert [state.name for state in descriptions["inspect"].state] == ["cache"]
+
+
+def test_flat_state_mapping_rejected_for_multiple_functions():
+    ctx = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(
+        """
+        module {
+          func.func public @first(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+            return %arg0 : tensor<2xf32>
+          }
+          func.func public @second(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+            return %arg0 : tensor<2xf32>
+          }
+        }
+        """,
+        context=ctx,
+    )
+
+    with pytest.raises(ValueError, match="flat state mapping"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 0})
 
 
 def test_unknown_state_name():

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -31,7 +31,7 @@ def test_accumulator_persists_across_calls():
         _accumulator,
         initial_inputs=(initial_state, jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)),
         states={"main": {"state": StateSpec(output=1)}},
-        extra_nonstate_steps=[
+        subsequent_inputs=[
             (jnp.array([0.5, -1.0, 2.0], dtype=jnp.float32),),
             (jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32),),
         ],
@@ -71,7 +71,7 @@ def test_multiple_states():
         step,
         initial_inputs=(zeros, zeros + 1.0, x0),
         states={0: 1, 1: 2},
-        extra_nonstate_steps=[
+        subsequent_inputs=[
             (jnp.full((2, 3), 0.5, dtype=jnp.float32),),
         ],
     )
@@ -86,13 +86,15 @@ def test_state_only_output():
     mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 0})
     mil_func = next(iter(mil_program.functions.values()))
     assert len(mil_func.outputs) == 1
-    assert mil_func.outputs[0].dtype == types.fp32
+    assert mil_func.outputs[0].name == "state_update_token"
+    assert mil_func.outputs[0].shape == (1,)
+    assert mil_func.outputs[0].dtype == types.fp16
 
     run_and_compare_stateful(
         add_into,
         initial_inputs=inputs,
         states={0: 0},
-        extra_nonstate_steps=[
+        subsequent_inputs=[
             (jnp.ones((4,), dtype=jnp.float32),),
         ],
     )

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -2,6 +2,7 @@ import coremltools as ct
 import jax
 import jax.numpy as jnp
 import pytest
+from coremltools.converters.mil.mil import types
 from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export, symbolic_shape
@@ -79,9 +80,16 @@ def test_state_only_output():
     def add_into(state, x):
         return state + x
 
+    inputs = (jnp.zeros((4,), dtype=jnp.float32), jnp.arange(4, dtype=jnp.float32))
+    hlo_module = export_hlo_module(add_into, inputs)
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 0})
+    mil_func = next(iter(mil_program.functions.values()))
+    assert len(mil_func.outputs) == 1
+    assert mil_func.outputs[0].dtype == types.fp32
+
     run_and_compare_stateful(
         add_into,
-        initial_inputs=(jnp.zeros((4,), dtype=jnp.float32), jnp.arange(4, dtype=jnp.float32)),
+        initial_inputs=inputs,
         states={0: 0},
         extra_nonstate_steps=[
             (jnp.ones((4,), dtype=jnp.float32),),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -396,8 +396,7 @@ def run_and_compare_stateful(
         compute_units=compute_units,
     )
 
-    # A JAX export has exactly one public function, which we always convert
-    # into the Core ML "main" function.
+    # A JAX export has exactly one public function, "main".
     hlo_func = next(
         func
         for func in hlo_module.body

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,8 @@ from jax.export import export as _jax_export
 
 from stablehlo_coreml import DEFAULT_HLO_PIPELINE
 from stablehlo_coreml.converter import convert
-from stablehlo_coreml.state import resolve_state_map
+from stablehlo_coreml.function_interface import sanitize_name
+from stablehlo_coreml.state import preferred_argument_name, resolve_state_map
 
 
 def jax_export(jax_func, input_spec):
@@ -173,6 +174,35 @@ def _convert_hlo_module(
     return mil_program, cml_model
 
 
+def model_io_names(cml_model):
+    """Return the ``(input, output, state)`` feature names of ``cml_model``.
+
+    ``input_description``/``output_description`` are empty for multifunction
+    models, whose features live under ``description.functions`` instead.
+    """
+    description = cml_model._spec.description
+    if description.functions:
+        function_name = cml_model.function_name or description.defaultFunctionName
+        description = next(
+            function for function in description.functions if function.name == function_name
+        )
+    return (
+        [feature.name for feature in description.input],
+        [feature.name for feature in description.output],
+        [feature.name for feature in description.state],
+    )
+
+
+def model_for_function(cml_model, function_name, compute_units=ct.ComputeUnit.CPU_ONLY):
+    """Load a single function of a multifunction Core ML model."""
+    return ct.models.MLModel(
+        cml_model.get_spec(),
+        weights_dir=cml_model.weights_dir,
+        function_name=function_name,
+        compute_units=compute_units,
+    )
+
+
 def _compare_model_outputs(
     cml_model,
     inputs,
@@ -181,23 +211,41 @@ def _compare_model_outputs(
     atol,
     rtol,
     state=None,
+    expects_no_outputs=False,
 ):
     """Predict with ``inputs`` and compare the results to ``expected_outputs``.
 
     Inputs and expected outputs are matched positionally against the model
     input/output descriptions. Only the outputs covered by ``expected_outputs``
     are compared, so any extra model output (such as ``state_update_token``) is
-    ignored.
+    ignored. ``expects_no_outputs`` marks the state-only case, where the model
+    has no tensor output beyond that token.
     """
+    input_names, output_names, _ = model_io_names(cml_model)
+    flat_inputs = flatten(inputs)
+    flat_expected = flatten(_as_tuple(expected_outputs))
+
+    # Core ML prunes inputs that the program never reads, so the model may take
+    # fewer inputs than we have values for, but never more.
+    assert len(input_names) <= len(flat_inputs), (
+        f"Model takes inputs {input_names}, but only {len(flat_inputs)} input values were given"
+    )
+    assert len(output_names) >= len(flat_expected), (
+        f"Model produces outputs {output_names}, but {len(flat_expected)} outputs were expected"
+    )
+
     cml_input_key_values = {
         input_name: _as_numpy(input_value)
-        for input_name, input_value in zip(cml_model.input_description, flatten(inputs))
+        for input_name, input_value in zip(input_names, flat_inputs)
     }
     cml_expected_outputs = {
         output_name: np.asarray(output_value)
-        for output_name, output_value
-        in zip(cml_model.output_description, flatten(_as_tuple(expected_outputs)))
+        for output_name, output_value in zip(output_names, flat_expected)
     }
+    assert cml_expected_outputs or expects_no_outputs, (
+        "No model output was compared. Model outputs: "
+        f"{output_names}, expected outputs: {flat_expected}"
+    )
 
     compare_backend(
         cml_model,
@@ -341,34 +389,50 @@ def run_and_compare_stateful(
     """
     jax_func = jax.jit(jax_func)
     hlo_module = export_hlo_module(jax_func, initial_inputs)
-    mil_program, cml_model = _convert_hlo_module(
+    _, cml_model = _convert_hlo_module(
         hlo_module,
         states=states,
         max_complexity=max_complexity,
         compute_units=compute_units,
     )
 
-    mil_func_name = mil_program.default_function_name
+    # A JAX export has exactly one public function, which we always convert
+    # into the Core ML "main" function.
+    hlo_func = next(
+        func
+        for func in hlo_module.body
+        if func.sym_visibility is None or func.sym_visibility.value == "public"
+    )
     function_states = states
     if states and all(isinstance(value, Mapping) for value in states.values()):
-        function_states = states[mil_func_name]
+        function_states = states[hlo_func.name.value]
 
-    # Map argument index -> index of the output holding the updated state
-    hlo_func = next(func for func in hlo_module.body if func.name.value == mil_func_name)
+    # Map argument index -> index of the output holding the updated state, and
+    # to the state name the caller expects the model to expose it under.
     resolved_states = {}
+    state_names = {}
     for in_idx, state_spec in resolve_state_map(hlo_func, function_states).items():
         if state_spec.output is None:
             raise ValueError("run_and_compare_stateful requires updated, not read-only, states")
         resolved_states[in_idx] = state_spec.output
+        state_names[in_idx] = state_spec.name or sanitize_name(
+            preferred_argument_name(hlo_func.arguments[in_idx])
+        )
 
     nonstate_indices = [i for i in range(len(initial_inputs)) if i not in resolved_states]
-    state_indices = [i for i in range(len(initial_inputs)) if i in resolved_states]
     state_outputs = set(resolved_states.values())
-    state_names = [feature.name for feature in cml_model._spec.description.state]
+    # Functions whose every result feeds a state only expose a state token
+    expects_no_outputs = len(state_outputs) == len(hlo_func.type.results)
+
+    _, _, model_state_names = model_io_names(cml_model)
+    assert set(model_state_names) == set(state_names.values()), (
+        f"Model exposes states {sorted(model_state_names)}, "
+        f"expected {sorted(state_names.values())}"
+    )
 
     cml_state = cml_model.make_state()
-    for name, idx in zip(state_names, state_indices):
-        cml_state.write_state(name=name, value=_as_numpy(initial_inputs[idx]))
+    for in_idx, name in state_names.items():
+        cml_state.write_state(name=name, value=_as_numpy(initial_inputs[in_idx]))
 
     def run_step(args):
         expected = _as_tuple(jax_func(*args))
@@ -383,9 +447,10 @@ def run_and_compare_stateful(
             atol=atol,
             rtol=rtol,
             state=cml_state,
+            expects_no_outputs=expects_no_outputs,
         )
 
-        for name, in_idx in zip(state_names, state_indices):
+        for in_idx, name in state_names.items():
             np.testing.assert_allclose(
                 np.asarray(cml_state.read_state(name=name)),
                 np.asarray(expected[resolved_states[in_idx]]),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,9 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export as _jax_export
 
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE
 from stablehlo_coreml.converter import convert
+from stablehlo_coreml.state import resolve_state_map
 
 
 def jax_export(jax_func, input_spec):
@@ -133,6 +134,81 @@ def _convert_mil_to_coreml(
     return ct.convert(mil_program, **convert_kwargs)
 
 
+def _as_tuple(value):
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return (value,)
+
+
+def _as_numpy(value):
+    """Detach JAX arrays into a Core ML-friendly contiguous ndarray."""
+    return np.array(value, copy=True)
+
+
+def _convert_hlo_module(
+    hlo_module,
+    *,
+    states=None,
+    max_complexity: int = 10_000,
+    compute_units=ct.ComputeUnit.CPU_ONLY,
+    ct_inputs=None,
+):
+    """Convert a StableHLO module to ``(mil_program, cml_model)``.
+
+    ``states`` is forwarded to :func:`convert`. ``ct_inputs`` is
+    either a list of ``ct.TensorType``s, or a callable that builds one from the
+    converted MIL program.
+    """
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states=states)
+
+    if callable(ct_inputs):
+        ct_inputs = ct_inputs(mil_program)
+
+    cml_model = _convert_mil_to_coreml(
+        mil_program,
+        max_complexity=max_complexity,
+        compute_units=compute_units,
+        ct_inputs=ct_inputs,
+    )
+    return mil_program, cml_model
+
+
+def _compare_model_outputs(
+    cml_model,
+    inputs,
+    expected_outputs,
+    *,
+    atol,
+    rtol,
+    state=None,
+):
+    """Predict with ``inputs`` and compare the results to ``expected_outputs``.
+
+    Inputs and expected outputs are matched positionally against the model
+    input/output descriptions. Only the outputs covered by ``expected_outputs``
+    are compared, so any extra model output (such as ``state_update_token``) is
+    ignored.
+    """
+    cml_input_key_values = {
+        input_name: _as_numpy(input_value)
+        for input_name, input_value in zip(cml_model.input_description, flatten(inputs))
+    }
+    cml_expected_outputs = {
+        output_name: np.asarray(output_value)
+        for output_name, output_value
+        in zip(cml_model.output_description, flatten(_as_tuple(expected_outputs)))
+    }
+
+    compare_backend(
+        cml_model,
+        cml_input_key_values,
+        cml_expected_outputs,
+        atol=atol,
+        rtol=rtol,
+        state=state,
+    )
+
+
 def run_and_compare_hlo_module(
     hlo_module,
     inputs,
@@ -143,29 +219,13 @@ def run_and_compare_hlo_module(
     rtol=1e-05,
     compute_units=ct.ComputeUnit.CPU_ONLY,
 ):
-    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
-
-    cml_model = _convert_mil_to_coreml(
-        mil_program,
+    _, cml_model = _convert_hlo_module(
+        hlo_module,
         max_complexity=max_complexity,
         compute_units=compute_units,
     )
 
-    # Generate random inputs that matches cml_model input spec
-    cml_input_key_values = {}
-    for input_name, input_value in zip(cml_model.input_description, flatten(inputs)):
-        cml_input_key_values[input_name] = input_value
-
-    # TODO(knielsen): Is there a nicer way of doing this?
-    if not isinstance(expected_outputs, (list, tuple)):
-        expected_outputs = (expected_outputs, )
-
-    # Prepare the output for comparison
-    cml_expected_outputs = {}
-    for output_name, output_value in zip(cml_model.output_description, flatten(expected_outputs)):
-        cml_expected_outputs[output_name] = np.asarray(output_value)
-
-    compare_backend(cml_model, cml_input_key_values, cml_expected_outputs, atol=atol, rtol=rtol)
+    _compare_model_outputs(cml_model, inputs, expected_outputs, atol=atol, rtol=rtol)
 
     return cml_model
 
@@ -262,22 +322,11 @@ def export_hlo_module(jax_func, inputs):
     return ir.Module.parse(exported.mlir_module(), context=context)
 
 
-def _as_numpy(value):
-    """Detach JAX arrays into a Core ML-friendly contiguous ndarray."""
-    return np.array(value, copy=True)
-
-
-def _as_output_tuple(value):
-    if isinstance(value, (list, tuple)):
-        return tuple(value)
-    return (value,)
-
-
 def run_and_compare_stateful(
     jax_func,
     initial_inputs,
     states,
-    extra_nonstate_steps=(),
+    subsequent_inputs=(),
     *,
     max_complexity: int = 10_000,
     atol=1e-04,
@@ -287,15 +336,16 @@ def run_and_compare_stateful(
     """Convert ``jax_func`` with ``states`` and compare multi-step predictions.
 
     ``states`` is either a single-function state mapping or a function-scoped
-    mapping. ``extra_nonstate_steps`` are tuples of the remaining (non-state)
-    positional arguments for subsequent calls.
+    mapping. ``subsequent_inputs`` are tuples of the remaining (non-state)
+    positional arguments for each subsequent call.
     """
     jax_func = jax.jit(jax_func)
     hlo_module = export_hlo_module(jax_func, initial_inputs)
-    mil_program = convert(
+    mil_program, cml_model = _convert_hlo_module(
         hlo_module,
-        minimum_deployment_target=ct.target.iOS18,
         states=states,
+        max_complexity=max_complexity,
+        compute_units=compute_units,
     )
 
     mil_func_name = mil_program.default_function_name
@@ -303,32 +353,17 @@ def run_and_compare_stateful(
     if states and all(isinstance(value, Mapping) for value in states.values()):
         function_states = states[mil_func_name]
 
+    # Map argument index -> index of the output holding the updated state
+    hlo_func = next(func for func in hlo_module.body if func.name.value == mil_func_name)
     resolved_states = {}
-    for key, state_spec in function_states.items():
-        out_idx = state_spec.output if isinstance(state_spec, StateSpec) else state_spec
-        if out_idx is None:
+    for in_idx, state_spec in resolve_state_map(hlo_func, function_states).items():
+        if state_spec.output is None:
             raise ValueError("run_and_compare_stateful requires updated, not read-only, states")
-        if isinstance(key, int):
-            resolved_states[key] = out_idx
-        else:
-            mil_func = mil_program.functions[mil_func_name]
-            for i, name in enumerate(mil_func.inputs):
-                aliases = {name, name.lstrip("%")}
-                if key in aliases:
-                    resolved_states[i] = out_idx
-                    break
-            else:
-                raise ValueError(f"Could not resolve state input {key!r}")
-
-    cml_model = _convert_mil_to_coreml(
-        mil_program,
-        max_complexity=max_complexity,
-        compute_units=compute_units,
-    )
+        resolved_states[in_idx] = state_spec.output
 
     nonstate_indices = [i for i in range(len(initial_inputs)) if i not in resolved_states]
     state_indices = [i for i in range(len(initial_inputs)) if i in resolved_states]
-    tensor_names = list(cml_model.input_description)
+    state_outputs = set(resolved_states.values())
     state_names = [feature.name for feature in cml_model._spec.description.state]
 
     cml_state = cml_model.make_state()
@@ -336,27 +371,19 @@ def run_and_compare_stateful(
         cml_state.write_state(name=name, value=_as_numpy(initial_inputs[idx]))
 
     def run_step(args):
-        expected = _as_output_tuple(jax_func(*args))
-        cml_inputs = {
-            name: _as_numpy(args[idx])
-            for name, idx in zip(tensor_names, nonstate_indices)
-        }
-        cml_outputs = cml_model.predict(cml_inputs, state=cml_state) if cml_inputs else cml_model.predict({}, state=cml_state)
-
+        expected = _as_tuple(jax_func(*args))
+        # Outputs that update state are not exposed by the Core ML model
         expected_tensor_outputs = [
-            expected[i] for i in range(len(expected)) if i not in resolved_states.values()
+            value for i, value in enumerate(expected) if i not in state_outputs
         ]
-        output_names = list(cml_model.output_description)
-        # If every HLO result is a state update, Core ML still keeps those
-        # values as outputs; ignore the extras when comparing tensors.
-        assert len(output_names) >= len(expected_tensor_outputs)
-        for name, value in zip(output_names, expected_tensor_outputs):
-            np.testing.assert_allclose(
-                np.asarray(cml_outputs[name]),
-                np.asarray(value),
-                atol=atol,
-                rtol=rtol,
-            )
+        _compare_model_outputs(
+            cml_model,
+            [args[idx] for idx in nonstate_indices],
+            expected_tensor_outputs,
+            atol=atol,
+            rtol=rtol,
+            state=cml_state,
+        )
 
         for name, in_idx in zip(state_names, state_indices):
             np.testing.assert_allclose(
@@ -368,14 +395,14 @@ def run_and_compare_stateful(
         return expected
 
     outputs = run_step(initial_inputs)
-    for extra in extra_nonstate_steps:
+    for next_nonstate_inputs in subsequent_inputs:
         next_args = [None] * len(initial_inputs)
-        extra_iter = iter(extra)
+        nonstate_iter = iter(next_nonstate_inputs)
         for i in range(len(initial_inputs)):
             if i in resolved_states:
                 next_args[i] = outputs[resolved_states[i]]
             else:
-                next_args[i] = next(extra_iter)
+                next_args[i] = next(nonstate_iter)
         outputs = run_step(next_args)
 
     return cml_model
@@ -412,50 +439,36 @@ def run_and_compare_symbolic(
     context = jax_mlir.make_ir_context()
     hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
 
-    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+    def build_ct_inputs(mil_program):
+        # Build ct.TensorType inputs with RangeDim for symbolic dimensions
+        ct_inputs = []
+        for func in mil_program.functions.values():
+            for inp_name, inp in func.inputs.items():
+                ct_shape = []
+                for dim in inp.shape:
+                    if isinstance(dim, Symbol):
+                        ct_shape.append(ct.RangeDim(1, range_dim_max, default=1))
+                    else:
+                        ct_shape.append(int(dim))
+                ct_inputs.append(ct.TensorType(name=inp_name, shape=ct_shape))
+            break  # only first (main) function
+        return ct_inputs
 
-    # Build ct.TensorType inputs with RangeDim for symbolic dimensions
-    ct_inputs = []
-    for func in mil_program.functions.values():
-        for inp_name, inp in func.inputs.items():
-            ct_shape = []
-            for dim in inp.shape:
-                if isinstance(dim, Symbol):
-                    ct_shape.append(ct.RangeDim(1, range_dim_max, default=1))
-                else:
-                    ct_shape.append(int(dim))
-            ct_inputs.append(ct.TensorType(name=inp_name, shape=ct_shape))
-        break  # only first (main) function
-
-    cml_model = _convert_mil_to_coreml(
-        mil_program,
+    _, cml_model = _convert_hlo_module(
+        hlo_module,
         max_complexity=max_complexity,
         compute_units=compute_units,
-        ct_inputs=ct_inputs,
+        ct_inputs=build_ct_inputs,
     )
 
-    input_names = list(cml_model.input_description)
-    output_names = list(cml_model.output_description)
-
     for concrete_inputs in test_shapes:
-        if not isinstance(concrete_inputs, (list, tuple)):
-            concrete_inputs = (concrete_inputs,)
-
-        expected_output = jax_func(*concrete_inputs)
-        if not isinstance(expected_output, (list, tuple)):
-            expected_output = (expected_output,)
-
-        cml_input_dict = {}
-        for name, val in zip(input_names, flatten(concrete_inputs)):
-            cml_input_dict[name] = np.asarray(val)
-
-        cml_expected = {}
-        for name, val in zip(output_names, flatten(expected_output)):
-            cml_expected[name] = np.asarray(val)
-
-        compare_backend(
-            cml_model, cml_input_dict, cml_expected,
-            atol=atol, rtol=rtol,
+        concrete_inputs = _as_tuple(concrete_inputs)
+        _compare_model_outputs(
+            cml_model,
+            concrete_inputs,
+            jax_func(*concrete_inputs),
+            atol=atol,
+            rtol=rtol,
         )
 
     return cml_model

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -253,6 +253,124 @@ def get_model_instruction_types(cml_model) -> list[str]:
     return all_ops
 
 
+def export_hlo_module(jax_func, inputs):
+    """Export ``jax_func`` traced at ``inputs`` to a parsed StableHLO module."""
+    jax_func = jax.jit(jax_func)
+    exported = jax_export(jax_func, inputs)
+    context = jax_mlir.make_ir_context()
+    return ir.Module.parse(exported.mlir_module(), context=context)
+
+
+def _as_numpy(value):
+    """Detach JAX arrays into a Core ML-friendly contiguous ndarray."""
+    return np.array(value, copy=True)
+
+
+def _as_output_tuple(value):
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return (value,)
+
+
+def run_and_compare_stateful(
+    jax_func,
+    initial_inputs,
+    states,
+    extra_nonstate_steps=(),
+    *,
+    max_complexity: int = 10_000,
+    atol=1e-04,
+    rtol=1e-05,
+    compute_units=ct.ComputeUnit.CPU_ONLY,
+):
+    """Convert ``jax_func`` with ``states`` and compare multi-step predictions.
+
+    ``states`` maps input indices (or names) to the output index that holds
+    the updated state. ``extra_nonstate_steps`` are tuples of the remaining
+    (non-state) positional arguments for subsequent calls.
+    """
+    jax_func = jax.jit(jax_func)
+    hlo_module = export_hlo_module(jax_func, initial_inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states=states,
+    )
+    cml_model = _convert_mil_to_coreml(
+        mil_program,
+        max_complexity=max_complexity,
+        compute_units=compute_units,
+    )
+
+    resolved_states = {}
+    for key, out_idx in states.items():
+        if isinstance(key, int):
+            resolved_states[key] = out_idx
+        else:
+            mil_func = next(iter(mil_program.functions.values()))
+            for i, name in enumerate(mil_func.inputs):
+                aliases = {name, name.lstrip("%")}
+                if key in aliases:
+                    resolved_states[i] = out_idx
+                    break
+            else:
+                raise ValueError(f"Could not resolve state input {key!r}")
+
+    nonstate_indices = [i for i in range(len(initial_inputs)) if i not in resolved_states]
+    state_indices = [i for i in range(len(initial_inputs)) if i in resolved_states]
+    tensor_names = list(cml_model.input_description)
+    state_names = [feature.name for feature in cml_model._spec.description.state]
+
+    cml_state = cml_model.make_state()
+    for name, idx in zip(state_names, state_indices):
+        cml_state.write_state(name=name, value=_as_numpy(initial_inputs[idx]))
+
+    def run_step(args):
+        expected = _as_output_tuple(jax_func(*args))
+        cml_inputs = {
+            name: _as_numpy(args[idx])
+            for name, idx in zip(tensor_names, nonstate_indices)
+        }
+        cml_outputs = cml_model.predict(cml_inputs, state=cml_state) if cml_inputs else cml_model.predict({}, state=cml_state)
+
+        expected_tensor_outputs = [
+            expected[i] for i in range(len(expected)) if i not in resolved_states.values()
+        ]
+        output_names = list(cml_model.output_description)
+        # If every HLO result is a state update, Core ML still keeps those
+        # values as outputs; ignore the extras when comparing tensors.
+        assert len(output_names) >= len(expected_tensor_outputs)
+        for name, value in zip(output_names, expected_tensor_outputs):
+            np.testing.assert_allclose(
+                np.asarray(cml_outputs[name]),
+                np.asarray(value),
+                atol=atol,
+                rtol=rtol,
+            )
+
+        for name, in_idx in zip(state_names, state_indices):
+            np.testing.assert_allclose(
+                np.asarray(cml_state.read_state(name=name)),
+                np.asarray(expected[resolved_states[in_idx]]),
+                atol=atol,
+                rtol=rtol,
+            )
+        return expected
+
+    outputs = run_step(initial_inputs)
+    for extra in extra_nonstate_steps:
+        next_args = [None] * len(initial_inputs)
+        extra_iter = iter(extra)
+        for i in range(len(initial_inputs)):
+            if i in resolved_states:
+                next_args[i] = outputs[resolved_states[i]]
+            else:
+                next_args[i] = next(extra_iter)
+        outputs = run_step(next_args)
+
+    return cml_model
+
+
 def run_and_compare_symbolic(
     jax_func,
     symbolic_input_specs,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Mapping
 
 import coremltools as ct
 import jax
@@ -10,7 +11,7 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export as _jax_export
 
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec
 from stablehlo_coreml.converter import convert
 
 
@@ -285,9 +286,9 @@ def run_and_compare_stateful(
 ):
     """Convert ``jax_func`` with ``states`` and compare multi-step predictions.
 
-    ``states`` maps input indices (or names) to the output index that holds
-    the updated state. ``extra_nonstate_steps`` are tuples of the remaining
-    (non-state) positional arguments for subsequent calls.
+    ``states`` is either a single-function state mapping or a function-scoped
+    mapping. ``extra_nonstate_steps`` are tuples of the remaining (non-state)
+    positional arguments for subsequent calls.
     """
     jax_func = jax.jit(jax_func)
     hlo_module = export_hlo_module(jax_func, initial_inputs)
@@ -296,18 +297,21 @@ def run_and_compare_stateful(
         minimum_deployment_target=ct.target.iOS18,
         states=states,
     )
-    cml_model = _convert_mil_to_coreml(
-        mil_program,
-        max_complexity=max_complexity,
-        compute_units=compute_units,
-    )
+
+    mil_func_name = mil_program.default_function_name
+    function_states = states
+    if states and all(isinstance(value, Mapping) for value in states.values()):
+        function_states = states[mil_func_name]
 
     resolved_states = {}
-    for key, out_idx in states.items():
+    for key, state_spec in function_states.items():
+        out_idx = state_spec.output if isinstance(state_spec, StateSpec) else state_spec
+        if out_idx is None:
+            raise ValueError("run_and_compare_stateful requires updated, not read-only, states")
         if isinstance(key, int):
             resolved_states[key] = out_idx
         else:
-            mil_func = next(iter(mil_program.functions.values()))
+            mil_func = mil_program.functions[mil_func_name]
             for i, name in enumerate(mil_func.inputs):
                 aliases = {name, name.lstrip("%")}
                 if key in aliases:
@@ -315,6 +319,12 @@ def run_and_compare_stateful(
                     break
             else:
                 raise ValueError(f"Could not resolve state input {key!r}")
+
+    cml_model = _convert_mil_to_coreml(
+        mil_program,
+        max_complexity=max_complexity,
+        compute_units=compute_units,
+    )
 
     nonstate_indices = [i for i in range(len(initial_inputs)) if i not in resolved_states]
     state_indices = [i for i in range(len(initial_inputs)) if i in resolved_states]


### PR DESCRIPTION
## Summary

Implements [#75](https://github.com/kasper0406/stablehlo-coreml/issues/75) without JAX buffer donation.

`convert(..., states={input: output_idx})` marks selected StableHLO arguments as Core ML state:

- `mb.state_tensor_placeholder` + `read_state` at function entry
- `coreml_update_state` from the mapped output, which is then dropped from regular I/O
- fp32 state is stored as fp16 (Core ML only serializes fp16 state) and cast around the read/write
- if every result is a state update, the updated values are kept as outputs because Core ML requires at least one

Keys may be input indices or argument names (`arg0`, `%arg0`, or an MLIR loc name). State must have a static floating-point shape.

Donation/`tf.aliasing_output` is intentionally not used: it is a memory hint and can alias the wrong output when several results share a shape.

## Test plan

- [x] `hatch run lint:check`
- [x] `hatch run +py=3.12 test:pytest tests/test_stateful.py` (11 passed)
- Multi-step accumulator, two caches, state-only result, and invalid-map coverage