### PR TITLE
Add optimization pass to remove no-op state updates

### DIFF
--- a/stablehlo_coreml/passes/remove_noop_state_update.py
+++ b/stablehlo_coreml/passes/remove_noop_state_update.py
@@ -1,0 +1,96 @@
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+
+def _unwrap_identity(var):
+    visited = set()
+    curr = var
+    while curr.op is not None and curr not in visited:
+        visited.add(curr)
+        if curr.op.op_type in ("cast", "identity"):
+            curr = curr.op.x
+        else:
+            break
+    return curr
+
+
+def _match_pattern(op):
+    if op.op_type == "coreml_update_state":
+        source_var = _unwrap_identity(op.value)
+        if source_var.op is not None and source_var.op.op_type == "read_state":
+            return source_var.op.input == op.state
+    return False
+
+
+def _try_to_transform(update_op):
+    block = update_op.enclosing_block
+    # Replace occurrences of the `coreml_update_state` output with `update_op.value`
+    block.replace_uses_of_var_after_op(
+        anchor_op=update_op,
+        old_var=update_op.outputs[0],
+        new_var=update_op.value,
+    )
+    val = update_op.value
+    update_op.remove_from_block()
+
+    # Clean up upstream casts/identities/read_state if they are no longer consumed
+    curr = val
+    while curr.op is not None and curr.op.op_type in ("cast", "identity", "read_state"):
+        op_to_check = curr.op
+        if len(curr.child_ops) == 0 and curr not in block.outputs:
+            prev = op_to_check.x if hasattr(op_to_check, "x") else None
+            op_to_check.remove_from_block()
+            if prev is not None:
+                curr = prev
+            else:
+                break
+        else:
+            break
+
+    return True
+
+
+@block_context_manager
+def _remove_noop_state_update(block):
+    did_optimize = False
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for b in op.blocks:
+            block_changed = True
+            while block_changed:
+                block_changed = _remove_noop_state_update(b)
+        if len(op.blocks) > 0:
+            continue
+
+        if _match_pattern(op):
+            if _try_to_transform(op):
+                did_optimize = True
+    return did_optimize
+
+
+@register_pass(namespace="common")
+class remove_noop_state_update(AbstractGraphPass):
+    """
+    If a coreml_update_state writes back the exact value read from the same state
+    (possibly through intermediate casts or identity operations), remove the redundant
+    state write and any unused upstream read/cast ops.
+
+    Given:
+        %1 = read_state(input=%state)
+        %2 = cast(x=%1, dtype="fp32")
+        ...
+        %3 = cast(x=%2, dtype="fp16")
+        %4 = coreml_update_state(state=%state, value=%3)
+
+    Result:
+        (removes %4, and eliminates %3, %2, %1 if they are not used downstream)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            block_changed = True
+            while block_changed:
+                block_changed = _remove_noop_state_update(f)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -5,7 +5,8 @@ DEFAULT_HLO_PIPELINE: ct.PassPipeline = ct.PassPipeline.DEFAULT
 
 def register_optimizations():
     from .remove_noop_slice_update import remove_noop_slice_update  # noqa: PLC0415
-    custom_passes = [remove_noop_slice_update]
+    from .remove_noop_state_update import remove_noop_state_update  # noqa: PLC0415
+    custom_passes = [remove_noop_slice_update, remove_noop_state_update]
 
     for custom_pass in custom_passes:
         pass_name = f"common::{custom_pass.__name__}"

--- a/tests/passes/test_register_optimizations.py
+++ b/tests/passes/test_register_optimizations.py
@@ -6,5 +6,5 @@ def test_register_optimizations_is_idempotent():
     register_optimizations()
     register_optimizations()
 
-    pass_name = "common::remove_noop_slice_update"
-    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1
+    assert DEFAULT_HLO_PIPELINE.passes.count("common::remove_noop_slice_update") == 1
+    assert DEFAULT_HLO_PIPELINE.passes.count("common::remove_noop_state_update") == 1

--- a/tests/passes/test_remove_noop_state_update.py
+++ b/tests/passes/test_remove_noop_state_update.py
@@ -1,0 +1,137 @@
+import coremltools as ct
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml import register_optimizations
+
+register_optimizations()
+
+
+class TestRemoveNoopStateUpdate:
+
+    def test_is_removed_direct(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2, 3)),
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, s):
+            r = mb.read_state(input=s)
+            mb.coreml_update_state(state=s, value=r)
+            return mb.add(x=x, y=1.0)
+
+        assert "coreml_update_state" in get_op_types_in_program(prog)
+        assert "read_state" in get_op_types_in_program(prog)
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_state_update")
+
+        op_types = get_op_types_in_program(prog)
+        assert "coreml_update_state" not in op_types
+        assert "read_state" not in op_types
+        assert "add" in op_types
+
+    def test_is_removed_with_casts(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2, 3)),
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, s):
+            r = mb.read_state(input=s)
+            c0 = mb.cast(x=r, dtype="fp32")
+            c1 = mb.cast(x=c0, dtype="fp16")
+            mb.coreml_update_state(state=s, value=c1)
+            return mb.add(x=x, y=1.0)
+
+        assert "coreml_update_state" in get_op_types_in_program(prog)
+        assert "read_state" in get_op_types_in_program(prog)
+        assert "cast" in get_op_types_in_program(prog)
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_state_update")
+
+        op_types = get_op_types_in_program(prog)
+        assert "coreml_update_state" not in op_types
+        assert "read_state" not in op_types
+        assert "cast" not in op_types
+        assert "add" in op_types
+
+    def test_not_removed_when_state_is_modified(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2, 3)),
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, s):
+            r = mb.read_state(input=s)
+            c0 = mb.cast(x=r, dtype="fp32")
+            new_val = mb.add(x=c0, y=1.0)
+            c1 = mb.cast(x=new_val, dtype="fp16")
+            mb.coreml_update_state(state=s, value=c1)
+            return mb.add(x=x, y=1.0)
+
+        assert "coreml_update_state" in get_op_types_in_program(prog)
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_state_update")
+
+        op_types = get_op_types_in_program(prog)
+        assert "coreml_update_state" in op_types
+        assert "read_state" in op_types
+
+    def test_not_removed_when_written_to_different_state(self):
+        @mb.program(
+            input_specs=[
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(s0, s1):
+            r0 = mb.read_state(input=s0)
+            mb.coreml_update_state(state=s1, value=r0)
+            return r0
+
+        assert "coreml_update_state" in get_op_types_in_program(prog)
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_state_update")
+
+        op_types = get_op_types_in_program(prog)
+        assert "coreml_update_state" in op_types
+        assert "read_state" in op_types
+
+    def test_read_state_preserved_when_used_downstream(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(2, 3)),
+                mb.StateTensorSpec(shape=(2, 3), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, s):
+            r = mb.read_state(input=s)
+            c0 = mb.cast(x=r, dtype="fp32")
+            c1 = mb.cast(x=c0, dtype="fp16")
+            mb.coreml_update_state(state=s, value=c1)
+            # c0 is used in the returned calculation
+            return mb.add(x=c0, y=1.0)
+
+        assert "coreml_update_state" in get_op_types_in_program(prog)
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_state_update")
+
+        op_types = get_op_types_in_program(prog)
+        # coreml_update_state and the c1 cast back to fp16 are removed
+        assert "coreml_update_state" not in op_types
+        # read_state and c0 (fp32 cast) are preserved for the add calculation
+        assert "read_state" in op_types
+        assert "cast" in op_types
+        assert "add" in op_types

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -3,6 +3,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.pass_registry import PASS_REGISTRY
 from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export, symbolic_shape
@@ -178,3 +179,40 @@ def test_symbolic_state_is_rejected():
     hlo_module = ir.Module.parse(exported.mlir_module(), context=context)
     with pytest.raises(ValueError, match="static shape"):
         convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+
+
+def test_multi_function_module_removes_unmodified_state_updates():
+    ctx = jax_mlir.make_ir_context()
+    mlir_text = """
+    module {
+      func.func public @update(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+        %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+        return %arg1, %0 : tensor<2xf32>, tensor<2xf32>
+      }
+      func.func public @no_update(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+        %0 = "stablehlo.multiply"(%arg1, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+        return %0, %arg0 : tensor<2xf32>, tensor<2xf32>
+      }
+      func.func public @read_only(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+        %0 = "stablehlo.add"(%arg0, %arg1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+        return %0, %arg0 : tensor<2xf32>, tensor<2xf32>
+      }
+    }
+    """
+    hlo_module = ir.Module.parse(mlir_text, context=ctx)
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
+
+    PASS_REGISTRY["common::remove_noop_state_update"](mil_program)
+
+    update_ops = [op.op_type for op in mil_program.functions["update"].operations]
+
+    assert "coreml_update_state" in update_ops
+    assert "read_state" in update_ops
+
+    no_update_ops = [op.op_type for op in mil_program.functions["no_update"].operations]
+    assert "coreml_update_state" not in no_update_ops
+    assert "read_state" not in no_update_ops
+
+    read_only_ops = [op.op_type for op in mil_program.functions["read_only"].operations]
+    assert "coreml_update_state" not in read_only_ops
+    assert "read_state" in read_only_ops

--- a/tests/test_symbolic_shapes.py
+++ b/tests/test_symbolic_shapes.py
@@ -24,6 +24,7 @@ from tests.utils import run_and_compare_symbolic
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _sym(spec: str):
     """Shorthand for jax.export.symbolic_shape."""
     return export.symbolic_shape(spec)
@@ -35,7 +36,9 @@ def _sym(spec: str):
 #            GetDimensionSizeOp, CustomCallOp(shape_assertion)
 # ---------------------------------------------------------------------------
 
+
 def test_symbolic_add_scalar():
+
     """x + 1.0 with symbolic first dim."""
     def f(x):
         return x + 1.0


### PR DESCRIPTION
When multiple public functions in a StableHLO module share a state mapping, functions that do not modify state receive redundant read_state and coreml_update_state operations with the unmodified values.

Add common::remove_noop_state_update MIL optimization pass to:
- Identify coreml_update_state ops writing back values originating from read_state on the same state (including through intermediate casts/identities)
- Replace uses and eliminate redundant coreml_update_state operations
- Clean up unused upstream read_state and intermediate cast ops while preserving read_state ops whose values are consumed downstream
- Register pass in DEFAULT_HLO_PIPELINE and add unit test coverage