### PR TITLE
Add MIL graph optimization passes (SDPA, softmax, GELU, softcap, tiles) and build_pass_pipeline()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,29 +113,18 @@ See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 
 ## Graph optimization passes
 
-`build_pass_pipeline()` extends coremltools' default pipeline with a set of MIL graph
-passes that clean up and fuse the patterns the StableHLO lowering produces:
-
-| Pass | What it does |
-|------|--------------|
-| `remove_broadcast_tiles` | Drops the `tile` ops that StableHLO's explicit broadcasting produces when the consumer broadcasts natively (also keeps scalar constants from being materialised at full size). |
-| `fuse_reduce_keep_dims` | Folds `reduce_*(keep_dims=False) → reshape` into `reduce_*(keep_dims=True)`, unlocking coremltools' own `reduce_mean` fusions. |
-| `remove_noop_slice_update` | Removes full-tensor `slice_update`s. |
-| `replace_decomposed_softmax` | Replaces JAX's decomposed softmax (`reduce_max → sub → exp → reduce_sum → real_div`) with MIL `softmax`. |
-| `fuse_attention_to_sdpa` | Fuses `matmul → [scale] → [mask] → softmax → matmul` into `scaled_dot_product_attention` (bool/additive/constant masks, GQA layouts, explicit or Gemma-style scaling, and PyTorch's `_safe_softmax` wrapper). |
-| `fuse_logit_softcap` | Fuses `tanh(x / cap) * cap` into `scaled_tanh`. |
-| `fuse_gelu_erfc` | Fuses the `erfc`-based exact GELU emitted by `jax.nn.gelu(approximate=False)` into MIL `gelu` (`chlo.erf`/`chlo.erfc` are mapped to MIL `erf` by the converter). |
-
-Passes are registered under the `common::` namespace and can be removed or configured
-like any coremltools pass, e.g.
+`build_pass_pipeline()` extends coremltools' default pipeline with a set of graph passes
+that clean up and fuse the patterns produced by the StableHLO lowering — for example
+attention blocks become a single `scaled_dot_product_attention` op, decomposed softmax /
+GELU / logit soft-capping become their native Core ML ops, and redundant broadcasts are
+removed. The passes live in `stablehlo_coreml/passes/` and are registered under the
+`common::` namespace, so they can be removed or configured like any coremltools pass:
 
 ```python
 pipeline = build_pass_pipeline()
 pipeline.remove_passes(["common::fuse_attention_to_sdpa"])
-# A `select` fill of exactly -inf always becomes a boolean SDPA mask. Use one for
-# finite fill values as well (-1e9, `torch.finfo(dtype).min`) -- cheaper, but a
-# fully masked row becomes NaN instead of the uniform distribution the original
-# graph produced:
+# Use a boolean SDPA mask even for finite mask fill values such as -1e9 (cheaper, but a
+# fully masked row becomes NaN instead of a uniform distribution):
 pipeline.set_options("common::fuse_attention_to_sdpa", {"finite_fill_mask": "bool"})
 ```
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ cml_model = ct.convert(
     mil_program,
     source="milinternal",
     minimum_deployment_target=ct.target.iOS18,
-    pass_pipeline=DEFAULT_HLO_PIPELINE,
+    pass_pipeline=build_pass_pipeline(),
     inputs=[
         ct.TensorType(name="arg0", shape=(ct.RangeDim(1, 2048, 1), 4)),
         ct.TensorType(name="arg1", shape=(4, 3)),

--- a/README.md
+++ b/README.md
@@ -111,23 +111,6 @@ them are dropped.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 
-## Graph optimization passes
-
-`build_pass_pipeline()` extends coremltools' default pipeline with a set of graph passes
-that clean up and fuse the patterns produced by the StableHLO lowering — for example
-attention blocks become a single `scaled_dot_product_attention` op, decomposed softmax /
-GELU / logit soft-capping become their native Core ML ops, and redundant broadcasts are
-removed. The passes live in `stablehlo_coreml/passes/` and are registered under the
-`common::` namespace, so they can be removed or configured like any coremltools pass:
-
-```python
-pipeline = build_pass_pipeline()
-pipeline.remove_passes(["common::fuse_attention_to_sdpa"])
-# Use a boolean SDPA mask even for finite mask fill values such as -1e9 (cheaper, but a
-# fully masked row becomes NaN instead of a uniform distribution):
-pipeline.set_options("common::fuse_attention_to_sdpa", {"finite_fill_mask": "bool"})
-```
-
 ## Dynamic / symbolic shapes
 
 JAX models exported with symbolic dimensions are supported. Symbolic dims flow

--- a/README.md
+++ b/README.md
@@ -29,16 +29,22 @@ To convert a StableHLO module:
 
 ```python
 import coremltools as ct
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec, convert
+from stablehlo_coreml import StateSpec, build_pass_pipeline, convert
 
 mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
 cml_model = ct.convert(
     mil_program,
     source="milinternal",
     minimum_deployment_target=ct.target.iOS18,
-    pass_pipeline=DEFAULT_HLO_PIPELINE,
+    pass_pipeline=build_pass_pipeline(),
 )
 ```
+
+`build_pass_pipeline()` returns a fresh `ct.PassPipeline` built from
+`ct.PassPipeline.DEFAULT` with the stablehlo-coreml graph passes inserted at the right
+places. Pass your own `base` pipeline to customise it, e.g.
+`build_pass_pipeline(my_pipeline)`. The pre-built `stablehlo_coreml.DEFAULT_HLO_PIPELINE`
+is the same thing, constructed once at import time — copy it before mutating it.
 
 ### Obtaining a StableHLO Module from JAX
 
@@ -85,7 +91,7 @@ cml_model = ct.convert(
     mil_program,
     source="milinternal",
     minimum_deployment_target=ct.target.iOS18,
-    pass_pipeline=DEFAULT_HLO_PIPELINE,
+    pass_pipeline=build_pass_pipeline(),
 )
 
 state = cml_model.make_state()
@@ -104,6 +110,34 @@ fp16). They are removed from the model's inputs, and the outputs that update
 them are dropped.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
+
+## Graph optimization passes
+
+`build_pass_pipeline()` extends coremltools' default pipeline with a set of MIL graph
+passes that clean up and fuse the patterns the StableHLO lowering produces:
+
+| Pass | What it does |
+|------|--------------|
+| `remove_broadcast_tiles` | Drops the `tile` ops that StableHLO's explicit broadcasting produces when the consumer broadcasts natively (also keeps scalar constants from being materialised at full size). |
+| `fuse_reduce_keep_dims` | Folds `reduce_*(keep_dims=False) → reshape` into `reduce_*(keep_dims=True)`, unlocking coremltools' own `reduce_mean` fusions. |
+| `remove_noop_slice_update` | Removes full-tensor `slice_update`s. |
+| `replace_decomposed_softmax` | Replaces JAX's decomposed softmax (`reduce_max → sub → exp → reduce_sum → real_div`) with MIL `softmax`. |
+| `fuse_attention_to_sdpa` | Fuses `matmul → [scale] → [mask] → softmax → matmul` into `scaled_dot_product_attention` (bool/additive/constant masks, GQA layouts, explicit or Gemma-style scaling, and PyTorch's `_safe_softmax` wrapper). |
+| `fuse_logit_softcap` | Fuses `tanh(x / cap) * cap` into `scaled_tanh`. |
+| `fuse_gelu_erfc` | Fuses the `erfc`-based exact GELU emitted by `jax.nn.gelu(approximate=False)` into MIL `gelu` (`chlo.erf`/`chlo.erfc` are mapped to MIL `erf` by the converter). |
+
+Passes are registered under the `common::` namespace and can be removed or configured
+like any coremltools pass, e.g.
+
+```python
+pipeline = build_pass_pipeline()
+pipeline.remove_passes(["common::fuse_attention_to_sdpa"])
+# A `select` fill of exactly -inf always becomes a boolean SDPA mask. Use one for
+# finite fill values as well (-1e9, `torch.finfo(dtype).min`) -- cheaper, but a
+# fully masked row becomes NaN instead of the uniform distribution the original
+# graph produced:
+pipeline.set_options("common::fuse_attention_to_sdpa", {"finite_fill_mask": "bool"})
+```
 
 ## Dynamic / symbolic shapes
 

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,6 +1,6 @@
 from .converter import convert
-from .passes.utils import DEFAULT_HLO_PIPELINE, build_pass_pipeline, register_optimizations
+from .passes.utils import DEFAULT_HLO_PIPELINE, build_pass_pipeline
 from .state import StateSpec
 
 __version__ = "0.0.0"
-__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'build_pass_pipeline', 'convert', 'register_optimizations']
+__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'build_pass_pipeline', 'convert']

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,6 +1,6 @@
 from .converter import convert
-from .passes.utils import DEFAULT_HLO_PIPELINE, register_optimizations
+from .passes.utils import DEFAULT_HLO_PIPELINE, build_pass_pipeline, register_optimizations
 from .state import StateSpec
 
 __version__ = "0.0.0"
-__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'convert', 'register_optimizations']
+__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'build_pass_pipeline', 'convert', 'register_optimizations']

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -85,7 +85,6 @@ from jaxlib.mlir.dialects.stablehlo import (
 from .function_interface import _FunctionInterface
 from .ops_register import StableHloOpsRegistry, register_composite_op, register_stablehlo_op
 from .padding import pad_with_cast
-from .passes.utils import register_optimizations
 from .reductions import compute_reduction, compute_windowed_reduction, match_computation, match_simple_reduce_window
 from .sort_utils import match_sort
 from .state import (
@@ -134,8 +133,6 @@ def convert(
     """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
-
-    register_optimizations()
 
     _normalize_module(module)
 

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -143,26 +143,51 @@ def convert(
     return converter.convert(module)
 
 
+def _composite_wrapped_op_names() -> list[str]:
+    """The CHLO op names that the converter has a dedicated composite handler for."""
+    return sorted(
+        name for name in StableHloConverter._composite_ops_registry if name.startswith("chlo.")
+    )
+
+
 def _normalize_module(module: ir.Module) -> None:
     """Normalize an incoming StableHLO module in-place before conversion.
 
-    Two passes are applied in sequence:
+    Three passes are applied in sequence:
 
-    1. ``chlo-legalize-to-stablehlo`` – lowers any raw CHLO ops that appear
-       *outside* a ``stablehlo.composite`` wrapper (e.g. from the
-       ``jax.jit().lower().compiler_ir('stablehlo')`` path) to their StableHLO
-       equivalents.  Ops already wrapped in a composite are intentionally left
-       untouched; the composite handlers in the converter map them directly to
-       CoreML primitives, bypassing the (potentially unsupported) stablehlo
-       decompositions.
+    1. ``stablehlo-wrap-in-composite`` – wraps the raw CHLO ops we have a
+       dedicated handler for (see :func:`_composite_wrapped_op_names`) in a
+       ``stablehlo.composite``, keeping their decomposition in a separate
+       private function.  ``jax.export`` already does this for some CHLO ops,
+       but ``jax.jit().lower().compiler_ir('stablehlo')`` hands us the raw CHLO
+       ops; wrapping makes both paths behave the same.  It also covers ops that
+       ``jax.export`` does *not* wrap (notably ``chlo.erfc``).
 
-    2. ``stablehlo-legalize-deprecated-ops`` – rewrites any deprecated
+    2. ``chlo-legalize-to-stablehlo`` – lowers any remaining CHLO ops (the ones
+       we have no handler for, plus the bodies of the decomposition functions)
+       to their StableHLO equivalents.  Ops wrapped in a composite are
+       intentionally left untouched; the composite handlers in the converter map
+       them directly to CoreML primitives, bypassing the (potentially
+       unsupported, and always much larger) stablehlo decompositions.
+
+    3. ``stablehlo-legalize-deprecated-ops`` – rewrites any deprecated
        StableHLO ops to their current equivalents, keeping the converter
        insulated from older serialized modules.
+
+    The decomposition functions created by step 1 are private, so
+    :meth:`StableHloConverter.convert` skips them; they are only walked when a
+    composite has no registered handler.
     """
     stablehlo_dialect.register_stablehlo_passes()
+
+    passes = []
+    op_names = ",".join(_composite_wrapped_op_names())
+    if op_names:
+        passes.append(f"stablehlo-wrap-in-composite{{op-names={op_names}}}")
+    passes.append("func.func(chlo-legalize-to-stablehlo, stablehlo-legalize-deprecated-ops)")
+
     pm = passmanager.PassManager.parse(
-        "builtin.module(func.func(chlo-legalize-to-stablehlo, stablehlo-legalize-deprecated-ops))",
+        f"builtin.module({','.join(passes)})",
         context=module.context,
     )
     pm.run(module.operation)
@@ -286,6 +311,20 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         values, indices = mb.topk(x=x, k=k, ascending=not largest)
         context.add_result(op.results[0], values)
         context.add_result(op.results[1], indices)
+
+    @register_composite_op("chlo.erf")
+    def _op_composite_chlo_erf(self, context: TranslationContext, op: CompositeOp):
+        # CoreML has erf natively; the stablehlo decomposition is a ~40 op
+        # rational polynomial.
+        x = context[op.inputs[0].get_name()]
+        context.add_result(op.results[0], mb.erf(x=x))
+
+    @register_composite_op("chlo.erfc")
+    def _op_composite_chlo_erfc(self, context: TranslationContext, op: CompositeOp):
+        x = context[op.inputs[0].get_name()]
+        # erfc(x) = 1 - erf(x). Keeping the `1 - erf(...)` shape also lets the
+        # `fuse_gelu_erfc` MIL pass recognise an exact GELU.
+        context.add_result(op.results[0], mb.sub(x=1.0, y=mb.erf(x=x)))
 
     @register_composite_op("chlo.asin")
     def _op_composite_chlo_asin(self, context: TranslationContext, op: CompositeOp):

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -1,0 +1,1063 @@
+"""MIL pass: fuse a decomposed attention block into ``scaled_dot_product_attention``.
+
+Attention arrives from StableHLO as two ``dot_general``\\ s with a softmax in
+between. ``dot_general`` lowers to ``[transpose] -> [reshape] -> matmul(...,
+transpose_y=True) -> [reshape] -> [transpose]``, so an attention block looks
+like::
+
+    matmul_0(Q, K, transpose_y=True) -> [reshape/transpose]* -> [scale] ->
+      [mask] -> [cast] -> softmax(axis=-1) -> [reshape/transpose]* ->
+      matmul_1(W, V, transpose_y=True)
+
+The pass matches that and emits a single ``scaled_dot_product_attention``.
+
+Everything happens in "matmul space": the SDPA operands are exactly the matmul
+operands, so nothing is assumed about how the model laid out heads, groups or
+batches. The reshapes and transposes around the softmax only re-group the two
+result axes of ``matmul_0``, and the pass tracks that re-grouping symbolically
+(see :class:`_Atom`) to work out
+
+* which of the two matmul result axes is the key axis ``S`` (the one softmax
+  reduces over) and which one holds the query rows ``L``,
+* how the query rows of ``matmul_0`` are permuted before they reach
+  ``matmul_1`` -- Gemma-style GQA einsums merge the group and token axes in a
+  different order on each side,
+* how a mask expressed in softmax space maps onto SDPA's ``[..., L, S]``
+  attention scores.
+
+Whenever that cannot be established (symbolic dimensions where concrete ones
+are needed, a result axis split across the softmax axis, an intermediate value
+that is consumed elsewhere, ...) the pass leaves the graph alone.
+
+PyTorch's ``_safe_softmax`` wrapper -- ``select(row_is_all_neg_inf, 0.0,
+softmax(x))``, which several HuggingFace models lower literally -- is peeled off
+as well, but only when the matched mask proves that no row can be entirely
+-inf; otherwise the wrapper is not an identity and the block is left alone.
+"""
+
+import logging
+import math
+
+import numpy as np
+from coremltools.converters.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .pattern_utils import (
+    broadcast_shapes,
+    const_int_list,
+    dims_equal,
+    normalize_axis,
+    remove_dead_ops,
+    shapes_equal,
+    sole_consumer,
+    uniform_scalar_value,
+)
+
+logger = logging.getLogger(__name__)
+
+# Ops that only re-group axes; they never reorder elements within an axis.
+_LAYOUT_OPS = frozenset({"reshape", "expand_dims", "squeeze", "transpose"})
+
+# A `select` fill at or below this value means "mask this key out".
+_MASK_FILL_THRESHOLD = -1e4
+
+# Tolerance when checking that a detected scale cancels SDPA's 1/sqrt(E).
+_SCALE_TOLERANCE = 1e-3
+
+# Ops that a boolean predicate may be routed through without changing which
+# rows it selects (a `tile` only when it merely broadcasts).
+_PREDICATE_LAYOUT_OPS = frozenset({"reshape", "expand_dims", "squeeze", "cast"})
+
+
+class _Atom:
+    """A (possibly split) axis of the ``matmul_0`` result.
+
+    Reshapes and transposes never reorder elements within an axis: they only
+    split axes into factors, merge them again and permute them. Representing the
+    axes as trees of atoms therefore describes such a chain exactly.
+    """
+
+    __slots__ = ("children", "size")
+
+    def __init__(self, size: int):
+        self.size = int(size)
+        self.children = None
+
+    def split(self, first: int):
+        """Split into a leading factor of ``first`` and the remainder."""
+        head, tail = _Atom(first), _Atom(self.size // first)
+        self.children = (head, tail)
+        return head, tail
+
+    def leaves(self) -> list["_Atom"]:
+        """The leaves of the split tree, in row-major (flattened) order."""
+        if self.children is None:
+            return [self]
+        return self.children[0].leaves() + self.children[1].leaves()
+
+
+def _spare_unit_atoms(flat: list[_Atom], index: int, needed_later: int) -> bool:
+    """Can the size-1 atom at ``index`` be absorbed by the current dimension?
+
+    Only if the atoms left over still cover the ``needed_later`` size-1 target
+    dimensions that follow: a size-1 target dimension can only ever be filled by
+    a size-1 atom, and groups have to stay contiguous.
+    """
+    available = sum(1 for atom in flat[index + 1:] if atom.size == 1)
+    return available >= needed_later
+
+
+def _regroup(flat: list[_Atom], target_dims) -> list[list[_Atom]] | None:
+    """Re-group a flat atom sequence into ``target_dims`` (that is: a reshape).
+
+    Atoms are split when a target dimension ends in the middle of one. Returns
+    the new per-dimension atom lists, or ``None`` when the target cannot be
+    formed (symbolic dimension, or an unexpected element count).
+    """
+    flat = list(flat)
+    dims = list(target_dims)
+    for dim in dims:
+        if is_symbolic(dim) or int(dim) <= 0:
+            return None
+    dims = [int(dim) for dim in dims]
+    # Number of size-1 target dimensions strictly after each position; a size-1
+    # atom may only be absorbed early when enough of them are left for those.
+    unit_dims_after = [0] * (len(dims) + 1)
+    for i in range(len(dims) - 1, -1, -1):
+        unit_dims_after[i] = unit_dims_after[i + 1] + (1 if dims[i] == 1 else 0)
+
+    grouped: list[list[_Atom]] = []
+    index = 0
+    for position, dim in enumerate(dims):
+        group: list[_Atom] = []
+        product = 1
+        while index < len(flat):
+            atom = flat[index]
+            if product == dim:
+                # Size-1 atoms carry no information, so they are absorbed
+                # greedily -- but not past a later size-1 target dimension that
+                # would then be left without an atom of its own.
+                if atom.size != 1 or not _spare_unit_atoms(flat, index, unit_dims_after[position + 1]):
+                    break
+                group.append(atom)
+                index += 1
+            elif atom.size == 1:
+                # Groups are contiguous, so a size-1 atom in the middle of a
+                # dimension has to go into it.
+                group.append(atom)
+                index += 1
+            elif product * atom.size <= dim:
+                product *= atom.size
+                group.append(atom)
+                index += 1
+            else:
+                needed = dim // product
+                if needed <= 1 or atom.size % needed != 0:
+                    return None
+                head, tail = atom.split(needed)
+                flat[index:index + 1] = [head, tail]
+        if product != dim:
+            return None
+        grouped.append(group)
+    if index != len(flat):
+        return None
+    return grouped
+
+
+def _track_layout(layout: list[list[_Atom]], ops) -> list[list[_Atom]] | None:
+    """Apply ``ops`` (in execution order) to ``layout``."""
+    for op in ops:
+        in_shape = tuple(op.inputs["x"].shape)
+        out_shape = tuple(op.outputs[0].shape)
+        if len(layout) != len(in_shape):
+            return None
+        if op.op_type == "transpose":
+            perm = const_int_list(op.inputs.get("perm"))
+            if perm is None or len(perm) != len(in_shape):
+                return None
+            perm = [normalize_axis(p, len(in_shape)) for p in perm]
+            if any(p is None for p in perm):
+                return None
+            layout = [layout[p] for p in perm]
+        else:
+            flat = [atom for dim in layout for atom in dim]
+            layout = _regroup(flat, out_shape)
+            if layout is None:
+                return None
+    return layout
+
+
+def _expand(dim) -> list[_Atom]:
+    """Expand a dimension's atoms to their (current) leaves."""
+    return [leaf for atom in dim for leaf in atom.leaves()]
+
+
+def _uniform_const_operand(op):
+    """For a binary op, return ``(const_value, other_var)`` if exactly one operand is uniform."""
+    x, y = op.inputs["x"], op.inputs["y"]
+    x_val, y_val = uniform_scalar_value(x), uniform_scalar_value(y)
+    if x_val is not None and y_val is None:
+        return x_val, y
+    if y_val is not None and x_val is None:
+        return y_val, x
+    return None
+
+
+def _leads_to_matmul(var, depth: int = 12) -> bool:
+    """Cheap check whether ``var`` is (transitively) produced by a matmul."""
+    for _ in range(depth):
+        op = getattr(var, "op", None)
+        if op is None:
+            return False
+        if op.op_type == "matmul":
+            return True
+        x = op.inputs.get("x")
+        if x is None:
+            return False
+        var = x
+    return False
+
+
+def _is_broadcast_tile(op) -> bool:
+    """True when ``op`` is a ``tile`` that only broadcasts size-1 dimensions."""
+    reps = const_int_list(op.inputs.get("reps"))
+    shape = op.inputs["x"].shape
+    if reps is None or shape is None or len(reps) != len(shape):
+        return False
+    # Repeating a dimension that is not 1 interleaves elements: a real tile.
+    return all(rep == 1 or dims_equal(dim, 1) for dim, rep in zip(shape, reps))
+
+
+def _peel_broadcast_tile(var):
+    """Strip a leading broadcast ``tile``; returns ``(var, tile_op or None)``."""
+    op = getattr(var, "op", None)
+    if op is not None and op.op_type == "tile" and _is_broadcast_tile(op):
+        return op.inputs["x"], op
+    return var, None
+
+
+def _is_uniform_neg_inf(var) -> bool:
+    """True when ``var`` is a constant whose every element is exactly -inf."""
+    value = uniform_scalar_value(var)
+    return value is not None and math.isinf(value) and value < 0
+
+
+def _peel_predicate(var, ops):
+    """Peel the layout/cast/``logical_not`` ops in front of a boolean predicate.
+
+    Returns ``(var, negations)``; ``negations`` counts the ``logical_not`` ops
+    that were peeled, so the caller can track the polarity. The peeled ops are
+    appended to ``ops``.
+    """
+    negations = 0
+    while True:
+        op = getattr(var, "op", None)
+        if op is None:
+            break
+        if op.op_type == "logical_not":
+            negations += 1
+        elif op.op_type == "tile":
+            if not _is_broadcast_tile(op):
+                break
+        elif op.op_type not in _PREDICATE_LAYOUT_OPS:
+            break
+        ops.append(op)
+        var = op.inputs["x"]
+    return var, negations
+
+
+class _SafeSoftmax:
+    """Torch's ``_safe_softmax`` wrapper around a plain softmax.
+
+    ``torch.nn.functional.scaled_dot_product_attention`` zeroes the rows whose
+    scores are all -inf instead of letting them become NaN. Lowered literally,
+    that is ``select(row_is_all_neg_inf, 0.0, softmax(x))``.
+    """
+
+    def __init__(self, select_op, ops):
+        self.select_op = select_op
+        self.ops = ops
+
+
+def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
+    """Recognise the ``select`` that zeroes fully masked rows after ``softmax_op``."""
+    weights = softmax_op.outputs[0]
+    select_op = sole_consumer(weights)
+    if select_op is None or select_op.op_type != "select":
+        return None
+    cond = select_op.inputs["cond"]
+    a, b = select_op.inputs["a"], select_op.inputs["b"]
+    if not shapes_equal(select_op.outputs[0].shape, weights.shape):
+        return None
+
+    a_zeros, b_zeros = uniform_scalar_value(a) == 0.0, uniform_scalar_value(b) == 0.0
+    if a is weights and b_zeros:
+        # The weights survive where the condition holds.
+        weights_when_true, zeros = True, b
+    elif b is weights and a_zeros:
+        weights_when_true, zeros = False, a
+    else:
+        return None
+
+    ops = [select_op]
+    base, cond_negations = _peel_predicate(cond, ops)
+
+    reduce_op = getattr(base, "op", None)
+    if reduce_op is None or reduce_op.op_type not in ("reduce_max", "reduce_min"):
+        return None
+    reduce_in = reduce_op.inputs["x"]
+    if reduce_in.shape is None or not shapes_equal(reduce_in.shape, softmax_op.x.shape):
+        return None
+    axes = const_int_list(reduce_op.inputs.get("axes"))
+    rank = len(reduce_in.shape)
+    if axes is None or len(axes) != 1 or normalize_axis(axes[0], rank) != rank - 1:
+        # The reduction has to be over the softmax axis to describe a "row".
+        return None
+    ops.append(reduce_op)
+
+    inner, inner_negations = _peel_predicate(reduce_in, ops)
+    compare_op = getattr(inner, "op", None)
+    if compare_op is None or compare_op.op_type not in ("equal", "not_equal"):
+        return None
+    x, y = compare_op.inputs["x"], compare_op.inputs["y"]
+    if _is_uniform_neg_inf(y):
+        scores = x
+    elif _is_uniform_neg_inf(x):
+        scores = y
+    else:
+        return None
+    if scores is not softmax_op.x:
+        # The comparison may run on the pre-/post-cast version of the scores.
+        scores_op, softmax_in_op = getattr(scores, "op", None), getattr(softmax_op.x, "op", None)
+        if scores_op is not None and scores_op.op_type == "cast" and scores_op.inputs["x"] is softmax_op.x:
+            ops.append(scores_op)
+        elif softmax_in_op is not None and softmax_in_op.op_type == "cast" and softmax_in_op.inputs["x"] is scores:
+            pass
+        else:
+            return None
+    ops.append(compare_op)
+
+    # -- polarity ------------------------------------------------------------
+    # `element_is_neg_inf` after the comparison and the `logical_not`s below the
+    # reduction; `flipped` means the predicate is "this element is NOT -inf".
+    flipped = ((0 if compare_op.op_type == "equal" else 1) + inner_negations) % 2
+    if flipped:
+        # any(not -inf) == "the row is not all -inf"
+        if reduce_op.op_type != "reduce_max":
+            return None
+        row_not_all_neg_inf = True
+    else:
+        # all(is -inf) == "the row is all -inf"
+        if reduce_op.op_type != "reduce_min":
+            return None
+        row_not_all_neg_inf = False
+    if cond_negations % 2:
+        row_not_all_neg_inf = not row_not_all_neg_inf
+
+    # The wrapper must keep the softmax weights exactly for the rows that are
+    # not entirely -inf; any other polarity means we misread the graph.
+    if weights_when_true != row_not_all_neg_inf:
+        return None
+
+    zeros_op = getattr(zeros, "op", None)
+    if zeros_op is not None:
+        ops.append(zeros_op)
+    return _SafeSoftmax(select_op, ops)
+
+
+def _safe_softmax_is_redundant(pattern) -> bool:
+    """True when no score row can be entirely -inf, so the wrapper is an identity."""
+    if pattern.mask_kind is None:
+        return True
+    if pattern.mask_kind == "select":
+        # A finite fill (`torch.finfo(dtype).min`) leaves a fully masked row
+        # finite, so softmax produces a uniform row rather than NaN.
+        return not math.isinf(float(pattern.mask_fill))
+    mask_value = getattr(pattern.mask_var, "val", None)
+    if mask_value is None:
+        # A mask computed at runtime (Whisper builds one out of -inf and 0.0)
+        # may well have an all -inf row, and then the wrapper is *not* an
+        # identity: SDPA would return NaN where the original graph returns 0.
+        return False
+    return not bool(np.isinf(np.asarray(mask_value)).any())
+
+
+def _swap_last_two(rank: int) -> list[int]:
+    return list(range(rank - 2)) + [rank - 1, rank - 2]
+
+
+def _np_scalar(value: float, dtype):
+    return np.float16(value) if dtype == types.fp16 else np.float32(value)
+
+
+def _as_sequence_major(var, needs_transpose: bool, before_op, name: str, peeled):
+    """Return ``var``, or its last-two-axes transpose, as a ``[batch..., seq, E]`` tensor.
+
+    When ``var`` is itself such a transpose it is peeled instead of stacking a
+    second one; the peeled op is appended to ``peeled`` so it can be collected.
+    """
+    if not needs_transpose:
+        return var
+    rank = len(var.shape)
+    op = getattr(var, "op", None)
+    if op is not None and op.op_type == "transpose":
+        perm = const_int_list(op.inputs.get("perm"))
+        if perm is not None and len(perm) == rank:
+            perm = [normalize_axis(p, rank) for p in perm]
+            if perm == _swap_last_two(rank):
+                peeled.append(op)
+                return op.inputs["x"]
+    return mb.transpose(x=var, perm=_swap_last_two(rank), before_op=before_op, name=name)
+
+
+class _Pattern:
+    """Everything the matcher found for one attention block."""
+
+    def __init__(self, softmax_op):
+        self.softmax_op = softmax_op
+        self.matmul_0 = None
+        self.matmul_1 = None
+        self.weights_var = None
+        self.back_layout_ops = []       # matmul_0 -> softmax, in execution order
+        self.fwd_layout_ops = []        # softmax -> matmul_1, in execution order
+        self.ops = [softmax_op]         # every matched op (removal candidates)
+        self.mask_kind = None           # None | "select" | "add"
+        self.mask_var = None            # the compact condition / additive mask
+        self.mask_fill = None           # the `select` fill value
+        self.mask_negated = False       # matched select(cond, fill, scores)
+        self.scale = None               # multiplicative factor applied to the scores
+        self.mask_before_scale = False  # forward order was mask -> scale
+
+
+class _Space:
+    """How softmax space and ``matmul_1``'s weights relate to matmul space."""
+
+    def __init__(self, n_batch, batch_shape, *, s_is_first=False, s_atom=None,
+                 l_atom=None, batch_atoms=None, softmax_layout=None, l_prime=None):
+        self.n_batch = n_batch
+        self.batch_shape = list(batch_shape)
+        # True when the softmax axis is `matmul_0`'s first result axis, i.e. the
+        # scores are transposed with respect to SDPA's [..., L, S] convention.
+        self.s_is_first = s_is_first
+        self.s_atom = s_atom
+        self.l_atom = l_atom
+        self.batch_atoms = batch_atoms
+        self.softmax_layout = softmax_layout
+        self.l_leaves = None if l_atom is None else l_atom.leaves()
+        self.l_prime = l_prime
+
+    @property
+    def is_identity(self) -> bool:
+        """True when there is no layout op at all between the matmuls and the softmax."""
+        return self.softmax_layout is None
+
+    def sdpa_atom_order(self) -> list[_Atom]:
+        """The atom order of SDPA's ``[batch..., L, S]`` score space."""
+        order = []
+        for atom in self.batch_atoms:
+            order.extend(atom.leaves())
+        return order + list(self.l_leaves) + [self.s_atom]
+
+    @property
+    def is_score_space(self) -> bool:
+        """True when softmax space already has SDPA's ``[batch..., L, S]`` layout."""
+        if self.is_identity:
+            return True
+        if len(self.softmax_layout) != self.n_batch + 2:
+            return False
+        for atom, dim in zip(self.batch_atoms, self.softmax_layout):
+            if [id(a) for a in dim] != [id(a) for a in atom.leaves()]:
+                return False
+        if self.softmax_layout[-1] != [self.s_atom]:
+            return False
+        return [id(a) for a in self.softmax_layout[-2]] == [id(a) for a in self.l_leaves]
+
+
+def _match_backward(softmax_op, pattern, ignored=()) -> bool:
+    """Walk from ``softmax.x`` back to ``matmul_0``, filling in ``pattern``.
+
+    ``ignored`` holds the ``id()`` of ops that were already matched as part of
+    the same pattern (the safe-softmax condition chain reads the scores too) and
+    that therefore do not count as consumers escaping the pattern.
+    """
+    var = softmax_op.x
+    consumer = softmax_op
+    n_casts = 0
+    order = []
+    back_ops = []
+
+    while True:
+        if sole_consumer(var, ignored) is not consumer:
+            return False
+        op = getattr(var, "op", None)
+        if op is None:
+            return False
+        op_type = op.op_type
+
+        if op_type == "matmul":
+            pattern.matmul_0 = op
+            pattern.ops.append(op)
+            break
+
+        if op_type == "cast":
+            if n_casts >= 2:
+                return False
+            n_casts += 1
+            next_var = op.inputs["x"]
+        elif op_type in _LAYOUT_OPS:
+            back_ops.append(op)
+            next_var = op.inputs["x"]
+        elif op_type == "select" and pattern.mask_kind is None:
+            cond, a, b = op.inputs["cond"], op.inputs["a"], op.inputs["b"]
+            fill_a, fill_b = uniform_scalar_value(a), uniform_scalar_value(b)
+            if fill_b is not None and fill_b <= _MASK_FILL_THRESHOLD:
+                pattern.mask_fill, pattern.mask_negated, next_var = fill_b, False, a
+            elif fill_a is not None and fill_a <= _MASK_FILL_THRESHOLD:
+                pattern.mask_fill, pattern.mask_negated, next_var = fill_a, True, b
+            else:
+                return False
+            pattern.mask_kind = "select"
+            pattern.mask_var = cond
+            order.append("mask")
+        elif op_type == "add" and pattern.mask_kind is None:
+            x, y = op.inputs["x"], op.inputs["y"]
+            # A uniform constant shifts every score by the same amount, which
+            # softmax cancels out; it carries no masking information, so there
+            # is nothing to translate and we leave the graph alone. A
+            # non-uniform constant (T5's relative position bias, folded to a
+            # constant) is a perfectly good additive float mask.
+            if uniform_scalar_value(x) is not None or uniform_scalar_value(y) is not None:
+                return False
+            if _leads_to_matmul(x):
+                next_var, pattern.mask_var = x, y
+            elif _leads_to_matmul(y):
+                next_var, pattern.mask_var = y, x
+            else:
+                return False
+            pattern.mask_kind = "add"
+            order.append("mask")
+        elif op_type in ("mul", "real_div") and pattern.scale is None:
+            if op_type == "real_div":
+                divisor = uniform_scalar_value(op.inputs["y"])
+                if divisor is None or divisor <= 0:
+                    return False
+                pattern.scale = 1.0 / divisor
+                next_var = op.inputs["x"]
+            else:
+                operand = _uniform_const_operand(op)
+                if operand is None or operand[0] <= 0:
+                    return False
+                pattern.scale, next_var = operand
+            order.append("scale")
+        else:
+            return False
+
+        if op_type not in ("cast", *_LAYOUT_OPS) and not shapes_equal(op.outputs[0].shape, next_var.shape):
+            # A mask or scale that broadcasts the scores up would change the
+            # score layout; only element-wise application is supported.
+            return False
+
+        pattern.ops.append(op)
+        consumer = op
+        var = next_var
+
+    pattern.back_layout_ops = list(reversed(back_ops))
+    # The op encountered first walking backwards is the one applied last.
+    pattern.mask_before_scale = order[:2] == ["scale", "mask"]
+    return True
+
+
+def _match_forward(softmax_op, pattern, safe_softmax=None) -> bool:
+    """Walk from the softmax output forward to ``matmul_1``.
+
+    When ``safe_softmax`` is given the walk starts after its ``select`` instead:
+    the wrapper has already been checked to be an identity here.
+    """
+    var = softmax_op.outputs[0] if safe_softmax is None else safe_softmax.select_op.outputs[0]
+    fwd_ops = []
+    n_casts = 0
+    while True:
+        consumer = sole_consumer(var)
+        if consumer is None:
+            return False
+        if consumer.op_type == "matmul":
+            pattern.matmul_1 = consumer
+            pattern.weights_var = var
+            pattern.ops.append(consumer)
+            break
+        if consumer.op_type == "cast":
+            if n_casts >= 2:
+                return False
+            n_casts += 1
+        elif consumer.op_type in _LAYOUT_OPS:
+            fwd_ops.append(consumer)
+        else:
+            return False
+        pattern.ops.append(consumer)
+        var = consumer.outputs[0]
+
+    pattern.fwd_layout_ops = fwd_ops
+    return True
+
+
+def _analyse_space(pattern) -> _Space | None:
+    """Work out the S/L roles and the row permutation between the two matmuls."""
+    scores_shape = tuple(pattern.matmul_0.outputs[0].shape)
+    n_batch = len(scores_shape) - 2
+    if n_batch < 1:
+        return None
+
+    if not pattern.back_layout_ops and not pattern.fwd_layout_ops:
+        # Softmax runs directly on the matmul result, so S is its last axis.
+        return _Space(n_batch, scores_shape[:n_batch])
+
+    if any(is_symbolic(dim) for dim in scores_shape):
+        return None
+
+    atoms = [_Atom(dim) for dim in scores_shape]
+    batch_atoms, m_atom, n_atom = atoms[:n_batch], atoms[-2], atoms[-1]
+
+    layout = _track_layout([[atom] for atom in atoms], pattern.back_layout_ops)
+    if not layout or len(layout[-1]) != 1:
+        return None
+
+    s_atom = layout[-1][0]
+    if s_atom is m_atom:
+        l_atom = n_atom
+    elif s_atom is n_atom:
+        l_atom = m_atom
+    else:
+        # Softmax reduces over a batch axis, or over only part of a result axis.
+        return None
+
+    weights_layout = _track_layout(layout, pattern.fwd_layout_ops)
+    if weights_layout is None or len(weights_layout) != n_batch + 2:
+        return None
+
+    # The forward chain may split axes further, so re-expand every layout to the
+    # (now finer) leaves before comparing them.
+    if s_atom.children is not None:
+        # The key axis itself was split; it is no longer a single SDPA axis.
+        return None
+    if _expand(weights_layout[-1]) != [s_atom]:
+        return None
+    for atom, dim in zip(batch_atoms, weights_layout):
+        # The batch layout of both matmuls has to agree: SDPA keeps it as is.
+        if _expand(dim) != atom.leaves():
+            return None
+
+    l_leaves = l_atom.leaves()
+    l_prime = _expand(weights_layout[n_batch])
+    if len(l_prime) != len(l_leaves) or {id(a) for a in l_prime} != {id(a) for a in l_leaves}:
+        return None
+
+    return _Space(
+        n_batch,
+        scores_shape[:n_batch],
+        s_is_first=s_atom is m_atom,
+        s_atom=s_atom,
+        l_atom=l_atom,
+        batch_atoms=batch_atoms,
+        softmax_layout=[_expand(dim) for dim in layout],
+        l_prime=l_prime,
+    )
+
+
+def _reorder_rows(var, space, source_atoms, target_atoms, trailing_dim, before_op, name):
+    """Permute the merged row axis of ``var`` from ``source_atoms`` to ``target_atoms`` order.
+
+    ``var`` has shape ``[batch..., prod(source_atoms), trailing_dim]``.
+    """
+    position = {id(atom): i for i, atom in enumerate(source_atoms)}
+    perm_tail = []
+    for atom in target_atoms:
+        index = position.get(id(atom))
+        if index is None:
+            return None
+        perm_tail.append(index)
+    if perm_tail == list(range(len(source_atoms))):
+        return var
+    if any(is_symbolic(dim) for dim in space.batch_shape) or trailing_dim is None:
+        return None
+
+    batch = [int(dim) for dim in space.batch_shape]
+    n_batch = len(batch)
+    total = 1
+    for atom in source_atoms:
+        total *= atom.size
+
+    split = mb.reshape(
+        x=var,
+        shape=batch + [atom.size for atom in source_atoms] + [int(trailing_dim)],
+        before_op=before_op,
+        name=name + "_split",
+    )
+    perm = list(range(n_batch)) + [n_batch + p for p in perm_tail] + [n_batch + len(source_atoms)]
+    permuted = mb.transpose(x=split, perm=perm, before_op=before_op, name=name + "_perm")
+    return mb.reshape(
+        x=permuted,
+        shape=batch + [total, int(trailing_dim)],
+        before_op=before_op,
+        name=name + "_merge",
+    )
+
+
+def _mask_to_sdpa_space(mask_var, space, softmax_shape, seq_len, before_op, name):
+    """Bring a mask expressed in softmax space into SDPA's ``[..., L, S]`` space."""
+    mask_shape = tuple(mask_var.shape)
+    softmax_shape = tuple(softmax_shape)
+    sdpa_rank = space.n_batch + 2
+    if len(mask_shape) == 0 or not dims_equal(mask_shape[-1], seq_len):
+        return None
+    if len(mask_shape) > len(softmax_shape):
+        return None
+    if not shapes_equal(broadcast_shapes(mask_shape, softmax_shape), softmax_shape):
+        return None
+
+    if space.is_score_space:
+        return mask_var if len(mask_shape) <= sdpa_rank else None
+
+    padded = (1,) * (len(softmax_shape) - len(mask_shape)) + mask_shape
+
+    if all(dims_equal(dim, 1) for dim in padded[:-1]):
+        # A pure key mask: identical for every query row.
+        return mb.reshape(
+            x=mask_var,
+            shape=[1] * (sdpa_rank - 1) + [int(seq_len)],
+            before_op=before_op,
+            name=name + "_key",
+        )
+
+    if any(is_symbolic(dim) for dim in softmax_shape) or any(is_symbolic(dim) for dim in padded):
+        return None
+    if any(is_symbolic(dim) for dim in space.batch_shape):
+        return None
+
+    var = mask_var
+    if len(mask_shape) != len(padded):
+        var = mb.reshape(x=var, shape=list(padded), before_op=before_op, name=name + "_expand")
+    reps = []
+    for target, current in zip(softmax_shape, padded):
+        if int(current) == int(target):
+            reps.append(1)
+        elif int(current) == 1:
+            reps.append(int(target))
+        else:
+            return None
+    if any(rep != 1 for rep in reps):
+        var = mb.tile(x=var, reps=reps, before_op=before_op, name=name + "_tile")
+
+    # Split softmax space into one axis per atom, then reorder to [batch..., L, S].
+    flat_atoms = [atom for dim in space.softmax_layout for atom in dim]
+    var = mb.reshape(
+        x=var,
+        shape=[atom.size for atom in flat_atoms],
+        before_op=before_op,
+        name=name + "_split",
+    )
+    position = {id(atom): i for i, atom in enumerate(flat_atoms)}
+    perm = []
+    for atom in space.sdpa_atom_order():
+        index = position.get(id(atom))
+        if index is None:
+            return None
+        perm.append(index)
+    if len(perm) != len(flat_atoms):
+        return None
+    if perm != list(range(len(flat_atoms))):
+        var = mb.transpose(x=var, perm=perm, before_op=before_op, name=name + "_perm")
+    total = 1
+    for atom in space.l_leaves:
+        total *= atom.size
+    return mb.reshape(
+        x=var,
+        shape=[int(dim) for dim in space.batch_shape] + [total, int(seq_len)],
+        before_op=before_op,
+        name=name + "_merge",
+    )
+
+
+def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
+    """Build SDPA's ``attn_mask`` from the matched ``select`` / additive mask."""
+    softmax_op = pattern.softmax_op
+    mask_var = pattern.mask_var
+    # Peel the broadcast tile the converter emits for `select`; the compact
+    # condition is what we want to re-layout. A tile that replicates a dimension
+    # that is not 1 is a real tile, not a broadcast, and must be kept.
+    mask_var, tile_op = _peel_broadcast_tile(mask_var)
+    if tile_op is not None:
+        pattern.ops.append(tile_op)
+
+    mask = _mask_to_sdpa_space(
+        mask_var, space, softmax_op.x.shape, seq_len, before_op, softmax_op.name + "_mask"
+    )
+    if mask is None:
+        return None
+
+    if pattern.mask_kind == "add":
+        if pattern.mask_before_scale and pattern.scale is not None:
+            mask = mb.mul(
+                x=mask,
+                y=_np_scalar(float(pattern.scale), query.dtype),
+                before_op=before_op,
+                name=softmax_op.name + "_mask_scaled",
+            )
+        return mask
+
+    if pattern.mask_negated:
+        mask = mb.logical_not(x=mask, before_op=before_op, name=softmax_op.name + "_mask_not")
+
+    fill = float(pattern.mask_fill)
+    if pattern.mask_before_scale and pattern.scale is not None:
+        fill *= float(pattern.scale)
+
+    if math.isinf(fill) or finite_fill_mask == "bool":
+        # A -inf fill and SDPA's boolean mask have identical semantics.
+        return mask
+
+    # A finite fill (-1e9, torch's `finfo(dtype).min`, ...) keeps a fully masked
+    # row finite -- softmax turns it into a uniform row -- while a boolean mask
+    # would turn it into NaN. Reproduce it as an additive mask.
+    float_mask = mb.cast(
+        x=mask,
+        dtype=types.builtin_to_string(query.dtype),
+        before_op=before_op,
+        name=softmax_op.name + "_mask_f",
+    )
+    inverted = mb.sub(
+        x=_np_scalar(1.0, query.dtype),
+        y=float_mask,
+        before_op=before_op,
+        name=softmax_op.name + "_mask_inv",
+    )
+    return mb.mul(
+        x=inverted,
+        y=_np_scalar(fill, query.dtype),
+        before_op=before_op,
+        name=softmax_op.name + "_mask_add",
+    )
+
+
+def _validate_operands(query, key, value, n_batch: int) -> bool:
+    for operand in (query, key, value):
+        if operand.shape is None or len(operand.shape) != n_batch + 2:
+            return False
+    if query.dtype != key.dtype or query.dtype != value.dtype:
+        return False
+    # SDPA does not broadcast the batch dimensions.
+    if not shapes_equal(query.shape[:-2], key.shape[:-2]):
+        return False
+    if not shapes_equal(query.shape[:-2], value.shape[:-2]):
+        return False
+    if not dims_equal(query.shape[-1], key.shape[-1]):
+        return False
+    return dims_equal(key.shape[-2], value.shape[-2])
+
+
+def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
+    out_rank = len(softmax_op.outputs[0].shape)
+    if normalize_axis(softmax_op.axis.val, out_rank) != out_rank - 1:
+        return False
+
+    # Torch lowers `_safe_softmax` literally; peel the wrapper when it cannot
+    # make a difference. Its condition reads the scores, so the backward walk
+    # has to know about those ops before it checks for escaping consumers.
+    safe_softmax = _match_safe_softmax(softmax_op)
+    ignored = frozenset(id(op) for op in safe_softmax.ops) if safe_softmax is not None else frozenset()
+
+    pattern = _Pattern(softmax_op)
+    if not _match_backward(softmax_op, pattern, ignored):
+        return False
+    if safe_softmax is not None and not _safe_softmax_is_redundant(pattern):
+        return False
+    if not _match_forward(softmax_op, pattern, safe_softmax):
+        return False
+    if safe_softmax is not None:
+        pattern.ops.extend(safe_softmax.ops)
+
+    matmul_0, matmul_1 = pattern.matmul_0, pattern.matmul_1
+    if bool(matmul_0.transpose_x.val) or bool(matmul_1.transpose_x.val):
+        return False
+
+    space = _analyse_space(pattern)
+    if space is None:
+        return False
+
+    # -- the two operands of matmul_0 ---------------------------------------
+    lhs, rhs = matmul_0.inputs["x"], matmul_0.inputs["y"]
+    rhs_transposed = not bool(matmul_0.transpose_y.val)
+    if space.s_is_first:
+        key_src, key_t = lhs, False
+        query_src, query_t = rhs, rhs_transposed
+    else:
+        query_src, query_t = lhs, False
+        key_src, key_t = rhs, rhs_transposed
+
+    # -- the value operand of matmul_1 --------------------------------------
+    if matmul_1.inputs["x"] is pattern.weights_var:
+        value_src = matmul_1.inputs["y"]
+        value_t = bool(matmul_1.transpose_y.val)
+        output_transposed = False
+    elif matmul_1.inputs["y"] is pattern.weights_var:
+        if not bool(matmul_1.transpose_y.val):
+            # The contracting axis would not be the last one of the weights.
+            return False
+        value_src = matmul_1.inputs["x"]
+        value_t = True
+        output_transposed = True
+    else:
+        return False
+
+    peeled = []
+    query = _as_sequence_major(query_src, query_t, matmul_1, softmax_op.name + "_query", peeled)
+    key = _as_sequence_major(key_src, key_t, matmul_1, softmax_op.name + "_key", peeled)
+    value = _as_sequence_major(value_src, value_t, matmul_1, softmax_op.name + "_value", peeled)
+    pattern.ops.extend(peeled)
+
+    if not _validate_operands(query, key, value, space.n_batch):
+        return False
+
+    embedding = query.shape[-1]
+    if is_symbolic(embedding):
+        return False
+    embedding = int(embedding)
+    seq_len = key.shape[-2]
+
+    attn_mask = None
+    if pattern.mask_kind is not None:
+        attn_mask = _build_mask(pattern, space, matmul_1, seq_len, query, finite_fill_mask)
+        if attn_mask is None:
+            return False
+
+    # -- scale: SDPA always divides by sqrt(E) ------------------------------
+    scale = 1.0 if pattern.scale is None else float(pattern.scale)
+    factor = scale * math.sqrt(embedding)
+    if abs(factor - 1.0) >= _SCALE_TOLERANCE:
+        query = mb.mul(
+            x=query,
+            y=_np_scalar(factor, query.dtype),
+            before_op=matmul_1,
+            name=softmax_op.name + "_query_scaled",
+        )
+
+    attention = mb.scaled_dot_product_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+        before_op=matmul_1,
+        name=softmax_op.name + "_sdpa",
+    )
+
+    # -- restore the row order matmul_1 produced ----------------------------
+    if not space.is_identity:
+        value_dim = value.shape[-1]
+        reordered = _reorder_rows(
+            attention,
+            space,
+            space.l_leaves,
+            list(space.l_prime),
+            None if is_symbolic(value_dim) else int(value_dim),
+            matmul_1,
+            softmax_op.name + "_sdpa_rows",
+        )
+        if reordered is None:
+            return False
+        attention = reordered
+
+    if output_transposed:
+        attention = mb.transpose(
+            x=attention,
+            perm=_swap_last_two(len(attention.shape)),
+            before_op=matmul_1,
+            name=softmax_op.name + "_sdpa_out",
+        )
+
+    old_var = matmul_1.outputs[0]
+    if attention.dtype != old_var.dtype:
+        attention = mb.cast(
+            x=attention,
+            dtype=types.builtin_to_string(old_var.dtype),
+            before_op=matmul_1,
+            name=softmax_op.name + "_sdpa_cast",
+        )
+    if not shapes_equal(attention.shape, old_var.shape):
+        return False
+
+    block.replace_uses_of_var_after_op(anchor_op=matmul_1, old_var=old_var, new_var=attention)
+    remove_dead_ops(block, pattern.ops)
+    return True
+
+
+@block_context_manager
+def _fuse_attention_to_sdpa(block, finite_fill_mask: str) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_attention_to_sdpa(nested_block, finite_fill_mask)
+        if len(op.blocks) > 0:
+            continue
+
+        if op.op_type != "softmax":
+            continue
+        # `_try_fuse` may build some replacement ops before a late check makes it
+        # give up; drop those again so an aborted attempt leaves no trace.
+        existing = set(block.operations)
+        if _try_fuse(op, block, finite_fill_mask):
+            fused += 1
+        else:
+            remove_dead_ops(block, [o for o in block.operations if o not in existing])
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_attention_to_sdpa(AbstractGraphPass):
+    """
+    Fuse ``matmul -> [scale] -> [mask] -> softmax -> matmul`` into
+    ``scaled_dot_product_attention``.
+
+    Support options:
+
+    - ``finite_fill_mask``: how to translate a ``select`` whose fill value is a
+      large but finite negative number (``-1e9``, ``torch.finfo(dtype).min``).
+      ``"additive"`` (the default) emits a float mask so that a fully masked row
+      stays finite, exactly like the original graph; ``"bool"`` emits the
+      boolean condition instead, which is cheaper but turns such rows into NaN.
+      Only a fill of exactly ``-inf`` maps to a boolean mask unconditionally.
+
+    Given:
+        %scores = matmul(x=%q, y=%k, transpose_y=True)
+        %scaled = mul(x=%scores, y=0.125)
+        %masked = select(cond=%m, a=%scaled, b=-1e9)
+        %w = softmax(x=%masked, axis=-1)
+        %out = matmul(x=%w, y=%v_t, transpose_y=True)
+
+    Result:
+        %out = scaled_dot_product_attention(query=%q, key=%k, value=%v, attn_mask=...)
+    """
+
+    _finite_fill_mask = "additive"
+
+    @property
+    def finite_fill_mask(self) -> str:
+        return self._finite_fill_mask
+
+    @finite_fill_mask.setter
+    def finite_fill_mask(self, mode: str):
+        if mode not in ("additive", "bool"):
+            raise ValueError(f"finite_fill_mask must be 'additive' or 'bool', got `{mode}`")
+        self._finite_fill_mask = mode
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_attention_to_sdpa(f, self._finite_fill_mask)
+            if fused:
+                logger.debug("fuse_attention_to_sdpa: fused %d attention block(s)", fused)

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -50,10 +50,11 @@ from .pattern_utils import (
     broadcast_shapes,
     const_int_list,
     dims_equal,
+    is_broadcast_tile,
     normalize_axis,
-    remove_dead_ops,
     shapes_equal,
     sole_consumer,
+    uniform_const_operand,
     uniform_scalar_value,
 )
 
@@ -193,17 +194,6 @@ def _expand(dim) -> list[_Atom]:
     return [leaf for atom in dim for leaf in atom.leaves()]
 
 
-def _uniform_const_operand(op):
-    """For a binary op, return ``(const_value, other_var)`` if exactly one operand is uniform."""
-    x, y = op.inputs["x"], op.inputs["y"]
-    x_val, y_val = uniform_scalar_value(x), uniform_scalar_value(y)
-    if x_val is not None and y_val is None:
-        return x_val, y
-    if y_val is not None and x_val is None:
-        return y_val, x
-    return None
-
-
 def _leads_to_matmul(var, depth: int = 12) -> bool:
     """Cheap check whether ``var`` is (transitively) produced by a matmul."""
     for _ in range(depth):
@@ -219,22 +209,12 @@ def _leads_to_matmul(var, depth: int = 12) -> bool:
     return False
 
 
-def _is_broadcast_tile(op) -> bool:
-    """True when ``op`` is a ``tile`` that only broadcasts size-1 dimensions."""
-    reps = const_int_list(op.inputs.get("reps"))
-    shape = op.inputs["x"].shape
-    if reps is None or shape is None or len(reps) != len(shape):
-        return False
-    # Repeating a dimension that is not 1 interleaves elements: a real tile.
-    return all(rep == 1 or dims_equal(dim, 1) for dim, rep in zip(shape, reps))
-
-
 def _peel_broadcast_tile(var):
-    """Strip a leading broadcast ``tile``; returns ``(var, tile_op or None)``."""
+    """Strip a leading broadcast ``tile`` off ``var``."""
     op = getattr(var, "op", None)
-    if op is not None and op.op_type == "tile" and _is_broadcast_tile(op):
-        return op.inputs["x"], op
-    return var, None
+    if op is not None and is_broadcast_tile(op):
+        return op.inputs["x"]
+    return var
 
 
 def _is_uniform_neg_inf(var) -> bool:
@@ -243,12 +223,12 @@ def _is_uniform_neg_inf(var) -> bool:
     return value is not None and math.isinf(value) and value < 0
 
 
-def _peel_predicate(var, ops):
+def _peel_predicate(var, readers):
     """Peel the layout/cast/``logical_not`` ops in front of a boolean predicate.
 
     Returns ``(var, negations)``; ``negations`` counts the ``logical_not`` ops
     that were peeled, so the caller can track the polarity. The peeled ops are
-    appended to ``ops``.
+    appended to ``readers``.
     """
     negations = 0
     while True:
@@ -258,11 +238,11 @@ def _peel_predicate(var, ops):
         if op.op_type == "logical_not":
             negations += 1
         elif op.op_type == "tile":
-            if not _is_broadcast_tile(op):
+            if not is_broadcast_tile(op):
                 break
         elif op.op_type not in _PREDICATE_LAYOUT_OPS:
             break
-        ops.append(op)
+        readers.append(op)
         var = op.inputs["x"]
     return var, negations
 
@@ -275,9 +255,11 @@ class _SafeSoftmax:
     that is ``select(row_is_all_neg_inf, 0.0, softmax(x))``.
     """
 
-    def __init__(self, select_op, ops):
+    def __init__(self, select_op, readers):
         self.select_op = select_op
-        self.ops = ops
+        # The ops of the wrapper that read the scores; `_match_backward` has to
+        # know about them so they do not look like consumers escaping the match.
+        self.readers = readers
 
 
 def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
@@ -294,14 +276,14 @@ def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
     a_zeros, b_zeros = uniform_scalar_value(a) == 0.0, uniform_scalar_value(b) == 0.0
     if a is weights and b_zeros:
         # The weights survive where the condition holds.
-        weights_when_true, zeros = True, b
+        weights_when_true = True
     elif b is weights and a_zeros:
-        weights_when_true, zeros = False, a
+        weights_when_true = False
     else:
         return None
 
-    ops = [select_op]
-    base, cond_negations = _peel_predicate(cond, ops)
+    readers = [select_op]
+    base, cond_negations = _peel_predicate(cond, readers)
 
     reduce_op = getattr(base, "op", None)
     if reduce_op is None or reduce_op.op_type not in ("reduce_max", "reduce_min"):
@@ -314,9 +296,9 @@ def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
     if axes is None or len(axes) != 1 or normalize_axis(axes[0], rank) != rank - 1:
         # The reduction has to be over the softmax axis to describe a "row".
         return None
-    ops.append(reduce_op)
+    readers.append(reduce_op)
 
-    inner, inner_negations = _peel_predicate(reduce_in, ops)
+    inner, inner_negations = _peel_predicate(reduce_in, readers)
     compare_op = getattr(inner, "op", None)
     if compare_op is None or compare_op.op_type not in ("equal", "not_equal"):
         return None
@@ -331,12 +313,12 @@ def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
         # The comparison may run on the pre-/post-cast version of the scores.
         scores_op, softmax_in_op = getattr(scores, "op", None), getattr(softmax_op.x, "op", None)
         if scores_op is not None and scores_op.op_type == "cast" and scores_op.inputs["x"] is softmax_op.x:
-            ops.append(scores_op)
+            readers.append(scores_op)
         elif softmax_in_op is not None and softmax_in_op.op_type == "cast" and softmax_in_op.inputs["x"] is scores:
             pass
         else:
             return None
-    ops.append(compare_op)
+    readers.append(compare_op)
 
     # -- polarity ------------------------------------------------------------
     # `element_is_neg_inf` after the comparison and the `logical_not`s below the
@@ -360,10 +342,7 @@ def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
     if weights_when_true != row_not_all_neg_inf:
         return None
 
-    zeros_op = getattr(zeros, "op", None)
-    if zeros_op is not None:
-        ops.append(zeros_op)
-    return _SafeSoftmax(select_op, ops)
+    return _SafeSoftmax(select_op, readers)
 
 
 def _safe_softmax_is_redundant(pattern) -> bool:
@@ -391,11 +370,11 @@ def _np_scalar(value: float, dtype):
     return np.float16(value) if dtype == types.fp16 else np.float32(value)
 
 
-def _as_sequence_major(var, needs_transpose: bool, before_op, name: str, peeled):
+def _as_sequence_major(var, needs_transpose: bool, before_op, name: str):
     """Return ``var``, or its last-two-axes transpose, as a ``[batch..., seq, E]`` tensor.
 
     When ``var`` is itself such a transpose it is peeled instead of stacking a
-    second one; the peeled op is appended to ``peeled`` so it can be collected.
+    second one.
     """
     if not needs_transpose:
         return var
@@ -406,7 +385,6 @@ def _as_sequence_major(var, needs_transpose: bool, before_op, name: str, peeled)
         if perm is not None and len(perm) == rank:
             perm = [normalize_axis(p, rank) for p in perm]
             if perm == _swap_last_two(rank):
-                peeled.append(op)
                 return op.inputs["x"]
     return mb.transpose(x=var, perm=_swap_last_two(rank), before_op=before_op, name=name)
 
@@ -421,7 +399,6 @@ class _Pattern:
         self.weights_var = None
         self.back_layout_ops = []       # matmul_0 -> softmax, in execution order
         self.fwd_layout_ops = []        # softmax -> matmul_1, in execution order
-        self.ops = [softmax_op]         # every matched op (removal candidates)
         self.mask_kind = None           # None | "select" | "add"
         self.mask_var = None            # the compact condition / additive mask
         self.mask_fill = None           # the `select` fill value
@@ -497,7 +474,6 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
 
         if op_type == "matmul":
             pattern.matmul_0 = op
-            pattern.ops.append(op)
             break
 
         if op_type == "cast":
@@ -545,7 +521,7 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
                 pattern.scale = 1.0 / divisor
                 next_var = op.inputs["x"]
             else:
-                operand = _uniform_const_operand(op)
+                operand = uniform_const_operand(op)
                 if operand is None or operand[0] <= 0:
                     return False
                 pattern.scale, next_var = operand
@@ -558,7 +534,6 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
             # score layout; only element-wise application is supported.
             return False
 
-        pattern.ops.append(op)
         consumer = op
         var = next_var
 
@@ -584,7 +559,6 @@ def _match_forward(softmax_op, pattern, safe_softmax=None) -> bool:
         if consumer.op_type == "matmul":
             pattern.matmul_1 = consumer
             pattern.weights_var = var
-            pattern.ops.append(consumer)
             break
         if consumer.op_type == "cast":
             if n_casts >= 2:
@@ -594,7 +568,6 @@ def _match_forward(softmax_op, pattern, safe_softmax=None) -> bool:
             fwd_ops.append(consumer)
         else:
             return False
-        pattern.ops.append(consumer)
         var = consumer.outputs[0]
 
     pattern.fwd_layout_ops = fwd_ops
@@ -785,9 +758,7 @@ def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
     # Peel the broadcast tile the converter emits for `select`; the compact
     # condition is what we want to re-layout. A tile that replicates a dimension
     # that is not 1 is a real tile, not a broadcast, and must be kept.
-    mask_var, tile_op = _peel_broadcast_tile(mask_var)
-    if tile_op is not None:
-        pattern.ops.append(tile_op)
+    mask_var = _peel_broadcast_tile(mask_var)
 
     mask = _mask_to_sdpa_space(
         mask_var, space, softmax_op.x.shape, seq_len, before_op, softmax_op.name + "_mask"
@@ -864,7 +835,7 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
     # make a difference. Its condition reads the scores, so the backward walk
     # has to know about those ops before it checks for escaping consumers.
     safe_softmax = _match_safe_softmax(softmax_op)
-    ignored = frozenset(id(op) for op in safe_softmax.ops) if safe_softmax is not None else frozenset()
+    ignored = frozenset(id(op) for op in safe_softmax.readers) if safe_softmax is not None else frozenset()
 
     pattern = _Pattern(softmax_op)
     if not _match_backward(softmax_op, pattern, ignored):
@@ -873,8 +844,6 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
         return False
     if not _match_forward(softmax_op, pattern, safe_softmax):
         return False
-    if safe_softmax is not None:
-        pattern.ops.extend(safe_softmax.ops)
 
     matmul_0, matmul_1 = pattern.matmul_0, pattern.matmul_1
     if bool(matmul_0.transpose_x.val) or bool(matmul_1.transpose_x.val):
@@ -909,11 +878,9 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
     else:
         return False
 
-    peeled = []
-    query = _as_sequence_major(query_src, query_t, matmul_1, softmax_op.name + "_query", peeled)
-    key = _as_sequence_major(key_src, key_t, matmul_1, softmax_op.name + "_key", peeled)
-    value = _as_sequence_major(value_src, value_t, matmul_1, softmax_op.name + "_value", peeled)
-    pattern.ops.extend(peeled)
+    query = _as_sequence_major(query_src, query_t, matmul_1, softmax_op.name + "_query")
+    key = _as_sequence_major(key_src, key_t, matmul_1, softmax_op.name + "_key")
+    value = _as_sequence_major(value_src, value_t, matmul_1, softmax_op.name + "_value")
 
     if not _validate_operands(query, key, value, space.n_batch):
         return False
@@ -986,7 +953,6 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
         return False
 
     block.replace_uses_of_var_after_op(anchor_op=matmul_1, old_var=old_var, new_var=attention)
-    remove_dead_ops(block, pattern.ops)
     return True
 
 
@@ -1005,12 +971,9 @@ def _fuse_attention_to_sdpa(block, finite_fill_mask: str) -> int:
         if op.op_type != "softmax":
             continue
         # `_try_fuse` may build some replacement ops before a late check makes it
-        # give up; drop those again so an aborted attempt leaves no trace.
-        existing = set(block.operations)
+        # give up; those are left dead in the block for `dead_code_elimination`.
         if _try_fuse(op, block, finite_fill_mask):
             fused += 1
-        else:
-            remove_dead_ops(block, [o for o in block.operations if o not in existing])
 
     return fused
 

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -65,9 +65,6 @@ _LAYOUT_OPS = frozenset({"reshape", "expand_dims", "squeeze", "transpose"})
 # A `select` fill at or below this value means "mask this key out".
 _MASK_FILL_THRESHOLD = -1e4
 
-# Tolerance when checking that a detected scale cancels SDPA's 1/sqrt(E).
-_SCALE_TOLERANCE = 1e-3
-
 # Ops that a boolean predicate may be routed through without changing which
 # rows it selects (a `tile` only when it merely broadcasts).
 _PREDICATE_LAYOUT_OPS = frozenset({"reshape", "expand_dims", "squeeze", "cast"})
@@ -936,7 +933,7 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
     # -- scale: SDPA always divides by sqrt(E) ------------------------------
     scale = 1.0 if pattern.scale is None else float(pattern.scale)
     factor = scale * math.sqrt(embedding)
-    if abs(factor - 1.0) >= _SCALE_TOLERANCE:
+    if factor != 1.0:
         query = mb.mul(
             x=query,
             y=_np_scalar(factor, query.dtype),

--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -34,7 +34,8 @@ _HALF_TOLERANCE = 1e-4
 _ONE_TOLERANCE = 1e-4
 # The erf argument must be -x/sqrt(2); the factor is compared with this tolerance.
 _FACTOR = -1.0 / math.sqrt(2.0)
-_FACTOR_TOLERANCE = 1e-3
+# Wide enough for fp16 rounding, but not for merely GELU-like formulae.
+_FACTOR_TOLERANCE = 1e-4
 
 # Upper bound on the number of scaling/negation ops peeled off the erf argument.
 # The converter emits at most two (a negate and a multiply); the bound just keeps

--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -1,0 +1,219 @@
+"""MIL pass: fuse the ``erfc`` spelling of the exact GELU into ``gelu(mode="EXACT")``.
+
+``jax.nn.gelu(x, approximate=False)`` is written as
+``0.5 * x * erfc(-x / sqrt(2))``. Together with the ``chlo.erfc`` composite
+handler (which emits ``1 - erf(...)``) the converter produces::
+
+    %h = mul(x=%x, y=0.5)
+    %n = sub(x=0.0, y=%x)
+    %s = mul(x=%n, y=0.70710677)     # -x / sqrt(2)
+    %e = erf(x=%s)
+    %c = sub(x=1.0, y=%e)
+    %o = mul(x=%h, y=%c)
+
+which is exactly ``gelu(x, mode="EXACT")``. coremltools' own ``fuse_gelu_exact``
+only recognises the algebraically equivalent but structurally different
+``0.5 * x * (1 + erf(x / sqrt(2)))`` form, so this pass complements it rather
+than duplicating it.
+"""
+
+import logging
+import math
+
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import remove_dead_ops, sole_consumer, uniform_scalar_value
+
+logger = logging.getLogger(__name__)
+
+# Absolute tolerances on the constants of the pattern.
+_HALF_TOLERANCE = 1e-4
+_ONE_TOLERANCE = 1e-4
+# The erf argument must be -x/sqrt(2); the factor is compared with this tolerance.
+_FACTOR = -1.0 / math.sqrt(2.0)
+_FACTOR_TOLERANCE = 1e-3
+
+# Upper bound on the number of scaling/negation ops peeled off the erf argument.
+# The converter emits at most two (a negate and a multiply); the bound just keeps
+# the search finite for hand-written graphs.
+_MAX_PEEL_DEPTH = 8
+
+
+def _other_operand(op, var):
+    """The operand of the binary ``op`` that is not ``var`` (``None`` if ``var`` is not one)."""
+    if op.x is var:
+        return op.y
+    if op.y is var:
+        return op.x
+    return None
+
+
+def _const_scaled_operand(op):
+    """Split a ``mul``/``real_div``/``sub`` op into ``(input_var, factor)``.
+
+    Recognises the ops that scale or negate a value by a compile-time constant:
+    ``mul(v, c)``/``mul(c, v)`` -> ``(v, c)``, ``real_div(v, c)`` -> ``(v, 1/c)``
+    and the negation ``sub(0, v)`` -> ``(v, -1)``. Returns ``None`` otherwise.
+    """
+    if op.op_type == "mul":
+        for operand in (op.x, op.y):
+            other = _other_operand(op, operand)
+            factor = uniform_scalar_value(other)
+            if factor is not None:
+                return operand, factor
+        return None
+
+    if op.op_type == "real_div":
+        divisor = uniform_scalar_value(op.y)
+        if divisor is not None and divisor != 0.0:
+            return op.x, 1.0 / divisor
+        return None
+
+    if op.op_type == "sub":
+        lhs = uniform_scalar_value(op.x)
+        if lhs is not None and abs(lhs) < 1e-12:
+            return op.y, -1.0
+        return None
+
+    return None
+
+
+def _peel_to_scaled_input(var, block):
+    """Walk back over constant scalings/negations, returning ``[(var, factor), ...]``.
+
+    The first entry is ``(var, 1.0)`` itself, then every prefix of the chain with
+    the accumulated factor: ``arg == entry_var * factor``.
+    """
+    chain = [(var, 1.0, [])]
+    factor = 1.0
+    ops = []
+    current = var
+    for _ in range(_MAX_PEEL_DEPTH):
+        op = current.op
+        if op is None or op.enclosing_block is not block:
+            break
+        if sole_consumer(current) is None:
+            # The intermediate value is used elsewhere; peeling further would
+            # leave the op in the graph anyway, and the rewrite must not change
+            # what that other consumer sees.
+            break
+        split = _const_scaled_operand(op)
+        if split is None:
+            break
+        current, step = split
+        factor *= step
+        ops = ops + [op]
+        chain.append((current, factor, ops))
+    return chain
+
+
+def _match_half_x(var, x, block) -> bool:
+    """True if ``var`` is ``0.5 * x``."""
+    op = var.op
+    if op is None or op.op_type != "mul" or op.enclosing_block is not block:
+        return False
+    other = _other_operand(op, x)
+    if other is None:
+        return False
+    half = uniform_scalar_value(other)
+    return half is not None and abs(half - 0.5) < _HALF_TOLERANCE
+
+
+def _match(mul_op, block):
+    """Return ``(x, ops)`` if ``mul_op`` computes ``0.5 * x * (1 - erf(-x/sqrt(2)))``."""
+    if mul_op.op_type != "mul":
+        return None
+
+    for complement in (mul_op.x, mul_op.y):
+        half_var = _other_operand(mul_op, complement)
+        if half_var is None or half_var is complement:
+            continue
+
+        sub_op = complement.op
+        if sub_op is None or sub_op.op_type != "sub" or sub_op.enclosing_block is not block:
+            continue
+        if sole_consumer(complement) is not mul_op:
+            continue
+        one = uniform_scalar_value(sub_op.x)
+        if one is None or abs(one - 1.0) > _ONE_TOLERANCE:
+            continue
+
+        erf_var = sub_op.y
+        erf_op = erf_var.op
+        if erf_op is None or erf_op.op_type != "erf" or erf_op.enclosing_block is not block:
+            continue
+        if sole_consumer(erf_var) is not sub_op:
+            continue
+
+        half_op = half_var.op
+        if half_op is None or half_op.enclosing_block is not block:
+            continue
+        if sole_consumer(half_var) is not mul_op:
+            continue
+
+        for candidate, factor, scale_ops in _peel_to_scaled_input(erf_op.x, block):
+            if abs(factor - _FACTOR) > _FACTOR_TOLERANCE:
+                continue
+            if not _match_half_x(half_var, candidate, block):
+                continue
+            return candidate, [mul_op, sub_op, erf_op, half_op, *scale_ops]
+
+    return None
+
+
+@block_context_manager
+def _fuse_gelu_erfc(block) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_gelu_erfc(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        match = _match(op, block)
+        if match is None:
+            continue
+        x, matched_ops = match
+
+        gelu = mb.gelu(x=x, mode="EXACT", before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
+        remove_dead_ops(block, matched_ops)
+        fused += 1
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_gelu_erfc(AbstractGraphPass):
+    """
+    Fuse ``0.5 * x * (1 - erf(k * x))`` with ``k == -1/sqrt(2)`` into
+    ``gelu(x, mode="EXACT")``.
+
+    ``k`` is recovered by peeling a chain of constant scalings (``mul``,
+    ``real_div``) and negations (``sub(0, .)``) off the ``erf`` argument until
+    the same var that feeds the ``0.5 *`` multiplication is reached. Every
+    intermediate value of the pattern must have exactly one consumer.
+
+    Given:
+        %1 = mul(x=%0, y=0.5)
+        %2 = sub(x=0.0, y=%0)
+        %3 = mul(x=%2, y=0.70710677)
+        %4 = erf(x=%3)
+        %5 = sub(x=1.0, y=%4)
+        %6 = mul(x=%1, y=%5)
+
+    Result:
+        %6 = gelu(x=%0, mode="EXACT")
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_gelu_erfc(f)
+            if fused:
+                logger.debug("fuse_gelu_erfc: fused %d exact GELU(s)", fused)

--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -25,7 +25,7 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import remove_dead_ops, sole_consumer, uniform_scalar_value
+from .pattern_utils import sole_consumer, uniform_const_operand, uniform_scalar_value
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +60,11 @@ def _const_scaled_operand(op):
     and the negation ``sub(0, v)`` -> ``(v, -1)``. Returns ``None`` otherwise.
     """
     if op.op_type == "mul":
-        for operand in (op.x, op.y):
-            other = _other_operand(op, operand)
-            factor = uniform_scalar_value(other)
-            if factor is not None:
-                return operand, factor
-        return None
+        scaled = uniform_const_operand(op)
+        if scaled is None:
+            return None
+        factor, operand = scaled
+        return operand, factor
 
     if op.op_type == "real_div":
         divisor = uniform_scalar_value(op.y)
@@ -88,9 +87,8 @@ def _peel_to_scaled_input(var, block):
     The first entry is ``(var, 1.0)`` itself, then every prefix of the chain with
     the accumulated factor: ``arg == entry_var * factor``.
     """
-    chain = [(var, 1.0, [])]
+    chain = [(var, 1.0)]
     factor = 1.0
-    ops = []
     current = var
     for _ in range(_MAX_PEEL_DEPTH):
         op = current.op
@@ -106,8 +104,7 @@ def _peel_to_scaled_input(var, block):
             break
         current, step = split
         factor *= step
-        ops = ops + [op]
-        chain.append((current, factor, ops))
+        chain.append((current, factor))
     return chain
 
 
@@ -116,15 +113,14 @@ def _match_half_x(var, x, block) -> bool:
     op = var.op
     if op is None or op.op_type != "mul" or op.enclosing_block is not block:
         return False
-    other = _other_operand(op, x)
-    if other is None:
+    scaled = uniform_const_operand(op)
+    if scaled is None or scaled[1] is not x:
         return False
-    half = uniform_scalar_value(other)
-    return half is not None and abs(half - 0.5) < _HALF_TOLERANCE
+    return abs(scaled[0] - 0.5) < _HALF_TOLERANCE
 
 
 def _match(mul_op, block):
-    """Return ``(x, ops)`` if ``mul_op`` computes ``0.5 * x * (1 - erf(-x/sqrt(2)))``."""
+    """Return ``x`` if ``mul_op`` computes ``0.5 * x * (1 - erf(-x/sqrt(2)))``."""
     if mul_op.op_type != "mul":
         return None
 
@@ -155,12 +151,12 @@ def _match(mul_op, block):
         if sole_consumer(half_var) is not mul_op:
             continue
 
-        for candidate, factor, scale_ops in _peel_to_scaled_input(erf_op.x, block):
+        for candidate, factor in _peel_to_scaled_input(erf_op.x, block):
             if abs(factor - _FACTOR) > _FACTOR_TOLERANCE:
                 continue
             if not _match_half_x(half_var, candidate, block):
                 continue
-            return candidate, [mul_op, sub_op, erf_op, half_op, *scale_ops]
+            return candidate
 
     return None
 
@@ -177,14 +173,12 @@ def _fuse_gelu_erfc(block) -> int:
         if len(op.blocks) > 0:
             continue
 
-        match = _match(op, block)
-        if match is None:
+        x = _match(op, block)
+        if x is None:
             continue
-        x, matched_ops = match
 
         gelu = mb.gelu(x=x, mode="EXACT", before_op=op, name=op.outputs[0].name)
         block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
-        remove_dead_ops(block, matched_ops)
         fused += 1
 
     return fused

--- a/stablehlo_coreml/passes/fuse_logit_softcap.py
+++ b/stablehlo_coreml/passes/fuse_logit_softcap.py
@@ -1,0 +1,172 @@
+"""MIL pass: fuse a "logit softcap" ``tanh`` sandwich into ``scaled_tanh``.
+
+Attention logit softcapping (Gemma-style) is written in JAX as
+``jnp.tanh(x / cap) * cap``, which the converter lowers to::
+
+    %1 = real_div(x=%x, y=30.0)     # or mul(x=%x, y=1/30)
+    %2 = tanh(x=%1)
+    %3 = mul(x=%2, y=30.0)
+
+MIL has a single op for that: ``scaled_tanh(x, alpha, beta) = alpha * tanh(beta * x)``.
+Fusing saves two elementwise passes over a (usually large) logits tensor.
+
+Only the exact ``alpha * beta ~= 1`` shape is fused -- i.e. a genuine softcap,
+where the composition is the identity for small ``x``. A general
+``a * tanh(b * x)`` would also be expressible as ``scaled_tanh``, but scaling by
+an arbitrary constant is not necessarily a softcap and is left alone so that the
+pass stays a targeted, easily reviewable rewrite.
+"""
+
+import logging
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import remove_dead_ops, sole_consumer, uniform_scalar_value
+
+logger = logging.getLogger(__name__)
+
+# Absolute tolerance on `alpha * beta == 1`.
+_TOLERANCE = 1e-4
+
+
+def _scalar_operand(op, other):
+    """Return the uniform constant value of the operand of ``op`` that is not ``other``.
+
+    ``None`` when ``other`` is not an operand, when the other operand is not a
+    uniform compile-time constant, or when it is not rank-0/1 (a constant with a
+    real shape would broadcast the output, which ``scaled_tanh`` cannot do).
+    """
+    x, y = op.x, op.y
+    if x is other:
+        const = y
+    elif y is other:
+        const = x
+    else:
+        return None
+
+    if const.shape is not None and int(np.prod(const.shape)) != 1:
+        return None
+    return uniform_scalar_value(const)
+
+
+def _inner_scale(tanh_op):
+    """Return ``(x, beta)`` for ``tanh(x * beta)``, peeling a ``mul``/``real_div`` by a constant."""
+    inner = tanh_op.x.op
+    if inner is None or inner.enclosing_block is not tanh_op.enclosing_block:
+        return tanh_op.x, 1.0
+    if sole_consumer(tanh_op.x) is not tanh_op:
+        # The scaled value is used elsewhere, so removing the scaling op would
+        # not pay off (and it has to stay in the graph anyway).
+        return tanh_op.x, 1.0
+
+    if inner.op_type == "mul":
+        for operand in (inner.x, inner.y):
+            beta = _scalar_operand(inner, operand)
+            if beta is not None:
+                return operand, beta
+        return tanh_op.x, 1.0
+
+    if inner.op_type == "real_div":
+        # Only `x / c` is a scaling; `c / x` is not.
+        divisor = _scalar_operand(inner, inner.x)
+        if divisor is not None and divisor != 0.0:
+            return inner.x, 1.0 / divisor
+
+    return tanh_op.x, 1.0
+
+
+def _match(mul_op, block):
+    """Return ``(x, alpha, beta, ops)`` if ``mul_op`` completes a softcap pattern."""
+    if mul_op.op_type != "mul":
+        return None
+
+    for tanh_var in (mul_op.x, mul_op.y):
+        tanh_op = tanh_var.op
+        if tanh_op is None or tanh_op.op_type != "tanh":
+            continue
+        if tanh_op.enclosing_block is not block:
+            continue
+        # The tanh result must feed nothing but this multiplication.
+        if sole_consumer(tanh_var) is not mul_op:
+            continue
+
+        alpha = _scalar_operand(mul_op, tanh_var)
+        if alpha is None:
+            continue
+
+        x, beta = _inner_scale(tanh_op)
+        if abs(alpha * beta - 1.0) > _TOLERANCE:
+            continue
+
+        ops = [mul_op, tanh_op]
+        scale_op = tanh_op.x.op
+        if x is not tanh_op.x and scale_op is not None:
+            ops.append(scale_op)
+        return x, alpha, beta, ops
+
+    return None
+
+
+@block_context_manager
+def _fuse_logit_softcap(block) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_logit_softcap(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        match = _match(op, block)
+        if match is None:
+            continue
+        x, alpha, beta, matched_ops = match
+
+        # `alpha`/`beta` are `const T`, with T the element type of `x`.
+        dtype = types.nptype_from_builtin(x.dtype)
+        capped = mb.scaled_tanh(
+            x=x,
+            alpha=dtype(alpha),
+            beta=dtype(beta),
+            before_op=op,
+            name=op.outputs[0].name,
+        )
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=capped)
+        remove_dead_ops(block, matched_ops)
+        fused += 1
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_logit_softcap(AbstractGraphPass):
+    """
+    Fuse ``alpha * tanh(x * beta)`` (with ``alpha * beta == 1``) into
+    ``scaled_tanh(x, alpha, beta)``.
+
+    Both operand orders of the multiplications are accepted, and the inner
+    scaling may be written as ``mul(x, beta)`` or ``real_div(x, 1/beta)``.
+    The scaling constants must be uniform, single-element, compile-time
+    constants, and the ``tanh`` output must have exactly one consumer.
+
+    Given:
+        %1 = real_div(x=%0, y=30.0)
+        %2 = tanh(x=%1)
+        %3 = mul(x=%2, y=30.0)
+
+    Result:
+        %3 = scaled_tanh(x=%0, alpha=30.0, beta=0.0333)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_logit_softcap(f)
+            if fused:
+                logger.debug("fuse_logit_softcap: fused %d softcap(s)", fused)

--- a/stablehlo_coreml/passes/fuse_logit_softcap.py
+++ b/stablehlo_coreml/passes/fuse_logit_softcap.py
@@ -26,7 +26,7 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import remove_dead_ops, sole_consumer, uniform_scalar_value
+from .pattern_utils import sole_consumer, uniform_const_operand
 
 logger = logging.getLogger(__name__)
 
@@ -34,24 +34,22 @@ logger = logging.getLogger(__name__)
 _TOLERANCE = 1e-4
 
 
-def _scalar_operand(op, other):
-    """Return the uniform constant value of the operand of ``op`` that is not ``other``.
+def _scalar_operand(op):
+    """Like :func:`uniform_const_operand`, but only for single-element constants.
 
-    ``None`` when ``other`` is not an operand, when the other operand is not a
-    uniform compile-time constant, or when it is not rank-0/1 (a constant with a
-    real shape would broadcast the output, which ``scaled_tanh`` cannot do).
+    Returns ``(const_value, other_var)``, or ``None`` when no operand is a
+    uniform compile-time constant or when that constant is not rank-0/1 (a
+    constant with a real shape would broadcast the output, which ``scaled_tanh``
+    cannot do).
     """
-    x, y = op.x, op.y
-    if x is other:
-        const = y
-    elif y is other:
-        const = x
-    else:
+    operand = uniform_const_operand(op)
+    if operand is None:
         return None
-
+    value, other = operand
+    const = op.y if op.x is other else op.x
     if const.shape is not None and int(np.prod(const.shape)) != 1:
         return None
-    return uniform_scalar_value(const)
+    return value, other
 
 
 def _inner_scale(tanh_op):
@@ -65,23 +63,23 @@ def _inner_scale(tanh_op):
         return tanh_op.x, 1.0
 
     if inner.op_type == "mul":
-        for operand in (inner.x, inner.y):
-            beta = _scalar_operand(inner, operand)
-            if beta is not None:
-                return operand, beta
+        scalar = _scalar_operand(inner)
+        if scalar is not None:
+            beta, operand = scalar
+            return operand, beta
         return tanh_op.x, 1.0
 
     if inner.op_type == "real_div":
         # Only `x / c` is a scaling; `c / x` is not.
-        divisor = _scalar_operand(inner, inner.x)
-        if divisor is not None and divisor != 0.0:
-            return inner.x, 1.0 / divisor
+        scalar = _scalar_operand(inner)
+        if scalar is not None and scalar[1] is inner.x and scalar[0] != 0.0:
+            return inner.x, 1.0 / scalar[0]
 
     return tanh_op.x, 1.0
 
 
 def _match(mul_op, block):
-    """Return ``(x, alpha, beta, ops)`` if ``mul_op`` completes a softcap pattern."""
+    """Return ``(x, alpha, beta)`` if ``mul_op`` completes a softcap pattern."""
     if mul_op.op_type != "mul":
         return None
 
@@ -95,19 +93,16 @@ def _match(mul_op, block):
         if sole_consumer(tanh_var) is not mul_op:
             continue
 
-        alpha = _scalar_operand(mul_op, tanh_var)
-        if alpha is None:
+        scalar = _scalar_operand(mul_op)
+        if scalar is None or scalar[1] is not tanh_var:
             continue
+        alpha = scalar[0]
 
         x, beta = _inner_scale(tanh_op)
         if abs(alpha * beta - 1.0) > _TOLERANCE:
             continue
 
-        ops = [mul_op, tanh_op]
-        scale_op = tanh_op.x.op
-        if x is not tanh_op.x and scale_op is not None:
-            ops.append(scale_op)
-        return x, alpha, beta, ops
+        return x, alpha, beta
 
     return None
 
@@ -127,7 +122,7 @@ def _fuse_logit_softcap(block) -> int:
         match = _match(op, block)
         if match is None:
             continue
-        x, alpha, beta, matched_ops = match
+        x, alpha, beta = match
 
         # `alpha`/`beta` are `const T`, with T the element type of `x`.
         dtype = types.nptype_from_builtin(x.dtype)
@@ -139,7 +134,6 @@ def _fuse_logit_softcap(block) -> int:
             name=op.outputs[0].name,
         )
         block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=capped)
