### PR TITLE
Upgrade torchax so PyTorch 2.13 can import in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,13 +69,13 @@ parallel = true
 
 extra-dependencies = [
     "pytest",
-    # torchax 0.0.13 still references named-tensor Dimname overloads
-    # (aten.prod.dim_Dimname) that PyTorch 2.13 removed. torchvision 0.28
-    # requires torch==2.13.0, so keep both below that pair until a stable
-    # torchax release drops Dimname (google/torchax#102 is only on nightlies).
-    "torch>=2.12.0,<2.13",
-    "torchvision>=0.27.0,<0.28",
-    "torchax",
+    "torch>=2.12.0",
+    "torchvision",
+    # torchax 0.0.13 imports removed PyTorch 2.13 named-tensor overloads
+    # (aten.prod.dim_Dimname) at module import. google/torchax#102 is on
+    # 0.0.14.dev* nightlies (no stable 0.0.14 yet). Pin the post-fix nightly
+    # exactly so hatch/pip will install the pre-release without --pre.
+    "torchax==0.0.14.dev20260814",
     "flax", # torchax wants flax to be installed
     "transformers>=5.12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,12 @@ parallel = true
 
 extra-dependencies = [
     "pytest",
-    "torch>=2.12.0",
-    "torchvision",
+    # torchax 0.0.13 still references named-tensor Dimname overloads
+    # (aten.prod.dim_Dimname) that PyTorch 2.13 removed. torchvision 0.28
+    # requires torch==2.13.0, so keep both below that pair until a stable
+    # torchax release drops Dimname (google/torchax#102 is only on nightlies).
+    "torch>=2.12.0,<2.13",
+    "torchvision>=0.27.0,<0.28",
     "torchax",
     "flax", # torchax wants flax to be installed
     "transformers>=5.12.0",


### PR DESCRIPTION
## Summary

`test-pytorch` jobs fail at collection, not during conversion:

```
torchax/amp.py:118: torch.ops.aten.prod.dim_Dimname
AttributeError: The underlying op of 'aten.prod' has no overload name 'dim_Dimname'
```

That is the only failure. Collection never reaches the 15 pytorch tests.

**Root cause:** PyTorch 2.13 removed named-tensor Dimname overloads. Unpinned `torch>=2.12.0` + unpinned `torchvision` resolve to torch 2.13.0 / torchvision 0.28.0. Stable torchax 0.0.13 still indexes `aten.prod.dim_Dimname` at import time.

**Fix:** keep current torch/torchvision and pin torchax to the post-fix PyPI nightly `0.0.14.dev20260814` (google/torchax#102, merged 2026-08-07). There is still no stable 0.0.14. An exact pre-release pin is required so hatch/pip will install it without `--pre`.

This replaces the earlier torch&lt;2.13 cap on this branch.

## Test plan

- [x] `hatch run +py=3.12 test-pytorch:python -c "import torch; import torchax; print(torch.__version__)"` → torch 2.13.0, torchax 0.0.14.dev20260814
- [x] `hatch run +py=3.12 test-pytorch:pytest tests/pytorch/test_pytorch.py` → 15 passed
- [x] `hatch run lint:check`
- [ ] CI `test-pytorch` jobs on this PR