-        remove_dead_ops(block, matched_ops)
         fused += 1
 
     return fused

--- a/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
+++ b/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
@@ -1,0 +1,177 @@
+"""MIL pass: fold a keep-dims ``reshape`` back into the reduction that feeds it.
+
+StableHLO's ``reduce`` always drops the reduced dimensions, so JAX's
+``jnp.sum(x, axis, keepdims=True)`` lowers to a ``reduce`` followed by a
+``broadcast_in_dim`` that re-inserts the size-1 axes. The converter turns that
+into::
+
+    %r = reduce_sum(x=%x, axes=[2], keep_dims=False)   # (2, 8)
+    %o = reshape(x=%r, shape=[2, 8, 1])                # (2, 8, 1)
+
+which is exactly ``reduce_sum(x=%x, axes=[2], keep_dims=True)``. Rewriting it
+into that single op is not just cosmetic: several of coremltools' own fusions
+(``fuse_reduce_mean``, ``fuse_layernorm_or_instancenorm``) require the reduction
+to be directly followed by the arithmetic that consumes it, and the intervening
+``reshape`` blocks them. With this pass in place an RMSNorm
+(``x * rsqrt(mean(x**2, -1, keepdims=True) + eps)``) becomes a ``reduce_mean``.
+"""
+
+import logging
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import remove_dead_ops, shapes_equal
+
+logger = logging.getLogger(__name__)
+
+# The MIL reduction ops whose builder takes an `axes` + `keep_dims` pair.
+# The arg-reductions (`reduce_argmax`/`reduce_argmin`) take a single `axis` and
+# are deliberately not part of this list.
+_REDUCE_OPS = frozenset({
+    "reduce_sum",
+    "reduce_mean",
+    "reduce_max",
+    "reduce_min",
+    "reduce_prod",
+    "reduce_l1_norm",
+    "reduce_l2_norm",
+    "reduce_log_sum",
+    "reduce_log_sum_exp",
+    "reduce_sum_square",
+})
+
+
+def _reduced_axes(reduce_op) -> list[int] | None:
+    """Return the (non-negative, deduplicated) axes of ``reduce_op``, or ``None``.
+
+    ``None`` is returned when the input rank or the axes are not known at
+    compile time. An absent `axes` input means "reduce every axis".
+    """
+    x_shape = reduce_op.x.shape
+    if x_shape is None:
+        return None
+    rank = len(x_shape)
+
+    axes_var = reduce_op.inputs.get("axes")
+    if axes_var is None:
+        return list(range(rank))
+    if axes_var.val is None:
+        return None
+
+    axes = {int(axis) % rank for axis in np.asarray(axes_var.val).reshape(-1).tolist()}
+    return sorted(axes)
+
+
+def _keep_dims_shape(x_shape, axes: list[int]) -> tuple:
+    shape = list(x_shape)
+    for axis in axes:
+        shape[axis] = 1
+    return tuple(shape)
+
+
+def _match(reshape_op, block):
+    """Return ``(reduce_op, axes)`` if ``reshape_op`` only re-inserts the reduced axes."""
+    if reshape_op.op_type != "reshape":
+        return None
+
+    reduce_op = reshape_op.x.op
+    if reduce_op is None or reduce_op.op_type not in _REDUCE_OPS:
+        return None
+    if reduce_op.enclosing_block is not block:
+        return None
+
+    keep_dims = reduce_op.inputs.get("keep_dims")
+    if keep_dims is None or keep_dims.val is None or bool(keep_dims.val):
+        # `keep_dims=True` already, or not known at compile time.
+        return None
+
+    axes = _reduced_axes(reduce_op)
+    if axes is None:
+        return None
+
+    # The reshape output must be exactly the input shape with 1s at the reduced
+    # axes. Comparing the *output shape* (rather than the `shape` operand) is
+    # both symbolic-aware and robust against `-1`/`0` entries in `shape`.
+    # Because `keep_dims=False` only deletes those axes, re-inserting them is
+    # always an order-preserving reshape, so matching shapes implies identity.
+    target = _keep_dims_shape(reduce_op.x.shape, axes)
+    if not shapes_equal(target, reshape_op.outputs[0].shape):
+        return None
+
+    return reduce_op, axes
+
+
+@block_context_manager
+def _fuse_reduce_keep_dims(block) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_reduce_keep_dims(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        match = _match(op, block)
+        if match is None:
+            continue
+        reduce_op, axes = match
+
+        # A fresh reduction with `keep_dims=True` replaces the reshape. The
+        # original reduction is left in place; it is removed below only if the
+        # reshape was its sole consumer (otherwise the other consumers, which
+        # expect the squeezed shape, keep using it).
+        keep_dims_var = getattr(mb, reduce_op.op_type)(
+            x=reduce_op.x,
+            axes=axes,
+            keep_dims=True,
+            before_op=op,
+            name=op.outputs[0].name,
+        )
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=keep_dims_var,
+        )
+        remove_dead_ops(block, [op, reduce_op])
+        fused += 1
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_reduce_keep_dims(AbstractGraphPass):
+    """
+    Fuse ``reduce_*(keep_dims=False) -> reshape(<keep-dims shape>)`` into a
+    single ``reduce_*(keep_dims=True)``.
+
+    The rewrite applies when
+
+    1. the reduce is one of the ops whose builder takes ``axes`` + ``keep_dims``
+       (the arg-reductions are excluded),
+    2. ``axes`` is known at compile time, and
+    3. the reshape output shape is exactly the reduce input shape with the
+       reduced axes set to 1 (compared symbolically, so dynamic dimensions are
+       preserved).
+
+    When the reduce has consumers besides the reshape it is kept for them and
+    only the reshape is replaced.
+
+    Given:
+        %1 = reduce_sum(x=%0, axes=[2], keep_dims=False)   # %0: (2, 8, 16)
+        %2 = reshape(x=%1, shape=[2, 8, 1])
+
+    Result:
+        %2 = reduce_sum(x=%0, axes=[2], keep_dims=True)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_reduce_keep_dims(f)
+            if fused:
+                logger.debug("fuse_reduce_keep_dims: fused %d reduce/reshape pair(s)", fused)

--- a/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
+++ b/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
@@ -24,7 +24,7 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import remove_dead_ops, shapes_equal
+from .pattern_utils import shapes_equal
 
 logger = logging.getLogger(__name__)
 
@@ -123,9 +123,10 @@ def _fuse_reduce_keep_dims(block) -> int:
         reduce_op, axes = match
 
         # A fresh reduction with `keep_dims=True` replaces the reshape. The
-        # original reduction is left in place; it is removed below only if the
-        # reshape was its sole consumer (otherwise the other consumers, which
-        # expect the squeezed shape, keep using it).
+        # original reduction is left in place; if the reshape was its sole
+        # consumer it becomes dead and `dead_code_elimination` picks it up
+        # (otherwise the other consumers, which expect the squeezed shape, keep
+        # using it).
         keep_dims_var = getattr(mb, reduce_op.op_type)(
             x=reduce_op.x,
             axes=axes,
@@ -138,7 +139,6 @@ def _fuse_reduce_keep_dims(block) -> int:
             old_var=op.outputs[0],
             new_var=keep_dims_var,
         )
-        remove_dead_ops(block, [op, reduce_op])
         fused += 1
 
     return fused

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -1,0 +1,282 @@
+"""Shared helpers for the stablehlo-coreml MIL graph passes.
+
+The passes in this package all have to deal with the same handful of problems:
+
+* recognising constants that hold a single repeated value (either a ``const``
+  or a ``fill`` op),
+* comparing shapes that may contain symbolic (sympy) dimensions,
+* checking that a pattern is safe to rewrite (no consumers outside the match),
+* and cleaning up the ops that became dead after a rewrite.
+
+Everything in here is intentionally conservative: whenever a property cannot be
+proven (typically because a dimension is symbolic) the helpers report the
+"unknown" answer (``None``/``False``) so that callers skip the optimization.
+"""
+
+import numpy as np
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+__all__ = [
+    "broadcast_shapes",
+    "const_int_list",
+    "dims_equal",
+    "is_large_negative",
+    "is_neg_inf",
+    "normalize_axis",
+    "peel_back",
+    "producer_ops",
+    "remove_dead_ops",
+    "shapes_equal",
+    "sole_consumer",
+    "uniform_scalar_value",
+]
+
+
+def uniform_scalar_value(var) -> float | None:
+    """Return the value of ``var`` if it is a constant with all elements equal.
+
+    Handles both plain constants (``var.val``) and ``fill`` ops whose ``value``
+    is such a constant. Returns ``None`` if the value is not known at
+    compile time, is empty, or is not uniform.
+    """
+    if var is None:
+        return None
+
+    val = getattr(var, "val", None)
+    if val is None:
+        op = getattr(var, "op", None)
+        if op is not None and op.op_type == "fill":
+            return uniform_scalar_value(op.inputs.get("value"))
+        return None
+
+    arr = np.asarray(val)
+    if arr.size == 0:
+        return None
+    flat = arr.reshape(-1)
+    first = flat[0]
+    # NaN never compares equal to itself, so handle it explicitly.
+    if np.issubdtype(arr.dtype, np.floating) and np.isnan(first):
+        return None
+    if arr.size > 1 and not bool(np.all(flat == first)):
+        return None
+    return float(first)
+
+
+def is_neg_inf(var) -> bool:
+    """True if ``var`` is a uniform constant that acts as negative infinity.
+
+    Values at or below ``-3e38`` (below the fp32 range) are treated as -inf,
+    matching how JAX materialises the softmax/masking constants.
+    """
+    value = uniform_scalar_value(var)
+    return value is not None and value <= -3e38
+
+
+def is_large_negative(var, threshold: float = -1e4) -> bool:
+    """True if ``var`` is a uniform constant ``<= threshold`` (e.g. a -1e9 mask fill)."""
+    value = uniform_scalar_value(var)
+    return value is not None and value <= threshold
+
+
+def dims_equal(a, b) -> bool:
+    """Structural equality of two shape dimensions, symbolic-aware.
+
+    A symbolic dimension is only equal to the very same symbol; a symbolic
+    dimension is never considered equal to a concrete one (it might happen to
+    take that value at runtime, but we cannot prove it).
+    """
+    a_symbolic, b_symbolic = is_symbolic(a), is_symbolic(b)
+    if a_symbolic != b_symbolic:
+        return False
+    if a_symbolic:
+        return bool(a == b)
+    return int(a) == int(b)
+
+
+def shapes_equal(a, b) -> bool:
+    """Structural, symbolic-aware equality of two shapes."""
+    if a is None or b is None:
+        return False
+    a, b = tuple(a), tuple(b)
+    if len(a) != len(b):
+        return False
+    return all(dims_equal(x, y) for x, y in zip(a, b))
+
+
+def _broadcast_dims(a, b):
+    """NumPy broadcast of two dimensions. Returns ``None`` when not provable."""
+    a_symbolic, b_symbolic = is_symbolic(a), is_symbolic(b)
+    if a_symbolic and b_symbolic:
+        return a if bool(a == b) else None
+    if a_symbolic:
+        # A symbolic dim only broadcasts provably against a literal 1.
+        return a if int(b) == 1 else None
+    if b_symbolic:
+        return b if int(a) == 1 else None
+    a, b = int(a), int(b)
+    if a == b:
+        return a
+    if a == 1:
+        return b
+    if b == 1:
+        return a
+    return None
+
+
+def broadcast_shapes(*shapes):
+    """NumPy-style broadcast of the given shapes, symbolic-aware.
+
+    Returns the broadcast shape as a tuple, or ``None`` if the shapes are
+    incompatible or the result cannot be determined (e.g. a symbolic dimension
+    broadcast against a concrete dimension != 1).
+    """
+    if len(shapes) == 0:
+        return ()
+    result = tuple(shapes[0])
+    for shape in shapes[1:]:
+        shape = tuple(shape)
+        rank = max(len(result), len(shape))
+        lhs = (1,) * (rank - len(result)) + result
+        rhs = (1,) * (rank - len(shape)) + shape
+        merged = []
+        for a, b in zip(lhs, rhs):
+            dim = _broadcast_dims(a, b)
+            if dim is None:
+                return None
+            merged.append(dim)
+        result = tuple(merged)
+    return result
+
+
+def const_int_list(var) -> list[int] | None:
+    """Return ``var``'s value as a flat list of ints, or ``None`` if not a constant."""
+    if var is None:
+        return None
+    val = getattr(var, "val", None)
+    if val is None:
+        return None
+    arr = np.asarray(val).reshape(-1)
+    if not np.issubdtype(arr.dtype, np.integer):
+        if not np.issubdtype(arr.dtype, np.floating):
+            return None
+        if not bool(np.all(arr == np.round(arr))):
+            return None
+    return [int(v) for v in arr]
+
+
+def normalize_axis(axis: int, rank: int) -> int | None:
+    """Turn a possibly negative axis into a non-negative one, or ``None`` if out of range."""
+    if rank <= 0:
+        return None
+    axis = int(axis)
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        return None
+    return axis
+
+
+def peel_back(var, op_types, max_ops: int | None = None):
+    """Walk backward through single-input ops whose type is in ``op_types``.
+
+    Returns ``(var, ops)`` where ``ops`` are the peeled ops in the order they
+    were encountered (i.e. from the consumer side towards the producer side).
+    """
+    ops = []
+    while True:
+        if max_ops is not None and len(ops) >= max_ops:
+            break
+        op = getattr(var, "op", None)
+        if op is None or op.op_type not in op_types:
+            break
+        x = op.inputs.get("x")
+        if x is None:
+            break
+        ops.append(op)
+        var = x
+    return var, ops
+
+
+def sole_consumer(var, ignored=()):
+    """Return the single consumer op of ``var``, or ``None``.
+
+    ``None`` is returned when ``var`` has zero or more than one consumer, or
+    when it escapes the pattern by being an output of its enclosing block.
+    Consumers whose ``id()`` is in ``ignored`` do not count; callers use that to
+    exempt ops they already matched as part of the same pattern.
+    """
+    if var is None:
+        return None
+    op = getattr(var, "op", None)
+    if op is not None:
+        block = op.enclosing_block
+        if block is not None and var in block.outputs:
+            return None
+    child_ops = [child for child in var.child_ops if id(child) not in ignored]
+    if len(child_ops) != 1:
+        return None
+    return child_ops[0]
+
+
+def producer_ops(var, max_ops: int = 32) -> list:
+    """Collect the ops that (transitively) produce ``var``, breadth first.
+
+    Useful to hand :func:`remove_dead_ops` the whole cone behind a rewritten
+    value: it only removes the ops that actually became dead, so passing extra
+    candidates is harmless.
+    """
+    collected = []
+    seen = set()
+    queue = [var]
+    while queue and len(collected) < max_ops:
+        current = queue.pop(0)
+        op = getattr(current, "op", None)
+        if op is None or id(op) in seen:
+            continue
+        seen.add(id(op))
+        collected.append(op)
+        for value in op.inputs.values():
+            if isinstance(value, (list, tuple)):
+                queue.extend(value)
+            else:
+                queue.append(value)
+    return collected
+
+
+def _is_dead(op) -> bool:
+    block = op.enclosing_block
+    if block is None:
+        return False
+    for out in op.outputs:
+        if len(out.child_ops) > 0:
+            return False
+        if out in block.outputs:
+            return False
+    return True
+
+
+def remove_dead_ops(block, ops) -> int:
+    """Remove the ops in ``ops`` that became dead, repeatedly, and return the count.
+
+    ``ops`` is a list of candidate ops (typically the ops that were matched by a
+    pattern). Only candidates whose outputs have no remaining consumers and that
+    are not block outputs are removed; the removal is repeated until a fixed
+    point so that whole chains disappear. Anything left over is picked up by
+    coremltools' ``dead_code_elimination`` later in the pipeline.
+    """
+    candidates = [op for op in ops if op is not None and op.enclosing_block is block]
+    removed = 0
+    changed = True
+    while changed:
+        changed = False
+        for op in list(candidates):
+            if op.enclosing_block is None:
+                # Already removed from the graph.
+                candidates.remove(op)
+                continue
+            if _is_dead(op):
+                op.remove_from_block()
+                candidates.remove(op)
+                removed += 1
+                changed = True
+    return removed

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -5,8 +5,8 @@ The passes in this package all have to deal with the same handful of problems:
 * recognising constants that hold a single repeated value (either a ``const``
   or a ``fill`` op),
 * comparing shapes that may contain symbolic (sympy) dimensions,
-* checking that a pattern is safe to rewrite (no consumers outside the match),
-* and cleaning up the ops that became dead after a rewrite.
+* and checking that a pattern is safe to rewrite (no consumers outside the
+  match).
 
 Everything in here is intentionally conservative: whenever a property cannot be
 proven (typically because a dimension is symbolic) the helpers report the
@@ -20,14 +20,11 @@ __all__ = [
     "broadcast_shapes",
     "const_int_list",
     "dims_equal",
-    "is_large_negative",
-    "is_neg_inf",
+    "is_broadcast_tile",
     "normalize_axis",
-    "peel_back",
-    "producer_ops",
-    "remove_dead_ops",
     "shapes_equal",
     "sole_consumer",
+    "uniform_const_operand",
     "uniform_scalar_value",
 ]
 
@@ -62,20 +59,19 @@ def uniform_scalar_value(var) -> float | None:
     return float(first)
 
 
-def is_neg_inf(var) -> bool:
-    """True if ``var`` is a uniform constant that acts as negative infinity.
+def uniform_const_operand(op):
+    """For a binary op, return ``(const_value, other_var)``, or ``None``.
 
-    Values at or below ``-3e38`` (below the fp32 range) are treated as -inf,
-    matching how JAX materialises the softmax/masking constants.
+    The pair is only returned when exactly one of ``x``/``y`` is a compile-time
+    constant with all elements equal (see :func:`uniform_scalar_value`).
     """
-    value = uniform_scalar_value(var)
-    return value is not None and value <= -3e38
-
-
-def is_large_negative(var, threshold: float = -1e4) -> bool:
-    """True if ``var`` is a uniform constant ``<= threshold`` (e.g. a -1e9 mask fill)."""
-    value = uniform_scalar_value(var)
-    return value is not None and value <= threshold
+    x, y = op.inputs["x"], op.inputs["y"]
+    x_val, y_val = uniform_scalar_value(x), uniform_scalar_value(y)
+    if x_val is not None and y_val is None:
+        return x_val, y
+    if y_val is not None and x_val is None:
+        return y_val, x
+    return None
 
 
 def dims_equal(a, b) -> bool:
@@ -176,27 +172,6 @@ def normalize_axis(axis: int, rank: int) -> int | None:
     return axis
 
 
-def peel_back(var, op_types, max_ops: int | None = None):
-    """Walk backward through single-input ops whose type is in ``op_types``.
-
-    Returns ``(var, ops)`` where ``ops`` are the peeled ops in the order they
-    were encountered (i.e. from the consumer side towards the producer side).
-    """
-    ops = []
-    while True:
-        if max_ops is not None and len(ops) >= max_ops:
-            break
-        op = getattr(var, "op", None)
-        if op is None or op.op_type not in op_types:
-            break
-        x = op.inputs.get("x")
-        if x is None:
-            break
-        ops.append(op)
-        var = x
-    return var, ops
-
-
 def sole_consumer(var, ignored=()):
     """Return the single consumer op of ``var``, or ``None``.
 
@@ -218,65 +193,18 @@ def sole_consumer(var, ignored=()):
     return child_ops[0]
 
 
-def producer_ops(var, max_ops: int = 32) -> list:
-    """Collect the ops that (transitively) produce ``var``, breadth first.
+def is_broadcast_tile(op) -> bool:
+    """True if ``op`` is a ``tile`` that only replicates size-1 dimensions.
 
-    Useful to hand :func:`remove_dead_ops` the whole cone behind a rewritten
-    value: it only removes the ops that actually became dead, so passing extra
-    candidates is harmless.
+    A tile of a dimension that is not 1 is *not* a broadcast:
+    ``tile([1, 2], reps=[2]) == [1, 2, 1, 2]`` cannot be expressed by implicit
+    broadcasting. ``reps`` must be known at compile time and match the input rank.
     """
-    collected = []
-    seen = set()
-    queue = [var]
-    while queue and len(collected) < max_ops:
-        current = queue.pop(0)
-        op = getattr(current, "op", None)
-        if op is None or id(op) in seen:
-            continue
-        seen.add(id(op))
-        collected.append(op)
-        for value in op.inputs.values():
-            if isinstance(value, (list, tuple)):
-                queue.extend(value)
-            else:
-                queue.append(value)
-    return collected
-
-
-def _is_dead(op) -> bool:
-    block = op.enclosing_block
-    if block is None:
+    if op.op_type != "tile":
         return False
-    for out in op.outputs:
-        if len(out.child_ops) > 0:
-            return False
-        if out in block.outputs:
-            return False
-    return True
-
-
-def remove_dead_ops(block, ops) -> int:
-    """Remove the ops in ``ops`` that became dead, repeatedly, and return the count.
-
-    ``ops`` is a list of candidate ops (typically the ops that were matched by a
-    pattern). Only candidates whose outputs have no remaining consumers and that
-    are not block outputs are removed; the removal is repeated until a fixed
-    point so that whole chains disappear. Anything left over is picked up by
-    coremltools' ``dead_code_elimination`` later in the pipeline.
-    """
-    candidates = [op for op in ops if op is not None and op.enclosing_block is block]
-    removed = 0
-    changed = True
-    while changed:
-        changed = False
-        for op in list(candidates):
-            if op.enclosing_block is None:
-                # Already removed from the graph.
-                candidates.remove(op)
-                continue
-            if _is_dead(op):
-                op.remove_from_block()
-                candidates.remove(op)
-                removed += 1
-                changed = True
-    return removed
+    reps = const_int_list(op.inputs.get("reps"))
+    x_shape = op.inputs["x"].shape
+    if reps is None or x_shape is None or len(reps) != len(x_shape):
+        return False
+    # `dim` may be symbolic; only a literal 1 is safe to broadcast.
+    return all(rep == 1 or dims_equal(dim, 1) for dim, rep in zip(x_shape, reps))

--- a/stablehlo_coreml/passes/remove_broadcast_tiles.py
+++ b/stablehlo_coreml/passes/remove_broadcast_tiles.py
@@ -1,0 +1,171 @@
+"""MIL pass: remove ``tile`` ops that only implement NumPy broadcasting.
+
+StableHLO requires all operands of an elementwise op to have the exact same
+shape, so ``broadcast_in_dim`` is lowered to ``reshape (-> reshape) -> tile``.
+MIL's elementwise ops broadcast natively, so those tiles are pure overhead --
+and if a tile of a constant survives until ``const_elimination`` it is folded
+into a full-size constant tensor (this is how exports end up with gigabytes of
+constant weights). The pass therefore runs before the first
+``const_elimination`` in the pipeline.
+"""
+
+import logging
+
+import numpy as np
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import broadcast_shapes, dims_equal, shapes_equal
+
+logger = logging.getLogger(__name__)
+
+# Ops that support implicit NumPy-style broadcasting of their operands.
+#
+# `select` is deliberately EXCLUDED: E5RT (Apple's CoreML runtime) cannot
+# propagate shapes through a `select` with implicit broadcasting when the model
+# is loaded as a multifunction .mlpackage. It fails with
+#   "Failed to PropagateInputTensorShapes: Validation error during type
+#    inference for select: Incompatible Dimension"
+# so tiles feeding a `select` must be preserved.
+_BROADCAST_OPS = frozenset({
+    "add", "sub", "mul", "real_div",
+    "maximum", "minimum",
+    "equal", "not_equal", "less", "less_equal", "greater", "greater_equal",
+    "logical_and", "logical_or", "logical_xor",
+    "pow", "floor_div", "mod",
+})
+
+# The operand names of the (binary) ops above.
+_BINARY_OPERANDS = ("x", "y")
+
+
+def _is_broadcast_tile(op) -> bool:
+    """True if ``op`` is a ``tile`` that only replicates size-1 dimensions.
+
+    A tile of a dimension that is not 1 is *not* a broadcast:
+    ``tile([1, 2], reps=[2]) == [1, 2, 1, 2]`` cannot be expressed by implicit
+    broadcasting. ``reps`` must be known at compile time.
+    """
+    if op.op_type != "tile":
+        return False
+
+    reps_var = op.inputs.get("reps")
+    if reps_var is None or reps_var.val is None:
+        return False
+    reps = np.asarray(reps_var.val).reshape(-1).tolist()
+
+    x_shape = op.x.shape
+    if x_shape is None or len(reps) != len(x_shape):
+        return False
+
+    for dim, rep in zip(x_shape, reps):
+        if int(rep) == 1:
+            continue
+        # `dim` may be symbolic; only a literal 1 is safe to broadcast.
+        if dims_equal(dim, 1):
+            continue
+        return False
+    return True
+
+
+def _consumer_output_is_unchanged(consumer, tile_out, tile_in) -> bool:
+    """True if replacing ``tile_out`` by ``tile_in`` keeps ``consumer``'s output shape."""
+    operand_shapes = []
+    for name in _BINARY_OPERANDS:
+        operand = consumer.inputs.get(name)
+        if operand is None:
+            return False
+        shape = tile_in.shape if operand is tile_out else operand.shape
+        if shape is None:
+            return False
+        operand_shapes.append(tuple(shape))
+
+    broadcast = broadcast_shapes(*operand_shapes)
+    if broadcast is None:
+        return False
+    return shapes_equal(broadcast, consumer.outputs[0].shape)
+
+
+def _can_remove(op, block) -> bool:
+    if not _is_broadcast_tile(op):
+        return False
+
+    tile_out = op.outputs[0]
+    if tile_out in block.outputs:
+        return False
+
+    consumers = list(tile_out.child_ops)
+    if len(consumers) == 0:
+        return False
+
+    for consumer in consumers:
+        if consumer.op_type not in _BROADCAST_OPS:
+            return False
+        # The tile output being consumed from inside a nested block (while_loop /
+        # cond body) is not safe to rewrite from here.
+        if consumer.enclosing_block is not block:
+            return False
+        if not _consumer_output_is_unchanged(consumer, tile_out, op.x):
+            return False
+    return True
+
+
+@block_context_manager
+def _remove_broadcast_tiles(block) -> int:
+    removed = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            removed += _remove_broadcast_tiles(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        if not _can_remove(op, block):
+            continue
+
+        # The replacement changes the shape of the operand, so type inference on
+        # the consumers must be skipped (`no_check_var_types`). That is safe: we
+        # verified above that every consumer keeps its current output shape.
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=op.x,
+            no_check_var_types=True,
+        )
+        op.remove_from_block()
+        removed += 1
+
+    return removed
+
+
+@register_pass(namespace="common")
+class remove_broadcast_tiles(AbstractGraphPass):
+    """
+    Remove ``tile`` ops that only implement NumPy broadcasting for consumers
+    that broadcast natively.
+
+    A tile is removed when all of the following hold:
+
+    1. It is a broadcast: ``reps`` is a compile-time constant and for every
+       axis either ``x.shape[i] == 1`` or ``reps[i] == 1``.
+    2. Every consumer is an elementwise op with implicit broadcasting support
+       (``select`` is excluded on purpose, see the module docstring), and lives
+       in the same block as the tile.
+    3. No consumer changes its output shape when the tile is bypassed.
+
+    Given:
+        %2 = tile(x=%1, reps=[1, 8])   # %1: (4, 1)
+        %3 = add(x=%0, y=%2)           # %0: (4, 8)
+
+    Result:
+        %3 = add(x=%0, y=%1)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            removed = _remove_broadcast_tiles(f)
+            if removed:
+                logger.debug("remove_broadcast_tiles: removed %d tile op(s)", removed)

--- a/stablehlo_coreml/passes/remove_broadcast_tiles.py
+++ b/stablehlo_coreml/passes/remove_broadcast_tiles.py
@@ -11,12 +11,11 @@ constant weights). The pass therefore runs before the first
 
 import logging
 
-import numpy as np
 from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import broadcast_shapes, dims_equal, shapes_equal
+from .pattern_utils import broadcast_shapes, is_broadcast_tile, shapes_equal
 
 logger = logging.getLogger(__name__)
 
@@ -40,35 +39,6 @@ _BROADCAST_OPS = frozenset({
 _BINARY_OPERANDS = ("x", "y")
 
 
-def _is_broadcast_tile(op) -> bool:
-    """True if ``op`` is a ``tile`` that only replicates size-1 dimensions.
-
-    A tile of a dimension that is not 1 is *not* a broadcast:
-    ``tile([1, 2], reps=[2]) == [1, 2, 1, 2]`` cannot be expressed by implicit
-    broadcasting. ``reps`` must be known at compile time.
-    """
-    if op.op_type != "tile":
-        return False
-
-    reps_var = op.inputs.get("reps")
-    if reps_var is None or reps_var.val is None:
-        return False
-    reps = np.asarray(reps_var.val).reshape(-1).tolist()
-
-    x_shape = op.x.shape
-    if x_shape is None or len(reps) != len(x_shape):
-        return False
-
-    for dim, rep in zip(x_shape, reps):
-        if int(rep) == 1:
-            continue
-        # `dim` may be symbolic; only a literal 1 is safe to broadcast.
-        if dims_equal(dim, 1):
-            continue
-        return False
-    return True
-
-
 def _consumer_output_is_unchanged(consumer, tile_out, tile_in) -> bool:
     """True if replacing ``tile_out`` by ``tile_in`` keeps ``consumer``'s output shape."""
     operand_shapes = []
@@ -88,7 +58,7 @@ def _consumer_output_is_unchanged(consumer, tile_out, tile_in) -> bool:
 
 
 def _can_remove(op, block) -> bool:
-    if not _is_broadcast_tile(op):
+    if not is_broadcast_tile(op):
         return False
 
     tile_out = op.outputs[0]

--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -1,0 +1,235 @@
+"""MIL pass: replace JAX's decomposed softmax with the native ``softmax`` op.
+
+``jax.nn.softmax`` has no single HLO instruction; it is lowered to the
+numerically stable decomposition, which this converter turns into::
+
+    reduce_max(x, axes=[a]) -> [maximum(., -inf)] -> reshape -> [tile]
+      -> sub(x, .) -> exp
+      -> reduce_sum(exp, axes=[a]) -> reshape -> [tile]
+      -> real_div(exp, .)
+
+For fp16 inputs JAX accumulates the sum in fp32, which adds a ``cast`` before
+``reduce_sum`` and another one after it. Depending on the surrounding layout,
+JAX may also compute the whole thing in a permuted axis order, so the ``sub``
+and the ``reduce_max`` do not always share the very same input tensor.
+
+Rather than pinning down every variant of the "subtract the maximum" part, the
+pass matches the part that actually defines softmax::
+
+    real_div(exp(z), broadcast(reduce_sum(exp(z), axis)))  ==  softmax(z, axis)
+
+and then, as a bonus, peels a leading ``sub(x, c)`` off ``z`` whenever ``c`` is
+constant along ``axis`` -- softmax is invariant under such a shift, so the whole
+``reduce_max``/``maximum``/``reshape`` chain becomes dead. That covers the
+``maximum(-inf, .)`` clamps and the permuted layouts for free.
+"""
+
+import logging
+
+from coremltools.converters.mil import Builder as mb
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import (
+    const_int_list,
+    dims_equal,
+    normalize_axis,
+    producer_ops,
+    remove_dead_ops,
+    shapes_equal,
+    sole_consumer,
+)
+
+logger = logging.getLogger(__name__)
+
+# Shape/dtype-only ops that broadcast the reduction result back over the input.
+_BROADCAST_BACK_OPS = frozenset({"reshape", "expand_dims", "squeeze", "tile", "cast", "identity"})
+
+
+def _match(real_div_op):
+    """Match a decomposed softmax ending at ``real_div_op``.
+
+    Returns ``(softmax_input, axis, matched_ops)`` or ``None``.
+    """
+    if real_div_op.op_type != "real_div":
+        return None
+
+    numerator = real_div_op.inputs["x"]
+    denominator = real_div_op.inputs["y"]
+
+    exp_op = getattr(numerator, "op", None)
+    if exp_op is None or exp_op.op_type != "exp":
+        return None
+    if numerator.shape is None:
+        return None
+    full_shape = tuple(numerator.shape)
+    rank = len(full_shape)
+    if rank == 0:
+        return None
+
+    matched = [real_div_op, exp_op]
+
+    # -- denominator: [tile] <- [reshape] <- [cast] <- reduce_sum(exp) -------
+    chain = []
+    var = denominator
+    consumer = real_div_op
+    while True:
+        op = getattr(var, "op", None)
+        if op is None or op.op_type not in _BROADCAST_BACK_OPS:
+            break
+        if sole_consumer(var) is not consumer:
+            return None
+        chain.append(op)
+        consumer = op
+        var = op.inputs["x"]
+
+    reduce_sum_op = getattr(var, "op", None)
+    if reduce_sum_op is None or reduce_sum_op.op_type != "reduce_sum":
+        return None
+    if sole_consumer(var) is not consumer:
+        return None
+
+    axes = const_int_list(reduce_sum_op.inputs.get("axes"))
+    if axes is None or len(axes) != 1:
+        return None
+    axis = normalize_axis(axes[0], rank)
+    if axis is None:
+        return None
+
+    # `reduce_sum` must consume the exp output, possibly through an fp32 cast.
+    sum_input = reduce_sum_op.inputs["x"]
+    matched += chain
+    matched.append(reduce_sum_op)
+    if sum_input is not numerator:
+        cast_op = getattr(sum_input, "op", None)
+        if cast_op is None or cast_op.op_type != "cast":
+            return None
+        if cast_op.inputs["x"] is not numerator:
+            return None
+        if sole_consumer(sum_input) is not reduce_sum_op:
+            return None
+        matched.append(cast_op)
+
+    # The intermediate values must be a plain "broadcast the sum back" chain.
+    keep_dims_shape = full_shape[:axis] + (1,) + full_shape[axis + 1:]
+    reduced_shape = full_shape[:axis] + full_shape[axis + 1:]
+    allowed = (full_shape, keep_dims_shape, reduced_shape)
+    for op in chain + [reduce_sum_op]:
+        if not any(shapes_equal(op.outputs[0].shape, shape) for shape in allowed):
+            return None
+
+    # The exp output must not be observed anywhere else.
+    block = real_div_op.enclosing_block
+    matched_set = set(matched)
+    if numerator in block.outputs:
+        return None
+    for child in numerator.child_ops:
+        if child not in matched_set:
+            return None
+
+    # -- optionally peel `sub(x, c)`; softmax is invariant under such a shift --
+    softmax_input = exp_op.inputs["x"]
+    # `producer_ops` also covers the (now dead) reduce_max chain; ops that are
+    # still live are simply not removed.
+    candidates = matched + producer_ops(softmax_input)
+
+    sub_op = getattr(softmax_input, "op", None)
+    if (
+        sub_op is not None
+        and sub_op.op_type == "sub"
+        and sole_consumer(softmax_input) is exp_op
+        and shapes_equal(sub_op.inputs["x"].shape, full_shape)
+        and _is_constant_along(sub_op.inputs["y"], axis, rank)
+    ):
+        softmax_input = sub_op.inputs["x"]
+
+    return softmax_input, axis, candidates
+
+
+def _is_constant_along(var, axis: int, rank: int) -> bool:
+    """True if ``var`` is constant along ``axis``.
+
+    A ``tile`` that only replicates size-1 dimensions is a broadcast, so it is
+    peeled before looking at the shape.
+    """
+    while True:
+        op = getattr(var, "op", None)
+        if op is None or op.op_type != "tile":
+            break
+        reps = const_int_list(op.inputs.get("reps"))
+        x_shape = op.inputs["x"].shape
+        if reps is None or x_shape is None or len(reps) != len(x_shape):
+            break
+        if any(rep != 1 and not dims_equal(dim, 1) for dim, rep in zip(x_shape, reps)):
+            break
+        var = op.inputs["x"]
+
+    if var.shape is None:
+        return False
+    shape = tuple(var.shape)
+    if len(shape) > rank:
+        return False
+    padded = (1,) * (rank - len(shape)) + shape
+    return dims_equal(padded[axis], 1)
+
+
+@block_context_manager
+def _replace_decomposed_softmax(block) -> int:
+    replaced = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            replaced += _replace_decomposed_softmax(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        match = _match(op)
+        if match is None:
+            continue
+        softmax_input, axis, candidates = match
+
+        softmax_var = mb.softmax(x=softmax_input, axis=axis, before_op=op, name=op.name + "_softmax")
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=softmax_var,
+        )
+        remove_dead_ops(block, candidates)
+        replaced += 1
+
+    return replaced
+
+
+@register_pass(namespace="common")
+class replace_decomposed_softmax(AbstractGraphPass):
+    """
+    Replace the decomposed softmax that JAX emits with MIL's ``softmax`` op.
+
+    Given:
+        %max = reduce_max(x=%x, axes=[a], keep_dims=False)
+        %clamped = maximum(x=-inf, y=%max)          # optional
+        %kd = reshape(x=%clamped, shape=<keep-dims>)
+        %sub = sub(x=%x, y=%kd)
+        %exp = exp(x=%sub)
+        %sum = reduce_sum(x=%exp, axes=[a], keep_dims=False)
+        %sum_kd = reshape(x=%sum, shape=<keep-dims>)
+        %out = real_div(x=%exp, y=%sum_kd)
+
+    Result:
+        %out = softmax(x=%x, axis=a)
+
+    ``tile`` ops broadcasting the sum back to the input shape and the ``cast``
+    pair that JAX adds around ``reduce_sum`` for fp16 inputs are matched as
+    well. The subtraction is only peeled off when the subtrahend is constant
+    along the softmax axis (which is what makes softmax invariant under it);
+    otherwise the ``sub`` output becomes the softmax input.
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            replaced = _replace_decomposed_softmax(f)
+            if replaced:
+                logger.debug("replace_decomposed_softmax: replaced %d softmax chain(s)", replaced)

--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -36,9 +36,8 @@ from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 from .pattern_utils import (
     const_int_list,
     dims_equal,
+    is_broadcast_tile,
     normalize_axis,
-    producer_ops,
-    remove_dead_ops,
     shapes_equal,
     sole_consumer,
 )
@@ -52,7 +51,7 @@ _BROADCAST_BACK_OPS = frozenset({"reshape", "expand_dims", "squeeze", "tile", "c
 def _match(real_div_op):
     """Match a decomposed softmax ending at ``real_div_op``.
 
-    Returns ``(softmax_input, axis, matched_ops)`` or ``None``.
+    Returns ``(softmax_input, axis)`` or ``None``.
     """
     if real_div_op.op_type != "real_div":
         return None
@@ -132,9 +131,6 @@ def _match(real_div_op):
 
     # -- optionally peel `sub(x, c)`; softmax is invariant under such a shift --
     softmax_input = exp_op.inputs["x"]
-    # `producer_ops` also covers the (now dead) reduce_max chain; ops that are
-    # still live are simply not removed.
-    candidates = matched + producer_ops(softmax_input)
 
     sub_op = getattr(softmax_input, "op", None)
     if (
@@ -147,7 +143,7 @@ def _match(real_div_op):
     ):
         softmax_input = sub_op.inputs["x"]
 
-    return softmax_input, axis, candidates
+    return softmax_input, axis
 
 
 def _is_constant_along(var, axis: int, rank: int) -> bool:
@@ -158,13 +154,7 @@ def _is_constant_along(var, axis: int, rank: int) -> bool:
     """
     while True:
         op = getattr(var, "op", None)
-        if op is None or op.op_type != "tile":
-            break
-        reps = const_int_list(op.inputs.get("reps"))
-        x_shape = op.inputs["x"].shape
-        if reps is None or x_shape is None or len(reps) != len(x_shape):
-            break
-        if any(rep != 1 and not dims_equal(dim, 1) for dim, rep in zip(x_shape, reps)):
+        if op is None or not is_broadcast_tile(op):
             break
         var = op.inputs["x"]
 
@@ -205,7 +195,7 @@ def _replace_decomposed_softmax(block) -> int:
         match = _match(op)
         if match is None:
             continue
-        softmax_input, axis, candidates = match
+        softmax_input, axis = match
 
         softmax_var = mb.softmax(x=softmax_input, axis=axis, before_op=op, name=op.name + "_softmax")
         block.replace_uses_of_var_after_op(
@@ -213,7 +203,6 @@ def _replace_decomposed_softmax(block) -> int:
             old_var=op.outputs[0],
             new_var=softmax_var,
         )
-        remove_dead_ops(block, candidates)
         replaced += 1
 
     return replaced

--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -19,13 +19,15 @@ pass matches the part that actually defines softmax::
     real_div(exp(z), broadcast(reduce_sum(exp(z), axis)))  ==  softmax(z, axis)
 
 and then, as a bonus, peels a leading ``sub(x, c)`` off ``z`` whenever ``c`` is
-constant along ``axis`` -- softmax is invariant under such a shift, so the whole
-``reduce_max``/``maximum``/``reshape`` chain becomes dead. That covers the
-``maximum(-inf, .)`` clamps and the permuted layouts for free.
+constant along ``axis`` and is not a statically known non-finite value --
+softmax is invariant under such a shift, so the whole ``reduce_max``/
+``maximum``/``reshape`` chain becomes dead. That covers the ``maximum(-inf,
+.)`` clamps and the permuted layouts for free.
 """
 
 import logging
 
+import numpy as np
 from coremltools.converters.mil import Builder as mb
 from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
@@ -141,6 +143,7 @@ def _match(real_div_op):
         and sole_consumer(softmax_input) is exp_op
         and shapes_equal(sub_op.inputs["x"].shape, full_shape)
         and _is_constant_along(sub_op.inputs["y"], axis, rank)
+        and not _is_statically_nonfinite(sub_op.inputs["y"])
     ):
         softmax_input = sub_op.inputs["x"]
 
@@ -172,6 +175,19 @@ def _is_constant_along(var, axis: int, rank: int) -> bool:
         return False
     padded = (1,) * (rank - len(shape)) + shape
     return dims_equal(padded[axis], 1)
+
+
+def _is_statically_nonfinite(var) -> bool:
+    """True if a compile-time shift contains NaN or infinity."""
+    val = getattr(var, "val", None)
+    if val is None:
+        op = getattr(var, "op", None)
+        if op is not None and op.op_type == "fill":
+            return _is_statically_nonfinite(op.inputs.get("value"))
+        return False
+
+    arr = np.asarray(val)
+    return np.issubdtype(arr.dtype, np.floating) and not bool(np.all(np.isfinite(arr)))
 
 
 @block_context_manager
@@ -224,8 +240,9 @@ class replace_decomposed_softmax(AbstractGraphPass):
     ``tile`` ops broadcasting the sum back to the input shape and the ``cast``
     pair that JAX adds around ``reduce_sum`` for fp16 inputs are matched as
     well. The subtraction is only peeled off when the subtrahend is constant
-    along the softmax axis (which is what makes softmax invariant under it);
-    otherwise the ``sub`` output becomes the softmax input.
+    along the softmax axis (which is what makes softmax invariant under it)
+    and is not statically known to contain NaN or infinity; otherwise the
+    ``sub`` output becomes the softmax input.
     """
 
     def apply(self, prog):

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -102,11 +102,3 @@ def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
 
 
 DEFAULT_HLO_PIPELINE: ct.PassPipeline = build_pass_pipeline()
-
-
-def register_optimizations() -> None:
-    """Ensure all stablehlo-coreml passes are registered with coremltools.
-
-    Kept for backwards compatibility; importing this module already registers
-    them, so this function is a no-op that is safe to call repeatedly.
-    """

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -1,13 +1,97 @@
+"""Pipeline integration for the stablehlo-coreml MIL graph passes.
+
+Importing this module registers every pass in ``stablehlo_coreml.passes`` with
+coremltools' ``PASS_REGISTRY``. Use :func:`build_pass_pipeline` to obtain a
+pipeline with the passes inserted at the right places, or the pre-built
+:data:`DEFAULT_HLO_PIPELINE` convenience object.
+"""
+
+import copy
+
 import coremltools as ct
 
-DEFAULT_HLO_PIPELINE: ct.PassPipeline = ct.PassPipeline.DEFAULT
+# Importing the pass modules registers them in coremltools' PASS_REGISTRY.
+from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
+from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
+from . import fuse_logit_softcap as _fuse_logit_softcap  # noqa: F401
+from . import fuse_reduce_keep_dims as _fuse_reduce_keep_dims  # noqa: F401
+from . import remove_broadcast_tiles as _remove_broadcast_tiles  # noqa: F401
+from . import remove_noop_slice_update as _remove_noop_slice_update  # noqa: F401
+from . import replace_decomposed_softmax as _replace_decomposed_softmax  # noqa: F401
+
+# Cleanup passes. They run before the first `const_elimination` so that the
+# broadcast `tile`s are gone before constants get folded (otherwise a tiled
+# scalar constant is materialised at full size).
+CLEANUP_PASSES: list[str] = [
+    "common::remove_broadcast_tiles",
+    "common::fuse_reduce_keep_dims",
+    "common::remove_noop_slice_update",
+]
+
+# Fusion passes. They run just before `common::fuse_matmul_weight_bias`: by then
+# constants are folded and small, the broadcast tiles are gone, and everything is
+# still fp32 (before `add_fp16_cast`), while coremltools' `reduce_transposes` /
+# `fuse_transpose_matmul` / DCE still run afterwards to clean up what we emit.
+#
+# Adding a fusion pass = adding a module in this package + one entry in this list
+# (and the corresponding import above).
+FUSION_PASSES: list[str] = [
+    "common::replace_decomposed_softmax",
+    "common::fuse_attention_to_sdpa",
+    "common::fuse_logit_softcap",
+    "common::fuse_gelu_erfc",
+]
+
+# The pass the CLEANUP group is inserted before (fallback: the front of the pipeline).
+_CLEANUP_ANCHOR = "common::const_elimination"
+# The pass the FUSION group is inserted before (fallback: the end of the pipeline).
+_FUSION_ANCHOR = "common::fuse_matmul_weight_bias"
 
 
-def register_optimizations():
-    from .remove_noop_slice_update import remove_noop_slice_update  # noqa: PLC0415
-    custom_passes = [remove_noop_slice_update]
+def _insert_passes(pipeline: ct.PassPipeline, pass_names: list[str], anchor: str, fallback_index: int | None) -> None:
+    """Insert ``pass_names`` (in order) immediately before the first ``anchor`` pass.
 
-    for custom_pass in custom_passes:
-        pass_name = f"common::{custom_pass.__name__}"
-        if pass_name not in DEFAULT_HLO_PIPELINE.passes:
-            DEFAULT_HLO_PIPELINE.append_pass(pass_name)
+    Passes already present in the pipeline are left where they are. If ``anchor``
+    is not part of the pipeline, ``fallback_index`` is used instead (``None``
+    meaning "append at the end").
+    """
+    missing = [name for name in pass_names if name not in pipeline.passes]
+    if not missing:
+        return
+
+    if anchor in pipeline.passes:
+        index = pipeline.passes.index(anchor)
+    elif fallback_index is None:
+        index = len(pipeline.passes)
+    else:
+        index = fallback_index
+
+    for offset, pass_name in enumerate(missing):
+        pipeline.insert_pass(index=index + offset, pass_name=pass_name)
+
+
+def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
+    """Return a new pipeline: ``base`` with the stablehlo-coreml passes inserted.
+
+    ``base`` defaults to ``ct.PassPipeline.DEFAULT``. The input pipeline is never
+    mutated, and inserting into a pipeline that already contains our passes is a
+    no-op for those passes.
+    """
+    # `ct.PassPipeline.DEFAULT` already hands out a fresh object on every access.
+    pipeline = ct.PassPipeline.DEFAULT if base is None else copy.deepcopy(base)
+
+    _insert_passes(pipeline, CLEANUP_PASSES, _CLEANUP_ANCHOR, fallback_index=0)
+    _insert_passes(pipeline, FUSION_PASSES, _FUSION_ANCHOR, fallback_index=None)
+
+    return pipeline
+
+
+DEFAULT_HLO_PIPELINE: ct.PassPipeline = build_pass_pipeline()
+
+
+def register_optimizations() -> None:
+    """Ensure all stablehlo-coreml passes are registered with coremltools.
+
+    Kept for backwards compatibility; importing this module already registers
+    them, so this function is a no-op that is safe to call repeatedly.
+    """

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -19,12 +19,20 @@ from . import remove_broadcast_tiles as _remove_broadcast_tiles  # noqa: F401
 from . import remove_noop_slice_update as _remove_noop_slice_update  # noqa: F401
 from . import replace_decomposed_softmax as _replace_decomposed_softmax  # noqa: F401
 
+# The passes do not clean up after themselves; the ops they leave behind are
+# removed by coremltools' dead code elimination, interleaved between them (one
+# pass's leftovers would otherwise look like extra consumers to the next one).
+_DCE = "common::dead_code_elimination"
+
 # Cleanup passes. They run before the first `const_elimination` so that the
 # broadcast `tile`s are gone before constants get folded (otherwise a tiled
 # scalar constant is materialised at full size).
 CLEANUP_PASSES: list[str] = [
     "common::remove_broadcast_tiles",
     "common::fuse_reduce_keep_dims",
+    # `fuse_reduce_keep_dims` leaves the old reduction behind when the reshape
+    # was its sole consumer.
+    _DCE,
     "common::remove_noop_slice_update",
 ]
 
@@ -34,12 +42,16 @@ CLEANUP_PASSES: list[str] = [
 # `fuse_transpose_matmul` / DCE still run afterwards to clean up what we emit.
 #
 # Adding a fusion pass = adding a module in this package + one entry in this list
-# (and the corresponding import above).
+# followed by a `_DCE` entry (and the corresponding import above).
 FUSION_PASSES: list[str] = [
     "common::replace_decomposed_softmax",
+    _DCE,
     "common::fuse_attention_to_sdpa",
+    _DCE,
     "common::fuse_logit_softcap",
+    _DCE,
     "common::fuse_gelu_erfc",
+    _DCE,
 ]
 
 # The pass the CLEANUP group is inserted before (fallback: the front of the pipeline).
@@ -51,12 +63,15 @@ _FUSION_ANCHOR = "common::fuse_matmul_weight_bias"
 def _insert_passes(pipeline: ct.PassPipeline, pass_names: list[str], anchor: str, fallback_index: int | None) -> None:
     """Insert ``pass_names`` (in order) immediately before the first ``anchor`` pass.
 
-    Passes already present in the pipeline are left where they are. If ``anchor``
-    is not part of the pipeline, ``fallback_index`` is used instead (``None``
-    meaning "append at the end").
+    Our own passes are only inserted when they are not in the pipeline yet, so
+    re-inserting into a pipeline that already has them is a no-op. The
+    ``dead_code_elimination`` entries are always inserted along with them:
+    coremltools' default pipeline runs those elsewhere too, but we need them
+    right between our own passes. If ``anchor`` is not part of the pipeline,
+    ``fallback_index`` is used instead (``None`` meaning "append at the end").
     """
-    missing = [name for name in pass_names if name not in pipeline.passes]
-    if not missing:
+    to_insert = [name for name in pass_names if name == _DCE or name not in pipeline.passes]
+    if all(name == _DCE for name in to_insert):
         return
 
     if anchor in pipeline.passes:
@@ -66,7 +81,7 @@ def _insert_passes(pipeline: ct.PassPipeline, pass_names: list[str], anchor: str
     else:
         index = fallback_index
 
-    for offset, pass_name in enumerate(missing):
+    for offset, pass_name in enumerate(to_insert):
         pipeline.insert_pass(index=index + offset, pass_name=pass_name)
 
 

--- a/stablehlo_coreml/reductions.py
+++ b/stablehlo_coreml/reductions.py
@@ -2,6 +2,7 @@ import numpy as np
 from coremltools import _logger as logger
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 from jaxlib.mlir.dialects.stablehlo import AddOp, AndOp, DivOp, MaxOp, MinOp, MulOp, OrOp, ReturnOp, SubtractOp
 
 from .translation_context import TranslationContext
@@ -141,12 +142,67 @@ def match_simple_reduce_window(body, inputs, init_values, window_dimensions, win
     return fold_init_value(final_res)
 
 
+def _is_identity_init(mode, init_value, x) -> bool:
+    """True if `init_value` is a constant equal to the identity element of `mode`.
+
+    Combining a reduction result with the identity element is a no-op, so the
+    clamp the StableHLO spec requires can be skipped. The dtype matters for the
+    integer/boolean cases (max: the smallest representable value, min: the largest).
+    """
+    val = getattr(init_value, "val", None)
+    if val is None:
+        return False
+    arr = np.asarray(val)
+    if arr.size != 1:
+        return False
+    value = arr.reshape(-1)[0]
+
+    dtype = x.dtype
+    match mode:
+        case "add":
+            return bool(value == 0)
+        case "mul":
+            return bool(value == 1)
+        case "or":
+            return not bool(value)
+        case "and":
+            return bool(value)
+        case "max" | "min":
+            if types.is_bool(dtype):
+                return bool(value) == (mode == "min")
+            if types.is_float(dtype):
+                return bool(np.isinf(value)) and ((value < 0) == (mode == "max"))
+            if types.is_int(dtype):
+                int_info = np.iinfo(types.nptype_from_builtin(dtype))
+                return bool(value == (int_info.min if mode == "max" else int_info.max))
+    return False
+
+
+def _can_skip_init_value(mode, dimensions, inputs, init_values) -> bool:
+    """True if folding in the reduction init value can be skipped entirely.
+
+    This requires the init value to be the identity element of the reduction, and
+    every reduced dimension to be statically known to be non-empty (for an empty
+    reduction, the MIL reduce op result is undefined, so the init value must stay).
+    """
+    if len(inputs) != 1 or len(init_values) != 1:
+        return False
+    x = inputs[0]
+    for dim in dimensions:
+        size = x.shape[dim]
+        if is_symbolic(size) or int(size) == 0:
+            return False
+    return _is_identity_init(mode, init_values[0], x)
+
+
 def compute_reduction(converter, context: TranslationContext, inputs, dimensions, body, init_values, result_types):
     mil_reduction, mil_single_reduction, mode = match_computation(body)
     if mil_reduction and mil_single_reduction and len(inputs) == 1:
         res = mil_reduction(x=inputs[0], axes=np.array(dimensions, dtype=np.int32))
-        # Handle initial value
-        res = mil_single_reduction(x=res, y=init_values[0])
+        # Handle initial value. If it is the identity element of the reduction, combining
+        # it in is a no-op and we skip it to keep the generated program small.
+        if not _can_skip_init_value(mode, dimensions, inputs, init_values):
+            res = mil_single_reduction(x=res, y=init_values[0])
         return [res]
 
     # Boolean Or/And: MIL has no reduce_or/reduce_and, so lower via
@@ -159,7 +215,8 @@ def compute_reduction(converter, context: TranslationContext, inputs, dimensions
         else:
             res = mb.reduce_min(x=x_int, axes=axes)
         res = mb.cast(x=res, dtype="bool")
-        res = mil_single_reduction(x=res, y=init_values[0])
+        if not _can_skip_init_value(mode, dimensions, inputs, init_values):
+            res = mil_single_reduction(x=res, y=init_values[0])
         return [res]
 
     # Fall back to loop implementation

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -1,0 +1,880 @@
+import math
+
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.mil.passes.pass_pipeline import PassPipelineManager
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from stablehlo_coreml.passes.fuse_attention_to_sdpa import _Atom, _regroup
+from tests.utils import get_model_instruction_types, run_and_compare
+
+register_optimizations()
+
+PASS_NAME = "common::fuse_attention_to_sdpa"
+
+# [B, H, L, S] scores from [B, H, L, E] queries and [B, H, S, E] keys.
+B, H, L, S, E = 2, 3, 5, 7, 4
+
+NEG_INF = np.float32(-np.inf)
+FINITE_FILL = np.float32(-1e9)
+# What HuggingFace actually uses for "masked out": large, but finite.
+TORCH_MIN_FILL = np.float32(np.finfo(np.float32).min)
+
+
+def _apply(prog, **options):
+    if not options:
+        return apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+    pipeline = ct.PassPipeline([PASS_NAME], "fuse_attention")
+    pipeline.set_options(PASS_NAME, options)
+    PassPipelineManager.apply_pipeline(prog, pipeline)
+    return prog
+
+
+def _ops(prog):
+    return list(prog.functions["main"].operations)
+
+
+def _sdpa_ops(prog, recurse: bool = True) -> int:
+    return get_op_types_in_program(prog, recurse=recurse).count("scaled_dot_product_attention")
+
+
+def _all_neg_inf_rows(scores, shape=(B, H, L, S)):
+    """The row predicate of torch's ``_safe_softmax``, as torchax lowers it.
+
+    ``not any(scores != -inf)``, broadcast back over the key axis.
+    """
+    *lead, keys = shape
+    finite = mb.logical_not(x=mb.equal(x=scores, y=NEG_INF))
+    any_finite = mb.reduce_max(x=mb.cast(x=finite, dtype="int32"), axes=[len(shape) - 1], keep_dims=False)
+    rows = mb.reshape(x=mb.cast(x=any_finite, dtype="bool"), shape=[*lead, 1])
+    return mb.tile(x=mb.logical_not(x=rows), reps=[1] * len(lead) + [keys])
+
+
+def _qkv_specs():
+    return [
+        mb.TensorSpec(shape=(B, H, L, E)),
+        mb.TensorSpec(shape=(B, H, S, E)),
+        mb.TensorSpec(shape=(B, H, S, E)),
+    ]
+
+
+class TestFuseAttentionToSdpa:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_masked_attention_with_neg_inf_fill(self):
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            masked = mb.select(cond=mask, a=scaled, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_dot_product_attention"]
+        sdpa = _ops(prog)[-1]
+        # A -inf fill has the same semantics as SDPA's boolean mask.
+        assert sdpa.attn_mask.dtype == types.bool
+        assert_model_is_valid(
+            prog,
+            {"q": (B, H, L, E), "k": (B, H, S, E), "v": (B, H, S, E), "mask": (B, 1, 1, S)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_masked_attention_with_finite_fill_defaults_to_additive(self):
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            masked = mb.select(cond=mask, a=scaled, b=FINITE_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops[-1] == "scaled_dot_product_attention"
+        assert ops.count("scaled_dot_product_attention") == 1
+        sdpa = _ops(prog)[-1]
+        assert sdpa.attn_mask.dtype == types.fp32
+
+    def test_masked_attention_with_torch_finfo_min_fill_is_additive(self):
+        """HuggingFace masks with `torch.finfo(dtype).min`, which is finite."""
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            masked = mb.select(cond=mask, a=scaled, b=TORCH_MIN_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        sdpa = _ops(prog)[-1]
+        # A fully masked row stays finite in the original graph, so the mask has
+        # to be additive even though the fill is way below the fp32 range.
+        assert sdpa.attn_mask.dtype == types.fp32
+
+    def test_masked_attention_with_finite_fill_bool_option(self):
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            masked = mb.select(cond=mask, a=scaled, b=FINITE_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog, finite_fill_mask="bool")
+        assert get_op_types_in_program(prog) == ["scaled_dot_product_attention"]
+        assert _ops(prog)[-1].attn_mask.dtype == types.bool
+
+    def test_swapped_select_operands(self):
+        """`select(cond, fill, scores)` masks where the condition is true."""
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            masked = mb.select(cond=mask, a=NEG_INF, b=scaled)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["logical_not", "scaled_dot_product_attention"]
+
+    def test_unmasked_attention(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.real_div(x=scores, y=np.float32(math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_dot_product_attention"]
+        assert _ops(prog)[-1].attn_mask is None
+
+    def test_additive_float_mask(self):
+        @mb.program(input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, L, S))], opset_version=ct.target.iOS18)
+        def prog(q, k, v, bias):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            biased = mb.add(x=scaled, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_dot_product_attention"]
+        sdpa = _ops(prog)[-1]
+        assert sdpa.attn_mask is prog.functions["main"].inputs["bias"]
+
+    def test_scale_applied_after_the_mask_scales_the_fill(self):
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            masked = mb.select(cond=mask, a=scores, b=FINITE_FILL)
+            scaled = mb.mul(x=masked, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        # The fill is applied before the scale, so it has to be scaled as well.
+        fill = next(op for op in _ops(prog) if op.op_type == "mul" and op.x.op is not None)
+        np.testing.assert_allclose(fill.y.val, -1e9 / math.sqrt(E), rtol=1e-5)
+
+    def test_not_fused_when_the_mask_broadcasts_the_scores_up(self):
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, H, L + 1, S))],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, bias):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            reduced = mb.reduce_sum(x=scores, axes=[2], keep_dims=True)
+            biased = mb.add(x=reduced, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            merged = mb.reduce_sum(x=weights, axes=[2], keep_dims=True)
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_uniform_constant_bias_is_not_a_mask(self):
+        """A uniform shift is a no-op for softmax; there is nothing to fuse."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=scores, y=np.float32(1.0))
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_non_uniform_constant_bias_is_an_additive_mask(self):
+        """T5 folds its relative position bias into a constant added to the scores."""
+        bias = np.arange(L * S, dtype=np.float32).reshape(1, 1, L, S)
+
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            biased = mb.add(x=scaled, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_dot_product_attention"]
+        sdpa = _ops(prog)[-1]
+        np.testing.assert_array_equal(sdpa.attn_mask.val, bias)
+
+    def test_no_scale_prescales_the_query(self):
+        """Without an explicit scale, Q must cancel SDPA's built-in 1/sqrt(E)."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["mul", "scaled_dot_product_attention"]
+        scale = _ops(prog)[-2]
+        np.testing.assert_allclose(scale.y.val, math.sqrt(E), rtol=1e-5)
+
+    @pytest.mark.parametrize("scale", [1.0 / math.sqrt(E), 0.5 / math.sqrt(E)])
+    def test_explicit_scale(self, scale):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=np.float32(scale), y=scores)
+            weights = mb.softmax(x=scaled, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        factor = scale * math.sqrt(E)
+        if abs(factor - 1.0) < 1e-3:
+            assert ops == ["scaled_dot_product_attention"]
+        else:
+            assert ops == ["mul", "scaled_dot_product_attention"]
+            np.testing.assert_allclose(_ops(prog)[-2].y.val, factor, rtol=1e-5)
+
+    def test_transposed_key(self):
+        """`transpose_y=False` means the key still has to be transposed."""
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(B, H, L, E)),
+            mb.TensorSpec(shape=(B, H, E, S)),
+            mb.TensorSpec(shape=(B, H, S, E)),
+        ])
+        def prog(q, k_t, v):
+            scores = mb.matmul(x=q, y=k_t, transpose_y=False)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert ops.count("transpose") == 1
+
+    def test_existing_key_transpose_is_peeled(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            k_t = mb.transpose(x=k, perm=[0, 1, 3, 2])
+            scores = mb.matmul(x=q, y=k_t, transpose_y=False)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "transpose" not in ops
+
+    def test_transposed_value(self):
+        """The converter emits `matmul(w, v_t, transpose_y=True)`; peel the transpose."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            v_t = mb.transpose(x=v, perm=[0, 1, 3, 2])
+            return mb.matmul(x=weights, y=v_t, transpose_y=True)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "transpose" not in ops
+
+    def test_reshaped_gqa_layout_with_key_mask(self):
+        """Gemma-style GQA: [B, K, G*T, E] queries reshaped to [B, K, G, T, E]."""
+        batch, heads, groups, tokens, keys, embedding = 1, 2, 3, 5, 7, 4
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(batch, heads, groups * tokens, embedding)),
+            mb.TensorSpec(shape=(batch, heads, keys, embedding)),
+            mb.TensorSpec(shape=(batch, heads, keys, embedding)),
+            mb.TensorSpec(shape=(batch, 1, 1, 1, keys), dtype=types.bool),
+        ])
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            split = mb.reshape(x=scores, shape=[batch, heads, groups, tokens, keys])
+            masked = mb.select(cond=mask, a=split, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            merged = mb.reshape(x=weights, shape=[batch, heads, groups * tokens, keys])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "softmax" not in ops
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        # A pure key mask collapses to [1, 1, 1, S].
+        assert tuple(sdpa.attn_mask.shape) == (1, 1, 1, keys)
+
+    def test_reshaped_gqa_layout_with_full_mask(self):
+        """A mask that varies per query row has to be materialised in matmul space."""
+        batch, heads, groups, tokens, keys, embedding = 1, 2, 3, 5, 7, 4
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(batch, heads, groups * tokens, embedding)),
+            mb.TensorSpec(shape=(batch, heads, keys, embedding)),
+            mb.TensorSpec(shape=(batch, heads, keys, embedding)),
+            mb.TensorSpec(shape=(batch, 1, 1, tokens, keys), dtype=types.bool),
+        ])
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            split = mb.reshape(x=scores, shape=[batch, heads, groups, tokens, keys])
+            masked = mb.select(cond=mask, a=split, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            merged = mb.reshape(x=weights, shape=[batch, heads, groups * tokens, keys])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "tile" in ops
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert tuple(sdpa.attn_mask.shape) == (batch, heads, groups * tokens, keys)
+
+    def test_degenerate_single_query_and_key(self):
+        """Whisper's decoder self-attention: L = S = 1 around a [1, H, 1, 1] reshape."""
+        heads = 4
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(heads, 1, E)),
+            mb.TensorSpec(shape=(heads, E, 1)),
+            mb.TensorSpec(shape=(heads, 1, E)),
+            mb.TensorSpec(shape=(1, 1, 1, 1)),
+        ])
+        def prog(q, k_t, v, bias):
+            scores = mb.matmul(x=q, y=k_t, transpose_y=False)   # [heads, 1, 1]
+            split = mb.reshape(x=scores, shape=[1, heads, 1, 1])
+            biased = mb.add(x=split, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            merged = mb.reshape(x=weights, shape=[heads, 1, 1])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "softmax" not in ops
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert tuple(sdpa.attn_mask.shape) == (1, 1, 1)
+        assert_model_is_valid(
+            prog,
+            {"q": (heads, 1, E), "k_t": (heads, E, 1), "v": (heads, 1, E), "bias": (1, 1, 1, 1)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_transposed_score_layout(self):
+        """Softmax may run over the *first* matmul result axis (roles swapped)."""
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(B, H, S, E)),
+            mb.TensorSpec(shape=(B, H, L, E)),
+            mb.TensorSpec(shape=(B, H, S, E)),
+        ])
+        def prog(k, q, v):
+            scores = mb.matmul(x=k, y=q, transpose_y=True)      # [B, H, S, L]
+            swapped = mb.transpose(x=scores, perm=[0, 1, 3, 2])  # [B, H, L, S]
+            weights = mb.softmax(x=swapped, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert sdpa.key is prog.functions["main"].inputs["k"]
+
+    def test_symbolic_sequence_dim(self):
+        seq = get_new_symbol()
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(B, H, L, E)),
+            mb.TensorSpec(shape=(B, H, seq, E)),
+            mb.TensorSpec(shape=(B, H, seq, E)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 1
+
+    def test_not_fused_when_weights_are_used_elsewhere(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            attention = mb.matmul(x=weights, y=v, transpose_y=False)
+            return mb.add(x=attention, y=mb.reduce_sum(x=weights, axes=[3], keep_dims=True))
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_not_fused_when_scores_are_used_elsewhere(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            attention = mb.matmul(x=weights, y=v, transpose_y=False)
+            return mb.add(x=attention, y=mb.reduce_sum(x=scores, axes=[3], keep_dims=True))
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_not_fused_for_rank_2_matmuls(self):
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(L, E)),
+            mb.TensorSpec(shape=(S, E)),
+            mb.TensorSpec(shape=(S, E)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_not_fused_when_batch_dims_disagree(self):
+        """SDPA does not broadcast batch dimensions."""
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(B, H, L, E)),
+            mb.TensorSpec(shape=(B, H, S, E)),
+            mb.TensorSpec(shape=(1, H, S, E)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_not_fused_when_softmax_is_not_over_the_last_axis(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=2)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(1,), dtype=types.bool)], opset_version=ct.target.iOS18)
+        def prog(q, k, v, pred):
+            def true_fn():
+                scores = mb.matmul(x=q, y=k, transpose_y=True)
+                weights = mb.softmax(x=scores, axis=-1)
+                return mb.matmul(x=weights, y=v, transpose_y=False)
+
+            def false_fn():
+                return mb.mul(x=q, y=np.float32(0.0))
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 1
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestSafeSoftmaxWrapper:
+    """`torch._safe_softmax` zeroes rows that are entirely -inf; peel that."""
+
+    @staticmethod
+    def _assert_peeled(prog):
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        for op_type in ("softmax", "select", "reduce_max", "reduce_min", "equal", "not_equal"):
+            assert op_type not in ops, f"{op_type} was left behind: {ops}"
+
+    def test_wrapper_is_peeled_when_there_is_no_mask(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(scaled), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        self._assert_peeled(prog)
+        assert_model_is_valid(
+            prog,
+            {"q": (B, H, L, E), "k": (B, H, S, E), "v": (B, H, S, E)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_wrapper_is_peeled_when_the_weights_are_the_true_branch(self):
+        """`select(any(scores != -inf), softmax, 0.0)` -- the mirrored polarity."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            finite = mb.cast(x=mb.logical_not(x=mb.equal(x=scaled, y=NEG_INF)), dtype="int32")
+            any_finite = mb.reduce_max(x=finite, axes=[3], keep_dims=True)
+            cond = mb.cast(x=any_finite, dtype="bool")
+            safe = mb.select(cond=cond, a=weights, b=np.float32(0.0))
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        self._assert_peeled(prog)
+
+    def test_wrapper_is_peeled_when_expressed_as_a_min_reduction(self):
+        """`select(all(scores == -inf), 0.0, softmax)`."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            masked_out = mb.cast(x=mb.equal(x=scaled, y=NEG_INF), dtype="int32")
+            all_masked = mb.reduce_min(x=masked_out, axes=[3], keep_dims=True)
+            cond = mb.cast(x=all_masked, dtype="bool")
+            safe = mb.select(cond=cond, a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        self._assert_peeled(prog)
+
+    def test_wrapper_with_inverted_polarity_is_not_fused(self):
+        """`select(all(scores == -inf), softmax, 0.0)` keeps only the masked rows."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(scaled), a=weights, b=np.float32(0.0))
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+        assert "softmax" in get_op_types_in_program(prog)
+
+    def test_wrapper_reducing_with_the_wrong_quantifier_is_not_fused(self):
+        """`any(scores == -inf)` is not `all(scores == -inf)`."""
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            masked_out = mb.cast(x=mb.equal(x=scaled, y=NEG_INF), dtype="int32")
+            any_masked = mb.reduce_max(x=masked_out, axes=[3], keep_dims=True)
+            cond = mb.cast(x=any_masked, dtype="bool")
+            safe = mb.select(cond=cond, a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_wrapper_reducing_over_the_wrong_axis_is_not_fused(self):
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            weights = mb.softmax(x=scaled, axis=-1)
+            finite = mb.cast(x=mb.logical_not(x=mb.equal(x=scaled, y=NEG_INF)), dtype="int32")
+            any_finite = mb.reduce_max(x=finite, axes=[2], keep_dims=True)
+            cond = mb.cast(x=any_finite, dtype="bool")
+            safe = mb.select(cond=cond, a=weights, b=np.float32(0.0))
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_wrapper_is_peeled_for_a_finite_select_fill(self):
+        """With a finite fill no row can be all -inf, so the wrapper is an identity."""
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            masked = mb.select(cond=mask, a=scores, b=TORCH_MIN_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(masked), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        self._assert_peeled(prog)
+
+    def test_wrapper_is_kept_for_a_neg_inf_select_fill(self):
+        """A -inf fill *can* produce an all -inf row, which the wrapper zeroes."""
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            masked = mb.select(cond=mask, a=scores, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(masked), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_wrapper_is_peeled_for_a_constant_additive_mask(self):
+        bias = np.arange(L * S, dtype=np.float32).reshape(1, 1, L, S)
+
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=scores, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(biased), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        self._assert_peeled(prog)
+
+    def test_wrapper_is_kept_for_a_constant_additive_mask_holding_neg_inf(self):
+        bias = np.zeros((1, 1, L, S), dtype=np.float32)
+        bias[0, 0, 0, :] = -np.inf
+
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=scores, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(biased), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_wrapper_is_kept_for_a_runtime_additive_mask(self):
+        """A mask built at runtime (Whisper) may well contain an all -inf row."""
+        @mb.program(
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, L, S))],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v, bias):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=scores, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            safe = mb.select(cond=_all_neg_inf_rows(biased), a=np.float32(0.0), b=weights)
+            return mb.matmul(x=safe, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+
+class TestRegroup:
+    """`_regroup` models a reshape as a re-grouping of the score axes."""
+
+    @staticmethod
+    def _sizes(grouped):
+        return [[atom.size for atom in group] for group in grouped]
+
+    def test_trailing_size_one_dimensions_each_get_an_atom(self):
+        """`[4, 1, 1] -> [1, 4, 1, 1]`: the last axis must stay identifiable."""
+        atoms = [_Atom(4), _Atom(1), _Atom(1)]
+        grouped = _regroup(atoms, [1, 4, 1, 1])
+        assert self._sizes(grouped) == [[], [4], [1], [1]]
+        assert grouped[-1][0] is atoms[-1]
+        assert grouped[-2][0] is atoms[-2]
+
+    def test_size_one_atoms_are_absorbed_when_they_are_spare(self):
+        atoms = [_Atom(1), _Atom(4), _Atom(1)]
+        assert self._sizes(_regroup(atoms, [4, 1])) == [[1, 4], [1]]
+        assert self._sizes(_regroup([_Atom(1), _Atom(4), _Atom(1)], [4])) == [[1, 4, 1]]
+
+    def test_axes_are_split_and_merged(self):
+        atoms = [_Atom(2), _Atom(15)]
+        assert self._sizes(_regroup(atoms, [6, 5])) == [[2, 3], [5]]
+        assert _regroup([_Atom(2), _Atom(15)], [4, 8]) is None
+        assert _regroup([_Atom(6)], [4]) is None
+
+
+class TestFuseAttentionToSdpaEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    @staticmethod
+    def _assert_fused(cml_model, expected: int = 1):
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_dot_product_attention") == expected
+        assert "softmax" not in ops
+        assert "matmul" not in ops
+        return ops
+
+    def test_plain_attention_with_bool_mask(self):
+        def attention(q, k, v, mask):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0)
+            scores = jnp.where(mask[:, None, None, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((2, 3, 5, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 7), jnp.bool_),
+        ])
+        self._assert_fused(cml_model)
+
+    def test_gemma_style_gqa_einsum_attention(self):
+        def attention(q, k, v, mask):
+            scores = jnp.einsum("btkgh,bskh->bkgts", q, k)
+            scores = jnp.where(mask[:, None, None, :, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bkgts,bskh->btkgh", weights, v)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((1, 5, 2, 3, 4), jnp.float32),   # b t k g h
+            jax.ShapeDtypeStruct((1, 7, 2, 4), jnp.float32),      # b s k h
+            jax.ShapeDtypeStruct((1, 7, 2, 4), jnp.float32),      # b s k h
+            jax.ShapeDtypeStruct((1, 5, 7), jnp.bool_),           # b t s
+        ])
+        self._assert_fused(cml_model)
+
+    def test_attention_without_mask(self):
+        def attention(q, k, v):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((2, 3, 5, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+        ])
+        ops = self._assert_fused(cml_model)
+        assert ops == ["scaled_dot_product_attention"]
+
+    def test_attention_with_additive_bias(self):
+        def attention(q, k, v, bias):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0) + bias
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((2, 3, 5, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 1, 5, 7), jnp.float32),
+        ])
+        self._assert_fused(cml_model)
+
+    def test_two_layer_attention_stack(self):
+        def layer(x, k, v, mask):
+            scores = jnp.einsum("bhld,bhsd->bhls", x, k) / jnp.sqrt(4.0)
+            scores = jnp.where(mask[:, None, None, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        def stack(x, k1, v1, k2, v2, mask):
+            hidden = layer(x, k1, v1, mask)
+            return layer(hidden, k2, v2, mask)
+
+        cml_model = run_and_compare(stack, [
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 7), jnp.bool_),
+        ])
+        self._assert_fused(cml_model, expected=2)
+
+    def test_fully_masked_row_stays_finite(self):
+        """The additive mask keeps a fully masked row finite, as -1e9 did."""
+        from tests.utils import run_and_compare_specific_input  # noqa: PLC0415
+
+        def attention(q, k, v, mask):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0)
+            scores = jnp.where(mask[:, None, None, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        key = jax.random.PRNGKey(0)
+        q = jax.random.normal(key, (2, 3, 5, 4), jnp.float32)
+        k = jax.random.normal(key, (2, 3, 7, 4), jnp.float32)
+        v = jax.random.normal(key, (2, 3, 7, 4), jnp.float32)
+        mask = jnp.array([[False] * 7, [True] * 7])
+
+        cml_model = run_and_compare_specific_input(attention, [q, k, v, mask])
+        self._assert_fused(cml_model)
+
+    def test_flax_multi_head_attention(self):
+        from flax import nnx  # noqa: PLC0415
+
+        class Attention(nnx.Module):
+            def __init__(self, rngs):
+                self.layer = nnx.MultiHeadAttention(
+                    num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=rngs
+                )
+
+            def __call__(self, q, k, v):
+                return self.layer(q, k, v)
+
+        shape = (4, 3, 2, 5)
+        cml_model = run_and_compare(
+            nnx.jit(Attention(nnx.Rngs(0))),
+            (jnp.zeros(shape), jnp.zeros(shape), jnp.zeros(shape)),
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "softmax" not in ops

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -14,11 +14,8 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from stablehlo_coreml.passes.fuse_attention_to_sdpa import _Atom, _regroup
 from tests.utils import get_model_instruction_types, run_and_compare
-
-register_optimizations()
 
 PASS_NAME = "common::fuse_attention_to_sdpa"
 DCE_PASS_NAME = "common::dead_code_elimination"

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -282,11 +282,25 @@ class TestFuseAttentionToSdpa:
         _apply(prog)
         ops = get_op_types_in_program(prog)
         factor = scale * math.sqrt(E)
-        if abs(factor - 1.0) < 1e-3:
+        if factor == 1.0:
             assert ops == ["scaled_dot_product_attention"]
         else:
             assert ops == ["mul", "scaled_dot_product_attention"]
             np.testing.assert_allclose(_ops(prog)[-2].y.val, factor, rtol=1e-5)
+
+    def test_near_builtin_scale_is_preserved(self):
+        scale = np.float32(0.4999)
+
+        @mb.program(input_specs=_qkv_specs(), opset_version=ct.target.iOS18)
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=scale)
+            weights = mb.softmax(x=scaled, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["mul", "scaled_dot_product_attention"]
+        np.testing.assert_allclose(_ops(prog)[-2].y.val, float(scale) * math.sqrt(E), rtol=1e-7)
 
     def test_transposed_key(self):
         """`transpose_y=False` means the key still has to be transposed."""

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -21,6 +21,7 @@ from tests.utils import get_model_instruction_types, run_and_compare
 register_optimizations()
 
 PASS_NAME = "common::fuse_attention_to_sdpa"
+DCE_PASS_NAME = "common::dead_code_elimination"
 
 # [B, H, L, S] scores from [B, H, L, E] queries and [B, H, S, E] keys.
 B, H, L, S, E = 2, 3, 5, 7, 4
@@ -32,9 +33,12 @@ TORCH_MIN_FILL = np.float32(np.finfo(np.float32).min)
 
 
 def _apply(prog, **options):
+    # The pass leaves the matched ops behind; DCE is what removes them.
     if not options:
-        return apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
-    pipeline = ct.PassPipeline([PASS_NAME], "fuse_attention")
+        result = apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+        apply_pass_and_basic_check(prog, DCE_PASS_NAME, skip_output_shape_check=True)
+        return result
+    pipeline = ct.PassPipeline([PASS_NAME, DCE_PASS_NAME], "fuse_attention")
     pipeline.set_options(PASS_NAME, options)
     PassPipelineManager.apply_pipeline(prog, pipeline)
     return prog

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -1,0 +1,207 @@
+import math
+
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_jit_lowering
+
+register_optimizations()
+
+PASS_NAME = "common::fuse_gelu_erfc"
+INV_SQRT2 = 1.0 / math.sqrt(2.0)
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME)
+
+
+def _erfc_gelu(x, negate_first=True, factor=INV_SQRT2, half=0.5, one=1.0):
+    """Build `half * x * (one - erf(-factor * x))` in the current MIL block."""
+    half_x = mb.mul(x=x, y=half)
+    if negate_first:
+        arg = mb.mul(x=mb.sub(x=0.0, y=x), y=factor)
+    else:
+        arg = mb.sub(x=0.0, y=mb.mul(x=x, y=factor))
+    return mb.mul(x=half_x, y=mb.sub(x=one, y=mb.erf(x=arg)))
+
+
+class TestFuseGeluErfc:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_negate_then_scale(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x)
+
+        assert get_op_types_in_program(prog) == ["mul", "sub", "mul", "erf", "sub", "mul"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+        assert_model_is_valid(
+            prog, {"x": (4, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_scale_then_negate(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x, negate_first=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_division_form(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            half_x = mb.mul(x=0.5, y=x)
+            arg = mb.real_div(x=mb.sub(x=0.0, y=x), y=math.sqrt(2.0))
+            return mb.mul(x=mb.sub(x=1.0, y=mb.erf(x=arg)), y=half_x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_single_negative_multiplier(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            half_x = mb.mul(x=x, y=0.5)
+            arg = mb.mul(x=x, y=-INV_SQRT2)
+            return mb.mul(x=half_x, y=mb.sub(x=1.0, y=mb.erf(x=arg)))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_uniform_tensor_constants(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(
+                x,
+                factor=np.full((1,), INV_SQRT2, dtype=np.float32),
+                half=np.full((1,), 0.5, dtype=np.float32),
+                one=np.full((1,), 1.0, dtype=np.float32),
+            )
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_not_fused_for_the_wrong_factor(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x, factor=0.5)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_without_the_negation(self):
+        """`0.5 * x * (1 - erf(x/sqrt(2)))` is not GELU (it is x - gelu(x))."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            half_x = mb.mul(x=x, y=0.5)
+            arg = mb.mul(x=x, y=INV_SQRT2)
+            return mb.mul(x=half_x, y=mb.sub(x=1.0, y=mb.erf(x=arg)))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_the_wrong_half(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x, half=0.25)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_a_different_input(self):
+        """The `0.5 *` and the `erf` must be applied to the same var."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 8))])
+        def prog(x, y):
+            half_x = mb.mul(x=x, y=0.5)
+            arg = mb.mul(x=mb.sub(x=0.0, y=y), y=INV_SQRT2)
+            return mb.mul(x=half_x, y=mb.sub(x=1.0, y=mb.erf(x=arg)))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_when_erf_is_shared(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            half_x = mb.mul(x=x, y=0.5)
+            arg = mb.mul(x=mb.sub(x=0.0, y=x), y=INV_SQRT2)
+            erf = mb.erf(x=arg)
+            return mb.mul(x=half_x, y=mb.sub(x=1.0, y=erf)), erf
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                return _erfc_gelu(x)
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog, recurse=True)
+        assert "gelu" in ops
+        assert "erf" not in ops
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestFuseGeluErfcEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_exact_gelu_via_jit_lowering(self):
+        """The `jax.jit(...).lower()` path keeps `chlo.erfc`, which becomes `1 - erf`."""
+        inputs = (jax.random.normal(jax.random.PRNGKey(0), (4, 16), dtype=jnp.float32),)
+        cml_model = run_and_compare_jit_lowering(
+            lambda x: jax.nn.gelu(x, approximate=False), inputs
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("gelu") == 1
+        assert "erf" not in ops
+
+    def test_exact_gelu_via_jax_export(self):
+        """`jax.export` expands `chlo.erfc` itself, so only the numerics are checked.
+
+        (jax.export legalizes CHLO before we ever see the module and, unlike
+        `chlo.erf`, `chlo.erfc` has no composite representation there.)
+        """
+        cml_model = run_and_compare(
+            lambda x: jax.nn.gelu(x, approximate=False),
+            [jax.ShapeDtypeStruct((4, 16), jnp.float32)],
+        )
+        assert "gelu" not in get_model_instruction_types(cml_model)
+
+    def test_tanh_approximated_gelu_still_converts(self):
+        """The tanh approximation converts correctly, but is not fused.
+
+        coremltools' `fuse_gelu_tanh_approximation` insists on a literal
+        `pow(x, 3)`, while JAX emits `x * x * x`. This pass deliberately only
+        covers the `erfc` form, so the approximation stays decomposed.
+        """
+        cml_model = run_and_compare(
+            lambda x: jax.nn.gelu(x, approximate=True),
+            [jax.ShapeDtypeStruct((4, 16), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("tanh") == 1

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -99,6 +99,14 @@ class TestFuseGeluErfc:
         _apply(prog)
         assert "gelu" not in get_op_types_in_program(prog)
 
+    def test_not_fused_for_a_nearby_factor(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _erfc_gelu(x, factor=0.7062)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
     def test_not_fused_without_the_negation(self):
         """`0.5 * x * (1 - erf(x/sqrt(2)))` is not GELU (it is x - gelu(x))."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -18,11 +18,14 @@ from tests.utils import get_model_instruction_types, run_and_compare, run_and_co
 register_optimizations()
 
 PASS_NAME = "common::fuse_gelu_erfc"
+DCE_PASS_NAME = "common::dead_code_elimination"
 INV_SQRT2 = 1.0 / math.sqrt(2.0)
 
 
 def _apply(prog):
     apply_pass_and_basic_check(prog, PASS_NAME)
+    # The pass leaves the matched ops behind; DCE is what removes them.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
 
 
 def _erfc_gelu(x, negate_first=True, factor=INV_SQRT2, half=0.5, one=1.0):

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -12,10 +12,7 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_jit_lowering
-
-register_optimizations()
 
 PASS_NAME = "common::fuse_gelu_erfc"
 DCE_PASS_NAME = "common::dead_code_elimination"

--- a/tests/passes/test_fuse_logit_softcap.py
+++ b/tests/passes/test_fuse_logit_softcap.py
@@ -1,0 +1,183 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from tests.utils import get_model_instruction_types, run_and_compare
+
+register_optimizations()
+
+PASS_NAME = "common::fuse_logit_softcap"
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME)
+
+
+def _scaled_tanh_ops(prog):
+    return [op for op in prog.functions["main"].operations if op.op_type == "scaled_tanh"]
+
+
+class TestFuseLogitSoftcap:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_div_then_mul(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.real_div(x=x, y=30.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=30.0)
+
+        assert get_op_types_in_program(prog) == ["real_div", "tanh", "mul"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+        fused = _scaled_tanh_ops(prog)[0]
+        assert np.isclose(fused.alpha.val, 30.0)
+        assert np.isclose(fused.beta.val, 1.0 / 30.0)
+        assert_model_is_valid(
+            prog, {"x": (2, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_mul_then_mul(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.mul(x=x, y=1.0 / 30.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=30.0)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+    def test_reversed_operand_orders(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.mul(x=1.0 / 30.0, y=x)
+            return mb.mul(x=30.0, y=mb.tanh(x=scaled))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+    def test_uniform_tensor_constants(self):
+        """The cap may be a (broadcast) constant tensor as long as it is uniform."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            cap = np.full((1,), 30.0, dtype=np.float32)
+            scaled = mb.real_div(x=x, y=cap)
+            return mb.mul(x=mb.tanh(x=scaled), y=cap)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+    def test_not_fused_when_product_is_not_one(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.real_div(x=x, y=30.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=20.0)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["real_div", "tanh", "mul"]
+
+    def test_not_fused_without_outer_scale(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8)), mb.TensorSpec(shape=(2, 8))])
+        def prog(x, y):
+            return mb.mul(x=mb.tanh(x=x), y=y)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tanh", "mul"]
+
+    def test_not_fused_when_tanh_has_multiple_consumers(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.real_div(x=x, y=30.0)
+            capped = mb.tanh(x=scaled)
+            return mb.mul(x=capped, y=30.0), mb.add(x=capped, y=1.0)
+
+        _apply(prog)
+        assert "scaled_tanh" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_non_uniform_constant(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2,))])
+        def prog(x):
+            cap = np.array([30.0, 20.0], dtype=np.float32)
+            scaled = mb.real_div(x=x, y=cap)
+            return mb.mul(x=mb.tanh(x=scaled), y=cap)
+
+        _apply(prog)
+        assert "scaled_tanh" not in get_op_types_in_program(prog)
+
+    def test_inner_scale_shared_keeps_beta_one(self):
+        """When the scaled value escapes, only `a * tanh(v)` may be fused (a == 1)."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.real_div(x=x, y=30.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=30.0), scaled
+
+        _apply(prog)
+        # beta would have to be 1 (the div cannot be peeled), and 30 * 1 != 1.
+        assert "scaled_tanh" not in get_op_types_in_program(prog)
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                scaled = mb.real_div(x=x, y=30.0)
+                return mb.mul(x=mb.tanh(x=scaled), y=30.0)
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog, recurse=True)
+        assert "scaled_tanh" in ops
+        assert "tanh" not in ops
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.real_div(x=x, y=30.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=30.0)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestFuseLogitSoftcapEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_softcap(self):
+        def f(x):
+            return jnp.tanh(x / 30.0) * 30.0
+
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_tanh") == 1
+        assert "tanh" not in ops
+
+    def test_softcap_with_multiplication(self):
+        def f(x):
+            return jnp.tanh(x * 0.02) * 50.0
+
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_tanh") == 1
+        assert "tanh" not in ops
+
+    def test_unbalanced_scaling_is_not_fused(self):
+        def f(x):
+            return jnp.tanh(x / 30.0) * 20.0
+
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert "scaled_tanh" not in ops
+        assert ops.count("tanh") == 1

--- a/tests/passes/test_fuse_logit_softcap.py
+++ b/tests/passes/test_fuse_logit_softcap.py
@@ -16,10 +16,13 @@ from tests.utils import get_model_instruction_types, run_and_compare
 register_optimizations()
 
 PASS_NAME = "common::fuse_logit_softcap"
+DCE_PASS_NAME = "common::dead_code_elimination"
 
 
 def _apply(prog):
     apply_pass_and_basic_check(prog, PASS_NAME)
+    # The pass leaves the matched ops behind; DCE is what removes them.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
 
 
 def _scaled_tanh_ops(prog):

--- a/tests/passes/test_fuse_logit_softcap.py
+++ b/tests/passes/test_fuse_logit_softcap.py
@@ -10,10 +10,7 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from tests.utils import get_model_instruction_types, run_and_compare
-
-register_optimizations()
 
 PASS_NAME = "common::fuse_logit_softcap"
 DCE_PASS_NAME = "common::dead_code_elimination"

--- a/tests/passes/test_fuse_reduce_keep_dims.py
+++ b/tests/passes/test_fuse_reduce_keep_dims.py
@@ -11,11 +11,8 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from stablehlo_coreml.passes.fuse_reduce_keep_dims import _REDUCE_OPS
 from tests.utils import get_model_instruction_types, run_and_compare
-
-register_optimizations()
 
 PASS_NAME = "common::fuse_reduce_keep_dims"
 DCE_PASS_NAME = "common::dead_code_elimination"

--- a/tests/passes/test_fuse_reduce_keep_dims.py
+++ b/tests/passes/test_fuse_reduce_keep_dims.py
@@ -18,10 +18,13 @@ from tests.utils import get_model_instruction_types, run_and_compare
 register_optimizations()
 
 PASS_NAME = "common::fuse_reduce_keep_dims"
+DCE_PASS_NAME = "common::dead_code_elimination"
 
 
 def _apply(prog):
     apply_pass_and_basic_check(prog, PASS_NAME)
+    # The pass leaves the matched ops behind; DCE is what removes them.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
 
 
 def _ops_of_type(prog, op_type):

--- a/tests/passes/test_fuse_reduce_keep_dims.py
+++ b/tests/passes/test_fuse_reduce_keep_dims.py
@@ -1,0 +1,239 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from stablehlo_coreml.passes.fuse_reduce_keep_dims import _REDUCE_OPS
+from tests.utils import get_model_instruction_types, run_and_compare
+
+register_optimizations()
+
+PASS_NAME = "common::fuse_reduce_keep_dims"
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME)
+
+
+def _ops_of_type(prog, op_type):
+    return [op for op in prog.functions["main"].operations if op.op_type == op_type]
+
+
+class TestFuseReduceKeepDims:
+    """Unit tests on hand-built MIL programs."""
+
+    @pytest.mark.parametrize("reduce_op", sorted(_REDUCE_OPS))
+    def test_every_supported_reduce_op_is_fused(self, reduce_op):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = getattr(mb, reduce_op)(x=x, axes=[2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        assert get_op_types_in_program(prog) == [reduce_op, "reshape"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == [reduce_op]
+
+        fused = _ops_of_type(prog, reduce_op)
+        assert len(fused) == 1
+        assert fused[0].keep_dims.val
+        assert prog.functions["main"].outputs[0].shape == (2, 8, 1)
+        assert_model_is_valid(
+            prog, {"x": (2, 8, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_multiple_axes_are_fused(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[0, 2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[1, 8, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (1, 8, 1)
+
+    def test_negative_axes_are_normalized(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_mean(x=x, axes=[-1], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_mean"]
+        assert list(_ops_of_type(prog, "reduce_mean")[0].axes.val) == [2]
+
+    def test_reduce_over_all_axes_is_fused(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[0, 1], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[1, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (1, 1)
+
+    def test_symbolic_dims_are_fused(self):
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[-1, 8, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (batch, 8, 1)
+
+    def test_keep_dims_already_true_is_untouched(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=True)
+            return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "reshape"]
+
+    def test_reshape_to_a_different_shape_is_untouched(self):
+        """The reshape merges dimensions instead of re-inserting the reduced one."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[16, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "reshape"]
+
+    def test_size_one_axis_in_the_wrong_place_is_untouched(self):
+        """`(2, 8, 16) -> reduce axis 1 -> (2, 16)` reshaped to `(2, 16, 1)`, not `(2, 1, 16)`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 16, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "reshape"]
+
+    def test_arg_reductions_are_untouched(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_argmax(x=x, axis=2, keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_argmax", "reshape"]
+
+    def test_reduce_with_extra_consumers_is_kept(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            keep_dims = mb.reshape(x=reduced, shape=[2, 8, 1])
+            squeezed = mb.mul(x=reduced, y=2.0)
+            return keep_dims, squeezed
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        # The reshape is gone, but the keep_dims=False reduce stays for `mul`.
+        assert ops.count("reshape") == 0
+        assert ops.count("reduce_sum") == 2
+        main = prog.functions["main"]
+        assert main.outputs[0].shape == (2, 8, 1)
+        assert main.outputs[1].shape == (2, 8)
+
+    def test_two_reshapes_on_the_same_reduce(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 8, 1]), mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("reshape") == 0
+        assert ops.count("reduce_sum") == 2
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+                return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+            def false_fn():
+                return mb.reduce_max(x=x, axes=[2], keep_dims=True)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert "reshape" in get_op_types_in_program(prog, recurse=True)
+        _apply(prog)
+        assert "reshape" not in get_op_types_in_program(prog, recurse=True)
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            return mb.reshape(x=reduced, shape=[2, 8, 1])
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestFuseReduceKeepDimsEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_rms_norm_becomes_reduce_mean(self):
+        def rms_norm(x):
+            return x * jax.lax.rsqrt(jnp.mean(x * x, axis=-1, keepdims=True) + 1e-6)
+
+        cml_model = run_and_compare(rms_norm, [jax.ShapeDtypeStruct((2, 8, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        # Removing the keep-dims reshape lets coremltools' own `fuse_reduce_mean`
+        # collapse `reduce_sum -> mul(1/N)` into a single `reduce_mean`.
+        assert ops.count("reduce_mean") == 1
+        assert "reduce_sum" not in ops
+        assert "reshape" not in ops
+
+    def test_mean_and_variance_become_reduce_means(self):
+        def layer_norm(x):
+            mean = jnp.mean(x, axis=-1, keepdims=True)
+            var = jnp.mean((x - mean) ** 2, axis=-1, keepdims=True)
+            return (x - mean) * jax.lax.rsqrt(var + 1e-6)
+
+        cml_model = run_and_compare(layer_norm, [jax.ShapeDtypeStruct((2, 8, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("reduce_mean") == 2
+        assert "reduce_sum" not in ops
+
+    def test_keepdims_max_keeps_a_single_reduce(self):
+        def f(x):
+            return x - jnp.max(x, axis=1, keepdims=True)
+
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 6, 8), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("reduce_max") == 1
+        assert "reshape" not in ops
+
+    def test_symbolic_batch_dim(self):
+        symbolic_shape = jax.export.symbolic_shape("(b, 8, 16)")
+
+        def f(x):
+            return jnp.sum(x, axis=-1, keepdims=True)
+
+        from tests.utils import run_and_compare_symbolic  # noqa: PLC0415
+
+        cml_model = run_and_compare_symbolic(
+            f,
+            [jax.ShapeDtypeStruct(symbolic_shape, jnp.float32)],
+            [(np.zeros((3, 8, 16), dtype=np.float32),), (np.ones((5, 8, 16), dtype=np.float32),)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("reduce_sum") == 1
+        assert "reshape" not in ops

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -1,7 +1,7 @@
 import coremltools as ct
 import pytest
 
-from stablehlo_coreml import build_pass_pipeline, register_optimizations
+from stablehlo_coreml import build_pass_pipeline
 from stablehlo_coreml.passes.utils import CLEANUP_PASSES, DEFAULT_HLO_PIPELINE, FUSION_PASSES
 
 DCE_PASS_NAME = "common::dead_code_elimination"
@@ -77,11 +77,3 @@ def test_build_pass_pipeline_preserves_pass_options():
 
     pipeline = build_pass_pipeline(base)
     assert "common::const_elimination" in pipeline._pass_options
-
-
-def test_register_optimizations_is_idempotent():
-    register_optimizations()
-    register_optimizations()
-
-    for pass_name in OUR_PASSES:
-        assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1

--- a/tests/passes/test_pattern_utils.py
+++ b/tests/passes/test_pattern_utils.py
@@ -1,0 +1,226 @@
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+
+from stablehlo_coreml.passes.pattern_utils import (
+    broadcast_shapes,
+    dims_equal,
+    is_large_negative,
+    is_neg_inf,
+    remove_dead_ops,
+    shapes_equal,
+    sole_consumer,
+    uniform_scalar_value,
+)
+
+
+def _build(builder_fn, input_shape=(4, 8)):
+    """Build a tiny MIL program, returning (prog, captured_vars).
+
+    ``builder_fn(x, captured)`` gets the program input and a dict it can stash
+    intermediate vars in, and must return the program output.
+    """
+    captured = {}
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=input_shape)])
+    def prog(x):
+        captured["x"] = x
+        return builder_fn(x, captured)
+
+    return prog, captured
+
+
+class TestUniformScalarValue:
+
+    def test_scalar_const(self):
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=np.float32(3.5))))
+        assert uniform_scalar_value(captured["v"].op.inputs["y"]) == pytest.approx(3.5)
+
+    def test_uniform_tensor_const(self):
+        const = np.full((4, 8), -2.25, dtype=np.float32)
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=const)))
+        assert uniform_scalar_value(captured["v"].op.inputs["y"]) == pytest.approx(-2.25)
+
+    def test_non_uniform_const_is_none(self):
+        const = np.arange(32, dtype=np.float32).reshape(4, 8)
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=const)))
+        assert uniform_scalar_value(captured["v"].op.inputs["y"]) is None
+
+    def test_fill_op(self):
+        def build(x, captured):
+            captured["fill"] = mb.fill(shape=[4, 8], value=-1e9)
+            return mb.add(x=x, y=captured["fill"])
+        _, captured = _build(build)
+        assert uniform_scalar_value(captured["fill"]) == pytest.approx(-1e9)
+
+    def test_non_const_var_is_none(self):
+        _, captured = _build(lambda x, c: mb.add(x=x, y=1.0))
+        assert uniform_scalar_value(captured["x"]) is None
+
+    def test_none_is_none(self):
+        assert uniform_scalar_value(None) is None
+
+    def test_empty_const_is_none(self):
+        empty = np.zeros((0,), dtype=np.float32)
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.concat(values=[mb.reshape(x=x, shape=(32,)), empty], axis=0)))
+        assert uniform_scalar_value(captured["v"].op.inputs["values"][1]) is None
+
+    def test_nan_const_is_none(self):
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=np.float32("nan"))))
+        assert uniform_scalar_value(captured["v"].op.inputs["y"]) is None
+
+
+class TestNegativeValueHelpers:
+
+    def _const_var(self, value):
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=value)))
+        return captured["v"].op.inputs["y"]
+
+    def test_is_neg_inf(self):
+        assert is_neg_inf(self._const_var(np.float32("-inf")))
+        assert is_neg_inf(self._const_var(np.float32(-3.4e38)))
+        assert not is_neg_inf(self._const_var(np.float32(-1e9)))
+        assert not is_neg_inf(self._const_var(np.float32("inf")))
+
+    def test_is_neg_inf_from_fill(self):
+        def build(x, captured):
+            captured["fill"] = mb.fill(shape=[4, 8], value=float("-inf"))
+            return mb.add(x=x, y=captured["fill"])
+        _, captured = _build(build)
+        assert is_neg_inf(captured["fill"])
+
+    def test_is_large_negative(self):
+        assert is_large_negative(self._const_var(np.float32(-1e9)))
+        assert is_large_negative(self._const_var(np.float32("-inf")))
+        assert not is_large_negative(self._const_var(np.float32(-1.0)))
+        assert is_large_negative(self._const_var(np.float32(-1.0)), threshold=-0.5)
+
+
+class TestShapeHelpers:
+
+    def test_dims_equal(self):
+        symbol = get_new_symbol()
+        other = get_new_symbol()
+        assert dims_equal(4, 4)
+        assert dims_equal(np.int64(4), 4)
+        assert not dims_equal(4, 5)
+        assert dims_equal(symbol, symbol)
+        assert not dims_equal(symbol, other)
+        # A symbolic dim is never provably equal to a concrete one
+        assert not dims_equal(symbol, 4)
+        assert not dims_equal(4, symbol)
+
+    def test_shapes_equal(self):
+        symbol = get_new_symbol()
+        assert shapes_equal((2, 3), [2, 3])
+        assert not shapes_equal((2, 3), (2, 3, 1))
+        assert not shapes_equal((2, 3), (2, 4))
+        assert shapes_equal((symbol, 3), (symbol, 3))
+        assert not shapes_equal((symbol, 3), (2, 3))
+        assert not shapes_equal(None, (2, 3))
+
+    def test_broadcast_static(self):
+        assert broadcast_shapes((4, 8), (4, 8)) == (4, 8)
+        assert broadcast_shapes((4, 1), (1, 8)) == (4, 8)
+        assert broadcast_shapes((8,), (4, 8)) == (4, 8)
+        assert broadcast_shapes((), (4, 8)) == (4, 8)
+        assert broadcast_shapes((4, 8)) == (4, 8)
+        assert broadcast_shapes() == ()
+        assert broadcast_shapes((4, 1), (1, 8), (4, 8)) == (4, 8)
+
+    def test_broadcast_incompatible(self):
+        assert broadcast_shapes((4, 3), (4, 8)) is None
+        assert broadcast_shapes((2,), (3,)) is None
+
+    def test_broadcast_symbolic(self):
+        symbol = get_new_symbol()
+        other = get_new_symbol()
+        assert broadcast_shapes((symbol, 8), (symbol, 8)) == (symbol, 8)
+        assert broadcast_shapes((symbol, 1), (symbol, 8)) == (symbol, 8)
+        assert broadcast_shapes((symbol, 8), (1, 8)) == (symbol, 8)
+        # Not provable: `symbol` might be 1, or might be 4
+        assert broadcast_shapes((symbol, 8), (4, 8)) is None
+        assert broadcast_shapes((symbol, 8), (other, 8)) is None
+
+
+class TestSoleConsumer:
+
+    def test_single_consumer(self):
+        def build(x, captured):
+            captured["mid"] = mb.mul(x=x, y=2.0)
+            return mb.add(x=captured["mid"], y=1.0)
+        _, captured = _build(build)
+        consumer = sole_consumer(captured["mid"])
+        assert consumer is not None and consumer.op_type == "add"
+
+    def test_two_consumers(self):
+        def build(x, captured):
+            captured["mid"] = mb.mul(x=x, y=2.0)
+            return mb.add(x=captured["mid"], y=captured["mid"])
+        _, captured = _build(build)
+        assert sole_consumer(captured["mid"]) is None
+
+    def test_no_consumer(self):
+        def build(x, captured):
+            captured["dead"] = mb.mul(x=x, y=2.0)
+            return mb.add(x=x, y=1.0)
+        _, captured = _build(build)
+        assert sole_consumer(captured["dead"]) is None
+
+    def test_block_output_is_not_sole_consumer(self):
+        def build(x, captured):
+            captured["mid"] = mb.mul(x=x, y=2.0)
+            return [mb.add(x=captured["mid"], y=1.0), captured["mid"]]
+        _, captured = _build(build)
+        assert sole_consumer(captured["mid"]) is None
+
+    def test_none(self):
+        assert sole_consumer(None) is None
+
+
+class TestRemoveDeadOps:
+
+    def test_removes_dead_chain(self):
+        def build(x, captured):
+            captured["a"] = mb.mul(x=x, y=2.0)
+            captured["b"] = mb.add(x=captured["a"], y=1.0)
+            return mb.relu(x=x)
+        prog, captured = _build(build)
+        block = prog.functions["main"]
+
+        @block_context_manager
+        def run(b):
+            return remove_dead_ops(b, [captured["a"].op, captured["b"].op])
+
+        # `a` only becomes dead once `b` is gone, so the helper must iterate.
+        assert run(block) == 2
+        assert [op.op_type for op in block.operations if op.op_type != "const"] == ["relu"]
+
+    def test_keeps_live_ops(self):
+        def build(x, captured):
+            captured["a"] = mb.mul(x=x, y=2.0)
+            return mb.add(x=captured["a"], y=1.0)
+        prog, captured = _build(build)
+        block = prog.functions["main"]
+
+        @block_context_manager
+        def run(b):
+            return remove_dead_ops(b, [captured["a"].op])
+
+        assert run(block) == 0
+        assert captured["a"].op.enclosing_block is block
+
+    def test_keeps_block_outputs(self):
+        def build(x, captured):
+            captured["a"] = mb.mul(x=x, y=2.0)
+            return captured["a"]
+        prog, captured = _build(build)
+        block = prog.functions["main"]
+
+        @block_context_manager
+        def run(b):
+            return remove_dead_ops(b, [captured["a"].op])
+
+        assert run(block) == 0

--- a/tests/passes/test_pattern_utils.py
+++ b/tests/passes/test_pattern_utils.py
@@ -2,14 +2,10 @@ import numpy as np
 import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 
 from stablehlo_coreml.passes.pattern_utils import (
     broadcast_shapes,
     dims_equal,
-    is_large_negative,
-    is_neg_inf,
-    remove_dead_ops,
     shapes_equal,
     sole_consumer,
     uniform_scalar_value,
@@ -70,32 +66,6 @@ class TestUniformScalarValue:
     def test_nan_const_is_none(self):
         _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=np.float32("nan"))))
         assert uniform_scalar_value(captured["v"].op.inputs["y"]) is None
-
-
-class TestNegativeValueHelpers:
-
-    def _const_var(self, value):
-        _, captured = _build(lambda x, c: c.setdefault("v", mb.add(x=x, y=value)))
-        return captured["v"].op.inputs["y"]
-
-    def test_is_neg_inf(self):
-        assert is_neg_inf(self._const_var(np.float32("-inf")))
-        assert is_neg_inf(self._const_var(np.float32(-3.4e38)))
-        assert not is_neg_inf(self._const_var(np.float32(-1e9)))
-        assert not is_neg_inf(self._const_var(np.float32("inf")))
-
-    def test_is_neg_inf_from_fill(self):
-        def build(x, captured):
-            captured["fill"] = mb.fill(shape=[4, 8], value=float("-inf"))
-            return mb.add(x=x, y=captured["fill"])
-        _, captured = _build(build)
-        assert is_neg_inf(captured["fill"])
-
-    def test_is_large_negative(self):
-        assert is_large_negative(self._const_var(np.float32(-1e9)))
-        assert is_large_negative(self._const_var(np.float32("-inf")))
-        assert not is_large_negative(self._const_var(np.float32(-1.0)))
-        assert is_large_negative(self._const_var(np.float32(-1.0)), threshold=-0.5)
 
 
 class TestShapeHelpers:
@@ -178,49 +148,3 @@ class TestSoleConsumer:
 
     def test_none(self):
         assert sole_consumer(None) is None
-
-
-class TestRemoveDeadOps:
-
-    def test_removes_dead_chain(self):
-        def build(x, captured):
-            captured["a"] = mb.mul(x=x, y=2.0)
-            captured["b"] = mb.add(x=captured["a"], y=1.0)
-            return mb.relu(x=x)
-        prog, captured = _build(build)
-        block = prog.functions["main"]
-
-        @block_context_manager
-        def run(b):
-            return remove_dead_ops(b, [captured["a"].op, captured["b"].op])
-
-        # `a` only becomes dead once `b` is gone, so the helper must iterate.
-        assert run(block) == 2
-        assert [op.op_type for op in block.operations if op.op_type != "const"] == ["relu"]
-
-    def test_keeps_live_ops(self):
-        def build(x, captured):
-            captured["a"] = mb.mul(x=x, y=2.0)
-            return mb.add(x=captured["a"], y=1.0)
-        prog, captured = _build(build)
-        block = prog.functions["main"]
-
-        @block_context_manager
-        def run(b):
-            return remove_dead_ops(b, [captured["a"].op])
-
-        assert run(block) == 0
-        assert captured["a"].op.enclosing_block is block
-
-    def test_keeps_block_outputs(self):
-        def build(x, captured):
-            captured["a"] = mb.mul(x=x, y=2.0)
-            return captured["a"]
-        prog, captured = _build(build)
-        block = prog.functions["main"]
-
-        @block_context_manager
-        def run(b):
-            return remove_dead_ops(b, [captured["a"].op])
-
-        assert run(block) == 0

--- a/tests/passes/test_register_optimizations.py
+++ b/tests/passes/test_register_optimizations.py
@@ -1,10 +1,84 @@
-from stablehlo_coreml import register_optimizations
-from stablehlo_coreml.passes.utils import DEFAULT_HLO_PIPELINE
+import coremltools as ct
+import pytest
+
+from stablehlo_coreml import build_pass_pipeline, register_optimizations
+from stablehlo_coreml.passes.utils import CLEANUP_PASSES, DEFAULT_HLO_PIPELINE, FUSION_PASSES
+
+ALL_PASSES = CLEANUP_PASSES + FUSION_PASSES
+
+
+@pytest.mark.parametrize("pass_name", ALL_PASSES)
+def test_pass_is_registered(pass_name):
+    from coremltools.converters.mil.mil.passes.pass_pipeline import PASS_REGISTRY  # noqa: PLC0415
+    assert pass_name in PASS_REGISTRY
+
+
+@pytest.mark.parametrize("pass_name", ALL_PASSES)
+def test_default_pipeline_contains_each_pass_exactly_once(pass_name):
+    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1
+
+
+def test_cleanup_passes_run_before_first_const_elimination():
+    passes = build_pass_pipeline().passes
+    first_const_elimination = passes.index("common::const_elimination")
+    for offset, pass_name in enumerate(CLEANUP_PASSES):
+        assert passes.index(pass_name) == first_const_elimination - len(CLEANUP_PASSES) + offset
+
+
+def test_fusion_passes_run_before_fuse_matmul_weight_bias():
+    passes = build_pass_pipeline().passes
+    anchor = passes.index("common::fuse_matmul_weight_bias")
+    for offset, pass_name in enumerate(FUSION_PASSES):
+        assert passes.index(pass_name) == anchor - len(FUSION_PASSES) + offset
+
+
+def test_build_pass_pipeline_returns_distinct_objects():
+    first = build_pass_pipeline()
+    second = build_pass_pipeline()
+    assert first is not second
+    assert first.passes is not second.passes
+    assert first.passes == second.passes
+
+    first.append_pass("common::dead_code_elimination")
+    assert first.passes != second.passes
+    assert DEFAULT_HLO_PIPELINE.passes == second.passes
+
+
+def test_build_pass_pipeline_does_not_mutate_the_base():
+    base = ct.PassPipeline.DEFAULT
+    original = list(base.passes)
+    build_pass_pipeline(base)
+    assert base.passes == original
+
+
+def test_build_pass_pipeline_is_idempotent():
+    once = build_pass_pipeline()
+    twice = build_pass_pipeline(once)
+    assert twice.passes == once.passes
+
+
+def test_build_pass_pipeline_with_base_missing_the_anchors():
+    """Without the anchors, cleanup passes go first and fusion passes last."""
+    base = ct.PassPipeline.EMPTY
+    base.passes = ["common::noop_elimination", "common::dead_code_elimination"]
+
+    pipeline = build_pass_pipeline(base)
+    assert pipeline.passes == (
+        CLEANUP_PASSES + ["common::noop_elimination", "common::dead_code_elimination"] + FUSION_PASSES
+    )
+
+
+def test_build_pass_pipeline_preserves_pass_options():
+    base = ct.PassPipeline.DEFAULT
+    base.set_options(pass_name="common::const_elimination", options={"skip_const_by_size": "100000"})
+
+    pipeline = build_pass_pipeline(base)
+    assert "common::const_elimination" in pipeline._pass_options
 
 
 def test_register_optimizations_is_idempotent():
     register_optimizations()
     register_optimizations()
 
-    pass_name = "common::remove_noop_slice_update"
-    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1
+    for pass_name in ALL_PASSES:
+        assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1

--- a/tests/passes/test_register_optimizations.py
+++ b/tests/passes/test_register_optimizations.py
@@ -4,7 +4,12 @@ import pytest
 from stablehlo_coreml import build_pass_pipeline, register_optimizations
 from stablehlo_coreml.passes.utils import CLEANUP_PASSES, DEFAULT_HLO_PIPELINE, FUSION_PASSES
 
-ALL_PASSES = CLEANUP_PASSES + FUSION_PASSES
+DCE_PASS_NAME = "common::dead_code_elimination"
+# The groups interleave coremltools' DCE with our own passes, so the same name
+# appears several times; only our own passes are expected in the pipeline exactly
+# once.
+ALL_PASSES = list(dict.fromkeys(CLEANUP_PASSES + FUSION_PASSES))
+OUR_PASSES = [name for name in ALL_PASSES if name != DCE_PASS_NAME]
 
 
 @pytest.mark.parametrize("pass_name", ALL_PASSES)
@@ -13,7 +18,7 @@ def test_pass_is_registered(pass_name):
     assert pass_name in PASS_REGISTRY
 
 
-@pytest.mark.parametrize("pass_name", ALL_PASSES)
+@pytest.mark.parametrize("pass_name", OUR_PASSES)
 def test_default_pipeline_contains_each_pass_exactly_once(pass_name):
     assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1
 
@@ -21,15 +26,13 @@ def test_default_pipeline_contains_each_pass_exactly_once(pass_name):
 def test_cleanup_passes_run_before_first_const_elimination():
     passes = build_pass_pipeline().passes
     first_const_elimination = passes.index("common::const_elimination")
-    for offset, pass_name in enumerate(CLEANUP_PASSES):
-        assert passes.index(pass_name) == first_const_elimination - len(CLEANUP_PASSES) + offset
+    assert passes[first_const_elimination - len(CLEANUP_PASSES):first_const_elimination] == CLEANUP_PASSES
 
 
 def test_fusion_passes_run_before_fuse_matmul_weight_bias():
     passes = build_pass_pipeline().passes
     anchor = passes.index("common::fuse_matmul_weight_bias")
-    for offset, pass_name in enumerate(FUSION_PASSES):
-        assert passes.index(pass_name) == anchor - len(FUSION_PASSES) + offset
+    assert passes[anchor - len(FUSION_PASSES):anchor] == FUSION_PASSES
 
 
 def test_build_pass_pipeline_returns_distinct_objects():
@@ -39,7 +42,7 @@ def test_build_pass_pipeline_returns_distinct_objects():
     assert first.passes is not second.passes
     assert first.passes == second.passes
 
-    first.append_pass("common::dead_code_elimination")
+    first.append_pass(DCE_PASS_NAME)
     assert first.passes != second.passes
     assert DEFAULT_HLO_PIPELINE.passes == second.passes
 
@@ -60,11 +63,11 @@ def test_build_pass_pipeline_is_idempotent():
 def test_build_pass_pipeline_with_base_missing_the_anchors():
     """Without the anchors, cleanup passes go first and fusion passes last."""
     base = ct.PassPipeline.EMPTY
-    base.passes = ["common::noop_elimination", "common::dead_code_elimination"]
+    base.passes = ["common::noop_elimination", DCE_PASS_NAME]
 
     pipeline = build_pass_pipeline(base)
     assert pipeline.passes == (
-        CLEANUP_PASSES + ["common::noop_elimination", "common::dead_code_elimination"] + FUSION_PASSES
+        CLEANUP_PASSES + ["common::noop_elimination", DCE_PASS_NAME] + FUSION_PASSES
     )
 
 
@@ -80,5 +83,5 @@ def test_register_optimizations_is_idempotent():
     register_optimizations()
     register_optimizations()
 
-    for pass_name in ALL_PASSES:
+    for pass_name in OUR_PASSES:
         assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1

--- a/tests/passes/test_remove_broadcast_tiles.py
+++ b/tests/passes/test_remove_broadcast_tiles.py
@@ -1,0 +1,257 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from tests.utils import get_model_instruction_types, run_and_compare
+
+register_optimizations()
+
+PASS_NAME = "common::remove_broadcast_tiles"
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+
+
+def _count_tiles(prog, recurse: bool = True) -> int:
+    return get_op_types_in_program(prog, recurse=recurse).count("tile")
+
+
+class TestRemoveBroadcastTiles:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_removed_for_scalar_const_operand(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            scalar = np.full((1, 1), 2.0, dtype=np.float32)
+            tiled = mb.tile(x=scalar, reps=[4, 8])
+            return mb.mul(x=x, y=tiled)
+
+        assert get_op_types_in_program(prog) == ["tile", "mul"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["mul"]
+        assert_model_is_valid(
+            prog, {"x": (4, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_removed_for_tensor_operand(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 8])
+            return mb.add(x=x, y=tiled)
+
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+        assert_model_is_valid(
+            prog, {"x": (4, 8), "y": (4, 1)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_removed_when_both_operands_are_tiled(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1)), mb.TensorSpec(shape=(1, 8))])
+        def prog(x, y):
+            tiled_x = mb.tile(x=x, reps=[1, 8])
+            tiled_y = mb.tile(x=y, reps=[4, 1])
+            return mb.add(x=tiled_x, y=tiled_y)
+
+        assert get_op_types_in_program(prog) == ["tile", "tile", "add"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+        assert_model_is_valid(
+            prog, {"x": (4, 1), "y": (1, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_removed_with_symbolic_batch_dim(self):
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 4, 8)), mb.TensorSpec(shape=(batch, 4, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 1, 8])
+            return mb.add(x=x, y=tiled)
+
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+
+    def test_not_removed_when_symbolic_dim_is_tiled(self):
+        """A symbolic dim cannot be proven to be 1, so tiling it is not a broadcast."""
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 8)), mb.TensorSpec(shape=(4, 8))])
+        def prog(x, y):
+            tiled = mb.tile(x=x, reps=[4, 1])
+            return mb.add(x=tiled, y=y)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+
+    def test_not_removed_for_real_tile(self):
+        """`tile([1, 2], reps=[3]) == [1, 2, 1, 2, 1, 2]` is not a broadcast."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2,)), mb.TensorSpec(shape=(6,))])
+        def prog(x, y):
+            tiled = mb.tile(x=x, reps=[3])
+            return mb.add(x=tiled, y=y)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+
+    def test_not_removed_for_select_consumer(self):
+        """E5RT cannot propagate shapes through `select` with implicit broadcasting."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 8), dtype=types.bool)])
+        def prog(x, cond):
+            fill = np.full((1, 1), -1e9, dtype=np.float32)
+            tiled = mb.tile(x=fill, reps=[4, 8])
+            return mb.select(cond=cond, a=x, b=tiled)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "select"]
+
+    def test_not_removed_for_mixed_consumers(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 8), dtype=types.bool)])
+        def prog(x, cond):
+            fill = np.full((1, 1), -1e9, dtype=np.float32)
+            tiled = mb.tile(x=fill, reps=[4, 8])
+            added = mb.add(x=x, y=tiled)
+            return mb.select(cond=cond, a=added, b=tiled)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "add", "select"]
+
+    def test_not_removed_when_output_shape_would_shrink(self):
+        """Both operands are rank-1 broadcasts; removing both would shrink the output."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1,))])
+        def prog(x):
+            const = np.zeros((1,), dtype=np.float32)
+            tiled_x = mb.tile(x=x, reps=[8])
+            tiled_const = mb.tile(x=const, reps=[8])
+            return mb.add(x=tiled_x, y=tiled_const)
+
+        _apply(prog)
+        # Exactly one of the two tiles can go; the other has to stay to keep the (8,) output.
+        assert _count_tiles(prog) == 1
+        assert prog.functions["main"].outputs[0].shape == (8,)
+        assert_model_is_valid(
+            prog, {"x": (1,)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_not_removed_when_tile_is_block_output(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            return mb.tile(x=x, reps=[1, 8])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile"]
+
+    def test_removed_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                scalar = np.full((1, 1), 2.0, dtype=np.float32)
+                tiled = mb.tile(x=scalar, reps=[4, 8])
+                return mb.mul(x=x, y=tiled)
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert _count_tiles(prog) == 1
+        _apply(prog)
+        assert _count_tiles(prog) == 0
+
+    def test_not_removed_when_consumed_from_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            scalar = np.full((1, 1), 2.0, dtype=np.float32)
+            tiled = mb.tile(x=scalar, reps=[4, 8])
+
+            def true_fn():
+                return mb.mul(x=x, y=tiled)
+
+            def false_fn():
+                return mb.identity(x=tiled)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert _count_tiles(prog) == 1
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 8])
+            return mb.add(x=x, y=tiled)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestRemoveBroadcastTilesEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    @staticmethod
+    def _large_constants(cml_model, max_elements: int = 16):
+        large = []
+        for func in cml_model._mil_program.functions.values():
+            for op in func.operations:
+                if op.op_type != "const":
+                    continue
+                val = op.outputs[0].val
+                if val is not None and np.asarray(val).size > max_elements:
+                    large.append((op.name, np.asarray(val).shape))
+        return large
+
+    def test_scalar_broadcast_leaves_no_tile_and_no_large_const(self):
+        def f(x):
+            return x * 2.0
+
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((256, 1024), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert "tile" not in ops
+        assert self._large_constants(cml_model) == []
+
+    def test_tensor_broadcast_leaves_no_tile(self):
+        def f(x, bias):
+            return x + bias
+
+        cml_model = run_and_compare(
+            f,
+            [jax.ShapeDtypeStruct((2, 16, 64), jnp.float32), jax.ShapeDtypeStruct((1, 1, 64), jnp.float32)],
+        )
+        assert "tile" not in get_model_instruction_types(cml_model)
+
+    def test_where_keeps_its_tile(self):
+        """`jnp.where` lowers to `select`, which must keep its explicit broadcast tile."""
+        def f(scores, mask):
+            return jnp.where(mask, scores, jnp.float32(-1e9))
+
+        cml_model = run_and_compare(
+            f,
+            [jax.ShapeDtypeStruct((2, 4, 8), jnp.float32), jax.ShapeDtypeStruct((2, 4, 8), jnp.bool_)],
+        )
+        assert "select" in get_model_instruction_types(cml_model)
+
+        # The tile feeding `select` survives our pass (coremltools' const_elimination
+        # then folds it into a full-shape constant), so `select` never sees operands
+        # that need implicit broadcasting.
+        selects = [
+            op
+            for func in cml_model._mil_program.functions.values()
+            for op in func.operations
+            if op.op_type == "select"
+        ]
+        assert len(selects) == 1
+        out_shape = tuple(selects[0].outputs[0].shape)
+        for operand in ("cond", "a", "b"):
+            assert tuple(selects[0].inputs[operand].shape) == out_shape

--- a/tests/passes/test_remove_broadcast_tiles.py
+++ b/tests/passes/test_remove_broadcast_tiles.py
@@ -10,10 +10,7 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from tests.utils import get_model_instruction_types, run_and_compare
-
-register_optimizations()
 
 PASS_NAME = "common::remove_broadcast_tiles"
 

--- a/tests/passes/test_remove_noop_slice_update.py
+++ b/tests/passes/test_remove_noop_slice_update.py
@@ -7,9 +7,8 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
-
-register_optimizations()
+# Importing the package registers the passes with coremltools' PASS_REGISTRY.
+import stablehlo_coreml  # noqa: F401
 
 
 class TestRemoveNoopSliceUpdate:

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -1,0 +1,290 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+from tests.utils import get_model_instruction_types, run_and_compare
+
+register_optimizations()
+
+PASS_NAME = "common::replace_decomposed_softmax"
+
+NEG_INF = np.float32(-np.inf)
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+
+
+def _decomposed_softmax(x, axis, shape, *, clamps=1, keep_dims=False, tile=False):
+    """Build the op chain JAX emits for ``softmax(x, axis)``."""
+    keep_dims_shape = list(shape)
+    keep_dims_shape[axis] = 1
+
+    maximum = mb.reduce_max(x=x, axes=[axis], keep_dims=keep_dims)
+    for _ in range(clamps):
+        maximum = mb.maximum(x=NEG_INF, y=maximum)
+    if not keep_dims:
+        maximum = mb.reshape(x=maximum, shape=keep_dims_shape)
+    if tile:
+        reps = [1] * len(shape)
+        reps[axis] = shape[axis]
+        maximum = mb.tile(x=maximum, reps=reps)
+
+    shifted = mb.sub(x=x, y=maximum)
+    exponentiated = mb.exp(x=shifted)
+
+    total = mb.reduce_sum(x=exponentiated, axes=[axis], keep_dims=keep_dims)
+    if not keep_dims:
+        total = mb.reshape(x=total, shape=keep_dims_shape)
+    if tile:
+        reps = [1] * len(shape)
+        reps[axis] = shape[axis]
+        total = mb.tile(x=total, reps=reps)
+
+    return mb.real_div(x=exponentiated, y=total)
+
+
+class TestReplaceDecomposedSoftmax:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_replaces_the_jax_chain(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            return _decomposed_softmax(x, 1, (2, 4))
+
+        assert get_op_types_in_program(prog) == [
+            "reduce_max", "maximum", "reshape", "sub", "exp", "reduce_sum", "reshape", "real_div",
+        ]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+        softmax_op = prog.functions["main"].operations[-1]
+        assert softmax_op.axis.val == 1
+        assert_model_is_valid(
+            prog, {"x": (2, 4)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    @pytest.mark.parametrize("clamps", [0, 1, 2])
+    def test_handles_zero_to_two_neg_inf_clamps(self, clamps):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            return _decomposed_softmax(x, 1, (2, 4), clamps=clamps)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_handles_keep_dims_reductions(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3, 4))])
+        def prog(x):
+            return _decomposed_softmax(x, 2, (2, 3, 4), keep_dims=True)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_handles_broadcast_tiles(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            return _decomposed_softmax(x, 1, (2, 4), tile=True)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_handles_negative_axis(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[-1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[-1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+        assert prog.functions["main"].operations[-1].axis.val == 1
+
+    def test_handles_the_fp16_cast_pair(self):
+        """JAX accumulates the fp16 sum in fp32, adding a cast on each side."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4), dtype=types.fp16)])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            promoted = mb.cast(x=exponentiated, dtype="fp32")
+            total = mb.reduce_sum(x=promoted, axes=[1], keep_dims=True)
+            demoted = mb.cast(x=total, dtype="fp16")
+            return mb.real_div(x=exponentiated, y=demoted)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_handles_symbolic_batch_dim(self):
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 4))])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_keeps_the_shift_when_it_varies_along_the_axis(self):
+        """Softmax is only invariant under a shift that is constant along the axis."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(x, bias):
+            shifted = mb.sub(x=x, y=bias)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["sub", "softmax"]
+
+    def test_uses_the_reduce_sum_axis(self):
+        """The softmax axis is the one the sum reduces over, not the max's."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[0], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        # The shift is not constant along axis 0, so it has to stay.
+        assert get_op_types_in_program(prog) == ["reduce_max", "sub", "softmax"]
+        assert prog.functions["main"].operations[-1].axis.val == 0
+
+    def test_not_replaced_for_a_multi_axis_sum(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3, 4))])
+        def prog(x):
+            exponentiated = mb.exp(x=x)
+            total = mb.reduce_sum(x=exponentiated, axes=[1, 2], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_not_replaced_when_the_sum_is_reshaped_incompatibly(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 4))])
+        def prog(x):
+            exponentiated = mb.exp(x=x)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=False)
+            # Broadcast along the wrong axis: this is not a softmax.
+            reshaped = mb.reshape(x=total, shape=[1, 4])
+            return mb.real_div(x=exponentiated, y=reshaped)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_not_replaced_when_denominator_is_not_a_sum(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_max(x=exponentiated, axes=[1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_not_replaced_when_exp_is_used_elsewhere(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            maximum = mb.reduce_max(x=x, axes=[1], keep_dims=True)
+            shifted = mb.sub(x=x, y=maximum)
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=True)
+            softmax = mb.real_div(x=exponentiated, y=total)
+            return mb.add(x=softmax, y=exponentiated)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_replaced_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                return _decomposed_softmax(x, 1, (2, 4))
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert "softmax" not in get_op_types_in_program(prog, recurse=True)
+        _apply(prog)
+        assert "softmax" in get_op_types_in_program(prog, recurse=True)
+        assert "real_div" not in get_op_types_in_program(prog, recurse=True)
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            return _decomposed_softmax(x, 1, (2, 4))
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestReplaceDecomposedSoftmaxEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_jax_softmax_last_axis(self):
+        cml_model = run_and_compare(
+            lambda x: jax.nn.softmax(x, axis=-1),
+            [jax.ShapeDtypeStruct((3, 16), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        for op_type in ("reduce_max", "reduce_sum", "exp", "real_div"):
+            assert op_type not in ops
+
+    def test_jax_softmax_middle_axis(self):
+        cml_model = run_and_compare(
+            lambda x: jax.nn.softmax(x, axis=1),
+            [jax.ShapeDtypeStruct((2, 5, 4), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+
+    def test_jax_softmax_fp16(self):
+        """The fp16 lowering wraps `reduce_sum` in a cast pair; it must still fuse.
+
+        CoreML cannot take fp16 model inputs here, so the check is done on the
+        MIL program produced by the very same pipeline the other tests use.
+        """
+        from jax._src.interpreters import mlir as jax_mlir  # noqa: PLC0415
+        from jax._src.lib.mlir import ir  # noqa: PLC0415
+
+        from stablehlo_coreml.converter import convert  # noqa: PLC0415
+        from tests.utils import _convert_mil_to_coreml, jax_export  # noqa: PLC0415
+
+        exported = jax_export(
+            jax.jit(lambda x: jax.nn.softmax(x, axis=-1)),
+            [jax.ShapeDtypeStruct((3, 16), jnp.float16)],
+        )
+        context = jax_mlir.make_ir_context()
+        hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
+        mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+
+        cml_model = _convert_mil_to_coreml(mil_program)
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+        assert "reduce_sum" not in ops

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -17,12 +17,15 @@ from tests.utils import get_model_instruction_types, run_and_compare
 register_optimizations()
 
 PASS_NAME = "common::replace_decomposed_softmax"
+DCE_PASS_NAME = "common::dead_code_elimination"
 
 NEG_INF = np.float32(-np.inf)
 
 
 def _apply(prog):
     apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+    # The pass leaves the matched ops behind; DCE is what removes them.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME, skip_output_shape_check=True)
 
 
 def _decomposed_softmax(x, axis, shape, *, clamps=1, keep_dims=False, tile=False):

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -11,10 +11,7 @@ from coremltools.converters.mil.testing_utils import (
     get_op_types_in_program,
 )
 
-from stablehlo_coreml import register_optimizations
 from tests.utils import get_model_instruction_types, run_and_compare
-
-register_optimizations()
 
 PASS_NAME = "common::replace_decomposed_softmax"
 DCE_PASS_NAME = "common::dead_code_elimination"

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -152,6 +152,17 @@ class TestReplaceDecomposedSoftmax:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["sub", "softmax"]
 
+    def test_keeps_a_statically_nonfinite_shift(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            shifted = mb.sub(x=x, y=np.float32(np.inf))
+            exponentiated = mb.exp(x=shifted)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["sub", "softmax"]
+
     def test_uses_the_reduce_sum_axis(self):
         """The softmax axis is the one the sum reduces over, not the max's."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])

--- a/tests/pytorch/test_pytorch.py
+++ b/tests/pytorch/test_pytorch.py
@@ -5,7 +5,7 @@ import pytest
 from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 
-from tests.utils import flatten, run_and_compare_hlo_module
+from tests.utils import flatten, get_model_instruction_types, run_and_compare_hlo_module
 
 torch = pytest.importorskip("torch")
 torchvision = pytest.importorskip("torchvision")
@@ -89,7 +89,18 @@ def _filter_unused_inputs(jaxpr, inputs):
     return [inputs[i].detach().numpy() for i in used_input_indices]
 
 
-def evaluate_pytorch_model(model, inputs, compute_units=ct.ComputeUnit.CPU_ONLY):
+def evaluate_pytorch_model(
+    model,
+    inputs,
+    compute_units=ct.ComputeUnit.CPU_ONLY,
+    expected_op_counts: dict[str, int] | None = None,
+):
+    """Convert `model`, check it against PyTorch, and return the CoreML model.
+
+    `expected_op_counts` asserts how often the named MIL ops occur in the
+    converted model, which is how the graph passes (SDPA fusion, GELU fusion,
+    ...) are regression tested on real architectures.
+    """
     hlo_module, module_inputs = export_to_stablehlo_module(model, inputs)
 
     model_outputs = model(*inputs)
@@ -119,7 +130,7 @@ def evaluate_pytorch_model(model, inputs, compute_units=ct.ComputeUnit.CPU_ONLY)
                              "This likely means the model has uninitialized weights")
 
     # These models are quite big, so tolerances are relaxed
-    run_and_compare_hlo_module(
+    cml_model = run_and_compare_hlo_module(
         hlo_module,
         module_inputs,
         expected_outputs,
@@ -128,6 +139,13 @@ def evaluate_pytorch_model(model, inputs, compute_units=ct.ComputeUnit.CPU_ONLY)
         rtol=5e-02,
         compute_units=compute_units,
     )
+
+    if expected_op_counts is not None:
+        ops = get_model_instruction_types(cml_model)
+        actual = {op_type: ops.count(op_type) for op_type in expected_op_counts}
+        assert actual == expected_op_counts
+
+    return cml_model
 
 
 # ==============================================================================
@@ -153,7 +171,15 @@ def test_tinyllama():
     prompt = "Hello, my name is"
     inputs = tokenizer(prompt, return_tensors="pt")
 
-    evaluate_pytorch_model(model, (inputs.input_ids, ))
+    evaluate_pytorch_model(
+        model,
+        (inputs.input_ids, ),
+        # One fused attention block per decoder layer, and no softmax left over.
+        expected_op_counts={
+            "scaled_dot_product_attention": config.num_hidden_layers,
+            "softmax": 0,
+        },
+    )
 
 
 def test_t5_small():
@@ -175,7 +201,17 @@ def test_t5_small():
     attention_mask = torch.ones_like(input_ids)
 
     # T5Model forward: (input_ids, attention_mask, decoder_input_ids, ...)
-    evaluate_pytorch_model(model, (input_ids, attention_mask, decoder_input_ids))
+    # Encoder self-attention + decoder self- and cross-attention. The relative
+    # position bias is folded into a constant additive mask on the scores.
+    attention_blocks = config.num_layers + 2 * config.num_decoder_layers
+    evaluate_pytorch_model(
+        model,
+        (input_ids, attention_mask, decoder_input_ids),
+        expected_op_counts={
+            "scaled_dot_product_attention": attention_blocks,
+            "softmax": 0,
+        },
+    )
 
 
 def test_distilbert():
@@ -189,7 +225,14 @@ def test_distilbert():
     model = AutoModel.from_config(config)
 
     inputs = tokenizer("this is a test of distilbert", return_tensors="pt")
-    evaluate_pytorch_model(model, (inputs.input_ids, inputs.attention_mask))
+    evaluate_pytorch_model(
+        model,
+        (inputs.input_ids, inputs.attention_mask),
+        expected_op_counts={
+            "scaled_dot_product_attention": config.n_layers,
+            "softmax": 0,
+        },
+    )
 
 
 def test_gpt2():
@@ -203,7 +246,16 @@ def test_gpt2():
     model = AutoModel.from_config(config)
 
     input_ids = tokenizer("this is a test of gpt2", return_tensors="pt").input_ids
-    evaluate_pytorch_model(model, (input_ids, ))
+    evaluate_pytorch_model(
+        model,
+        (input_ids, ),
+        expected_op_counts={
+            "scaled_dot_product_attention": config.n_layer,
+            "softmax": 0,
+            # gpt2 uses the tanh GELU approximation, which coremltools fuses.
+            "gelu": config.n_layer,
+        },
+    )
 
 
 def test_bert():
@@ -217,7 +269,14 @@ def test_bert():
     model = AutoModel.from_config(config)
 
     inputs = tokenizer("this is a test of bert", return_tensors="pt")
-    evaluate_pytorch_model(model, (inputs.input_ids, inputs.attention_mask))
+    evaluate_pytorch_model(
+        model,
+        (inputs.input_ids, inputs.attention_mask),
+        expected_op_counts={
+            "scaled_dot_product_attention": config.num_hidden_layers,
+            "softmax": 0,
+        },
+    )
 
 
 # ==============================================================================
@@ -245,10 +304,16 @@ def test_whisper_tiny():
 
     # Whisper forward: (input_features, attention_mask, decoder_input_ids, ...)
     # Temporary workaround: Whisper hits a CoreML CPU backend bug, so allow all compute units.
+    # Encoder self-attention + decoder self- and cross-attention.
+    attention_blocks = config.encoder_layers + 2 * config.decoder_layers
     evaluate_pytorch_model(
         model,
         (input_features, attention_mask, decoder_input_ids),
         compute_units=ct.ComputeUnit.ALL,
+        expected_op_counts={
+            "scaled_dot_product_attention": attention_blocks,
+            "softmax": 0,
+        },
     )
 
 
@@ -265,7 +330,17 @@ def test_convnext_tiny():
 def test_vit_b_16():
     inputs = (torch.randn(1, 3, 224, 224), )
     model = torchvision.models.vit_b_16(weights="DEFAULT")
-    evaluate_pytorch_model(model, inputs)
+    # torch's `_safe_softmax` wrapper is peeled off, so every block fuses.
+    # ViT's exact (erf) GELU is not fused: torchax expands `erf` into a
+    # polynomial that neither coremltools nor `fuse_gelu_erfc` recognises.
+    evaluate_pytorch_model(
+        model,
+        inputs,
+        expected_op_counts={
+            "scaled_dot_product_attention": len(model.encoder.layers),
+            "softmax": 0,
+        },
+    )
 
 
 def test_efficientnet_b0():

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -12,6 +12,7 @@ from tests.utils import (
     get_model_instruction_types,
     run_and_compare,
     run_and_compare_hlo_module,
+    run_and_compare_jit_lowering,
     run_and_compare_specific_input,
 )
 
@@ -190,6 +191,51 @@ def test_reduce_with_reversed_operands():
     ops = get_model_instruction_types(cml_model)
     assert "reduce_sum" in ops
     assert "while_loop" not in ops
+
+
+def test_reduction_identity_init_is_not_emitted():
+    """A reduce whose init value is the identity element does not need the clamp.
+
+    `jnp.max` uses -inf as the init value, `jnp.sum` uses 0, `jnp.prod` uses 1;
+    combining the result with those is a no-op, so no `maximum`/`add`/`mul` op
+    should be emitted on top of the reduction.
+    """
+    cml_model = run_and_compare(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4)),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_max" in ops
+    assert "maximum" not in ops
+
+    cml_model = run_and_compare(partial(jnp.min, axis=1), (jnp.zeros((2, 3, 4)),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_min" in ops
+    assert "minimum" not in ops
+
+    cml_model = run_and_compare(partial(jnp.sum, axis=1), (jnp.zeros((2, 3, 4)),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_sum" in ops
+    assert "add" not in ops
+
+    cml_model = run_and_compare(partial(jnp.prod, axis=1), (jnp.zeros((2, 3, 4)),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_prod" in ops
+    assert "mul" not in ops
+
+    # Integer max reduction: the identity is iinfo.min
+    cml_model = run_and_compare(partial(jnp.max, axis=1), (jnp.zeros((2, 3, 4), dtype=jnp.int32),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_max" in ops
+    assert "maximum" not in ops
+
+
+def test_reduction_non_identity_init_is_emitted():
+    """A non-identity init value must still be folded into the reduction result."""
+    def reduce_max_with_init(x):
+        return jax.lax.reduce(x, np.float32(5.0), jax.lax.max, (1,))
+
+    cml_model = run_and_compare(reduce_max_with_init, (jnp.zeros((2, 3, 4)),))
+    ops = get_model_instruction_types(cml_model)
+    assert "reduce_max" in ops
+    assert "maximum" in ops
 
 
 def test_reduce_window():
@@ -438,6 +484,57 @@ def test_trigonmetry():
         (jnp.zeros((50, 20), dtype=jnp.float16), jnp.zeros((50, 20), dtype=jnp.float16),),
         rtol=1e-05 / jnp.finfo(jnp.float32).eps * jnp.finfo(jnp.float16).eps
     )
+
+
+def test_erf():
+    """`chlo.erf` maps straight to `mb.erf` on both lowering paths."""
+    inputs = (jnp.linspace(-3, 3, 30, dtype=jnp.float32).reshape(5, 6),)
+
+    for cml_model in (
+        run_and_compare_specific_input(jax.lax.erf, inputs),
+        run_and_compare_jit_lowering(jax.lax.erf, inputs),
+    ):
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("erf") == 1
+        # No trace of the ~40 op polynomial the chlo decomposition would give.
+        assert len([op for op in ops if op != "const"]) == 1
+
+
+def test_erfc():
+    """`chlo.erfc` maps to `1 - erf(x)` when it survives as a composite."""
+    inputs = (jnp.linspace(-3, 3, 30, dtype=jnp.float32).reshape(5, 6),)
+
+    cml_model = run_and_compare_jit_lowering(jax.lax.erfc, inputs)
+    ops = get_model_instruction_types(cml_model)
+    assert ops.count("erf") == 1
+    assert ops.count("sub") == 1
+
+    # `jax.export` expands `chlo.erfc` before we get to see the module (unlike
+    # `chlo.erf`, it has no composite representation there), so that path keeps
+    # the polynomial. Only the numerics are checked.
+    run_and_compare_specific_input(jax.lax.erfc, inputs)
+
+
+def test_composite_ops_via_jit_lowering():
+    """`jax.jit(...).lower()` hands us raw CHLO; the converter wraps it in composites.
+
+    Without that the CHLO ops would be legalized into large polynomials instead
+    of being mapped to the corresponding CoreML primitive.
+    """
+    x = jnp.linspace(-0.9, 0.9, 30, dtype=jnp.float32).reshape(5, 6)
+
+    expected_op = {
+        jnp.arcsin: "asin",
+        jnp.arccos: "acos",
+        jnp.sinh: "sinh",
+        jnp.cosh: "cosh",
+    }
+    for jax_func, op_type in expected_op.items():
+        cml_model = run_and_compare_jit_lowering(jax_func, (x,))
+        assert get_model_instruction_types(cml_model).count(op_type) == 1
+
+    cml_model = run_and_compare_jit_lowering(partial(jax.lax.top_k, k=3), (x,))
+    assert get_model_instruction_types(cml_model).count("topk") == 1
 
 
 def test_is_finite():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -345,6 +345,39 @@ def run_and_compare(
     )
 
 
+def run_and_compare_jit_lowering(
+    jax_func,
+    inputs,
+    max_complexity: int = 10_000,
+    atol=1e-04,
+    rtol=1e-05,
+    compute_units=ct.ComputeUnit.CPU_ONLY,
+):
+    """
+    Same as `run_and_compare_specific_input`, but takes the StableHLO module from
+    `jax.jit(...).lower(...).compiler_ir("stablehlo")` instead of `jax.export`.
+
+    That path hands the converter raw CHLO ops (`jax.export` legalizes most of
+    them away first), so it exercises the composite handlers for ops such as
+    `chlo.erf` / `chlo.erfc`.
+    """
+    jax_func = jax.jit(jax_func)
+    hlo_module = jax_func.lower(*flatten(inputs)).compiler_ir("stablehlo")
+
+    jax_input_values = __nest_flat_jax_input_to_input_spec(inputs, flatten(inputs))
+    expected_output = jax_func(*jax_input_values)
+
+    return run_and_compare_hlo_module(
+        hlo_module,
+        inputs,
+        expected_output,
+        max_complexity=max_complexity,
+        atol=atol,
+        rtol=rtol,
+        compute_units=compute_units,
+    )
+
+
 def get_model_instruction_types(cml_model) -> list[str]:
     def collect_ops(ops: list) -> list[str]:
         collected_ops = []


### PR DESCRIPTION
## Summary

Brings the MIL optimization passes from [gemma-coreml-chat](https://github.com/kasper0406/gemma-coreml-chat/tree/main/gemma_chat/mil_passes) into the library — re-implemented against the current `dot_general` lowering rather than copied — plus a cleaner way to include them in a pipeline.

### Passes (all `common::` namespace, in `stablehlo_coreml/passes/`)

| Pass | Group | What it does |
|---|---|---|
| `remove_broadcast_tiles` | cleanup | Drops the `tile` ops StableHLO's explicit broadcasting produces when the consumer broadcasts natively. Runs **before** the first `const_elimination`, which fixes the "GB-sized uniform constants" problem at the source (`replace_scalar_broadcasts` is therefore not needed). Fixes two latent bugs of the original (non-broadcast tiles, consumer output-shape changes). |
| `fuse_reduce_keep_dims` | cleanup | `reduce_*(keep_dims=False) → reshape` ⇒ `reduce_*(keep_dims=True)`; unlocks coremltools' own `fuse_reduce_mean` (RMSNorm now yields `reduce_mean`). Replaces `fuse_reduce_sum_to_mean`. |
| `remove_noop_slice_update` | cleanup | existing, moved to the cleanup group |
| `replace_decomposed_softmax` | fusion | JAX's decomposed softmax → `softmax` (semantic match; covers the `-inf` clamps, fp16 casts, permuted layouts). Subsumes `remove_redundant_maximum`. |
| `fuse_attention_to_sdpa` | fusion | `matmul → [scale] → [mask] → softmax → matmul` → `scaled_dot_product_attention`. Works in "matmul space": plain 4-D, Gemma GQA einsum layouts, bool / additive / constant-bias masks, explicit or Gemma-style scaling, transposed K/V, symbolic seq dims, PyTorch's `_safe_softmax` wrapper. Option `finite_fill_mask` (`additive` default: `-1e9`/`finfo.min` fills keep fully-masked rows finite exactly like the source graph; `bool` for the cheaper form). |
| `fuse_logit_softcap` | fusion | `tanh(x/cap)*cap` → `scaled_tanh` |
| `fuse_gelu_erfc` | fusion | erfc-form exact GELU (`jax.nn.gelu(approximate=False)`) → `gelu`. Backed by a converter change: `chlo.erf`/`chlo.erfc` are mapped to MIL `erf` via composite handlers, and `_normalize_module` wraps all chlo ops with handlers via `stablehlo-wrap-in-composite` so the `jit().lower().compiler_ir()` path behaves like `jax.export`. |

Not ported, on purpose: `collapse_cast_chains` (coremltools' `cast_optimization` covers the lossless cases), `collapse_reshape/transpose_chains` (coremltools equivalents; value was tied to the old lowering), `replace_scalar_broadcasts` (obsolete, see above), `quantize_const_weights` (Gemma-specific policy).

Small converter tweak: `reductions.py` no longer emits the identity init clamp (`maximum(x, -inf)` etc.).

### Pipeline integration

`build_pass_pipeline(base=None)` returns a fresh copy of `ct.PassPipeline.DEFAULT` with the passes inserted at anchors (cleanup group before the first `const_elimination`; fusion group before `fuse_matmul_weight_bias`, i.e. after consts fold, before `add_fp16_cast`, and before coremltools' own fusions/DCE clean up after us). It never mutates its input, is idempotent, works with custom base pipelines. `DEFAULT_HLO_PIPELINE` / `register_optimizations()` are kept for compatibility. README documents the passes and options.

### Tests

* Unit tests (hand-built MIL) + end-to-end JAX tests per pass (`tests/passes/`, 193 tests).
* The whole existing suite runs through the new pipeline (361 passed).
* `tests/pytorch`: model tests now assert fused op counts — **every** attention block of TinyLlama, T5, DistilBERT, GPT-2, BERT, Whisper and ViT fuses to SDPA (no `softmax` left); GPT-2's tanh-GELU fuses. `torch` pinned `<2.13` (torchax 0.0.13 does not import against 2.13).

## Test plan
- [x] `hatch run lint:check`
- [x] `hatch -e test.py3.12 run pytest tests` — 361 passed (before the last SDPA extensions; passes/jax/flax/equinox/symbolic re-run afterwards: 193 + 180 passed)
- [x] `hatch -e test-pytorch.py3.12 run pytest tests/pytorch` — 15 passed
- [x] Production-flow probe (fp16 with `add_fp16_cast`, `compute_units=ALL`) on a Gemma-style block: SDPA + gelu + scaled_tanh present, fp32 numerics 7e-7 vs JAX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7Pmvg8d572L2S7Jmpys6E
