### PR TITLE
Scope Core ML states by function

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ y = cml_model.predict({x_name: x}, state=state)
 
 The outer keys are public StableHLO function names. Inner keys may be input
 indices or argument names; JAX argument names are preserved when available.
-`StateSpec.output` identifies the function output that updates the state. Use
-`output=None` for read-only state, and `name=...` to override its Core ML name.
-A flat `{input: output}` mapping remains supported for single-function modules.
+`StateSpec.output` identifies the function output that updates the state. It may
+be an output index, an exact JAX `result_info` name such as
+`"result['cache']"`, or the unique leaf name `"cache"`. Use `output=None` for
+read-only state, and `name=...` to override its Core ML name. A flat
+`{input: output}` mapping remains supported for single-function modules.
 
 State tensors must have a static shape and a floating-point dtype (Core ML
 stores them as fp16). They do not appear in the model's regular inputs. Updated

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ To convert a StableHLO module:
 
 ```python
 import coremltools as ct
-from stablehlo_coreml.converter import convert
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec, convert
 
 mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
 cml_model = ct.convert(
@@ -76,7 +75,11 @@ def step(cache, x):
 mil_program = convert(
     hlo_module,
     minimum_deployment_target=ct.target.iOS18,
-    states={0: 1},  # input 0 is updated by output 1
+    states={
+        "main": {
+            "cache": StateSpec(output=1),
+        },
+    },
 )
 cml_model = ct.convert(
     mil_program,
@@ -93,11 +96,16 @@ y = cml_model.predict({x_name: x}, state=state)
 # state.read_state(...) / state.write_state(...)
 ```
 
-Keys may be input indices or argument names. State tensors must have a static
-shape and a floating-point dtype (Core ML stores them as fp16). They do not
-appear in the model's regular inputs. Mapped outputs are omitted unless every
-result updates state; Core ML requires at least one output, so those updated
-values are then kept as results.
+The outer keys are public StableHLO function names. Inner keys may be input
+indices or argument names; JAX argument names are preserved when available.
+`StateSpec.output` identifies the function output that updates the state. Use
+`output=None` for read-only state, and `name=...` to override its Core ML name.
+A flat `{input: output}` mapping remains supported for single-function modules.
+
+State tensors must have a static shape and a floating-point dtype (Core ML
+stores them as fp16). They do not appear in the model's regular inputs. Updated
+outputs are omitted unless every result updates state; Core ML requires at least
+one output, so those updated values are then kept as results.
 
 See [`tests/test_stateful.py`](tests/test_stateful.py) for multi-step examples.
 

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,5 +1,5 @@
-from .converter import convert
+from .converter import StateSpec, convert
 from .passes.utils import DEFAULT_HLO_PIPELINE, register_optimizations
 
 __version__ = "0.0.0"
-__all__ = ['DEFAULT_HLO_PIPELINE', 'convert', 'register_optimizations']
+__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'convert', 'register_optimizations']

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import partial, reduce
 
 import numpy as np
@@ -111,22 +112,36 @@ from .utils import (
 _STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
 
 
+@dataclass(frozen=True)
+class StateSpec:
+    """Describe how a StableHLO function argument is exposed as Core ML state."""
+
+    output: int | None
+    name: str | None = None
+
+
+StateMapping = Mapping[int | str, int | StateSpec]
+FunctionStateMapping = Mapping[str, StateMapping]
+
+
 def convert(
     module,
     minimum_deployment_target: AvailableTarget,
-    states: Mapping[int | str, int] | None = None,
+    states: StateMapping | FunctionStateMapping | None = None,
 ):
     """Convert a StableHLO module to a MIL program.
 
-    ``states`` maps function inputs that should become Core ML state
-    tensors onto the output that holds the updated value. Keys are input
-    indices or argument names; values are output indices. Those outputs
-    are written back with ``coreml_update_state`` and omitted from the
-    function results, except when every result is a state write: Core ML
-    requires at least one output, so the updated state values are then
-    kept as results (cast back to the computation dtype). State is stored
-    as fp16 (a Core ML requirement); fp32 values are cast around the
-    read/write.
+    ``states`` maps public function names to their state arguments. Each
+    argument maps to a :class:`StateSpec` identifying the output that
+    updates it, or ``None`` for read-only state. A flat argument mapping
+    and integer output values remain supported for single-function
+    modules.
+
+    State arguments may be identified by index or by their JAX/MLIR name.
+    Updated outputs are omitted from the function results, except when
+    every result is a state write: Core ML requires at least one output,
+    so the updated values are then kept as results. State is stored as
+    fp16; fp32 values are cast around the read/write.
     """
     if minimum_deployment_target < AvailableTarget.iOS18:
         raise ValueError("Converting to <iOS18 is not supported")
@@ -147,11 +162,20 @@ def _argument_name_aliases(arg) -> list[str]:
         if raw.startswith("%"):
             names.append(raw[1:])
 
-    loc = getattr(arg, "location", None)
-    loc_name = getattr(loc, "name", None) if loc is not None else None
+    loc_name = _argument_location_name(arg)
     if loc_name:
-        names.append(str(loc_name))
+        names.append(loc_name)
     return names
+
+
+def _argument_location_name(arg) -> str | None:
+    loc = getattr(arg, "location", None)
+    name = getattr(loc, "name_str", None) if loc is not None else None
+    return name if isinstance(name, str) and name else None
+
+
+def _preferred_argument_name(arg) -> str:
+    return _argument_location_name(arg) or arg.get_name().lstrip("%")
 
 
 def _function_outputs(hlo_func: FuncOp):
@@ -165,7 +189,22 @@ def _function_outputs(hlo_func: FuncOp):
     return None
 
 
-def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dict[int, int]:
+def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
+    if isinstance(value, StateSpec):
+        spec = value
+    elif isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"State specification must be a StateSpec or output index, got {value!r}")
+    else:
+        spec = StateSpec(output=value)
+
+    if spec.output is not None and (isinstance(spec.output, bool) or not isinstance(spec.output, int)):
+        raise TypeError(f"State output index must be an int or None, got {spec.output!r}")
+    if spec.name is not None and (not isinstance(spec.name, str) or not spec.name):
+        raise TypeError(f"State name must be a non-empty str or None, got {spec.name!r}")
+    return spec
+
+
+def _resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, StateSpec]:
     args = list(hlo_func.arguments)
     name_to_idx: dict[str, int] = {}
     for i, arg in enumerate(args):
@@ -175,11 +214,11 @@ def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dic
     results = _function_outputs(hlo_func)
     num_outputs = len(results) if results is not None else None
 
-    resolved: dict[int, int] = {}
+    resolved: dict[int, StateSpec] = {}
     output_owners: dict[int, int] = {}
-    for key, out_idx in states.items():
-        if isinstance(out_idx, bool) or not isinstance(out_idx, int):
-            raise TypeError(f"State output index must be an int, got {out_idx!r}")
+    state_names: set[str] = set()
+    for key, value in states.items():
+        spec = _coerce_state_spec(value)
         if isinstance(key, bool) or not isinstance(key, (int, str)):
             raise TypeError(f"State input must be an int index or str name, got {key!r}")
 
@@ -197,26 +236,66 @@ def _resolve_state_map(hlo_func: FuncOp, states: Mapping[int | str, int]) -> dic
             )
         if in_idx in resolved:
             raise ValueError(f"Function argument {in_idx} is mapped as state more than once")
-        if out_idx < 0:
-            raise ValueError(f"State output index {out_idx} is invalid")
-        if num_outputs is not None and out_idx >= num_outputs:
+        if spec.name is not None and spec.name in state_names:
+            raise ValueError(f"Core ML state name {spec.name!r} is used more than once")
+        if spec.output is not None and spec.output < 0:
+            raise ValueError(f"State output index {spec.output} is invalid")
+        if spec.output is not None and num_outputs is not None and spec.output >= num_outputs:
             raise ValueError(
-                f"State output index {out_idx} is out of range for a function with {num_outputs} outputs"
+                f"State output index {spec.output} is out of range for a function with {num_outputs} outputs"
             )
-        if out_idx in output_owners:
+        if spec.output is not None and spec.output in output_owners:
             raise ValueError(
-                f"Output {out_idx} cannot update both argument {output_owners[out_idx]} and {in_idx}"
+                f"Output {spec.output} cannot update both argument "
+                f"{output_owners[spec.output]} and {in_idx}"
             )
-        if results is not None and args[in_idx].type != results[out_idx]:
+        if spec.output is not None and results is not None and args[in_idx].type != results[spec.output]:
             raise ValueError(
                 f"State input {in_idx} has type {args[in_idx].type}, but output "
-                f"{out_idx} has type {results[out_idx]}"
+                f"{spec.output} has type {results[spec.output]}"
             )
 
-        resolved[in_idx] = out_idx
-        output_owners[out_idx] = in_idx
+        resolved[in_idx] = spec
+        if spec.name is not None:
+            state_names.add(spec.name)
+        if spec.output is not None:
+            output_owners[spec.output] = in_idx
 
     return resolved
+
+
+def _normalize_function_state_maps(
+    states: StateMapping | FunctionStateMapping | None,
+    public_function_names: list[str],
+) -> dict[str, StateMapping]:
+    if not states:
+        return {}
+
+    values = list(states.values())
+    has_nested_values = any(isinstance(value, Mapping) for value in values)
+    if has_nested_values:
+        if not all(isinstance(value, Mapping) for value in values):
+            raise TypeError("State mappings cannot mix function mappings with state specifications")
+        invalid_names = [name for name in states if not isinstance(name, str)]
+        if invalid_names:
+            raise TypeError(
+                f"Function names in a state mapping must be strings, got {invalid_names[0]!r}"
+            )
+        unknown = set(states) - set(public_function_names)
+        if unknown:
+            known = ", ".join(public_function_names) or "<none>"
+            raise ValueError(
+                f"Unknown public function(s) in state mapping: {', '.join(sorted(unknown))}. "
+                f"Known public functions: {known}"
+            )
+        return {name: mapping for name, mapping in states.items()}
+
+    if len(public_function_names) != 1:
+        raise ValueError(
+            "A flat state mapping is only supported for single-function modules; "
+            "map each public function name to its states"
+        )
+    return {public_function_names[0]: states}
 
 
 def _normalize_module(module: ir.Module) -> None:
@@ -249,12 +328,13 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
     def __init__(
         self,
         opset_version: int | None = None,
-        states: Mapping[int | str, int] | None = None,
+        states: StateMapping | FunctionStateMapping | None = None,
     ):
         self.opset_version = AvailableTarget(opset_version) if opset_version is not None else None
         self.prog = mil.Program()
         self.func_index = {}
         self.states = dict(states) if states else {}
+        self.function_states: dict[str, StateMapping] = {}
 
     def convert(self, module: ir.Module) -> Program:
         logger.info("Converting graph.")
@@ -263,24 +343,63 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         for func in module.body:
             self.func_index[func.name.value] = func
 
-        for func in module.body:
-            if func.sym_visibility is None or func.sym_visibility.value == "public":
-                self.build_func(func)
+        public_functions = [
+            func
+            for func in module.body
+            if func.sym_visibility is None or func.sym_visibility.value == "public"
+        ]
+        public_function_names = [func.name.value for func in public_functions]
+        self.function_states = _normalize_function_state_maps(self.states, public_function_names)
 
+        for func in public_functions:
+            self.build_func(func)
+
+        if public_function_names:
+            self.prog.default_function_name = (
+                "main" if "main" in public_function_names else public_function_names[0]
+            )
+        self.prog.export_as_multifunction = len(public_function_names) > 1
         return self.prog
 
     def build_func(self, hlo_func: FuncOp):
         context = TranslationContext()  # Map from results to created variables
 
-        state_map = _resolve_state_map(hlo_func, self.states) if self.states else {}
+        function_states = self.function_states.get(hlo_func.name.value, {})
+        state_map = _resolve_state_map(hlo_func, function_states) if function_states else {}
 
         func_inputs = {}
-        state_output_index: dict[str, int] = {}
+        state_specs: dict[str, StateSpec] = {}
         state_compute_dtype: dict[str, object] = {}
+        argument_input_names: dict[int, str] = {}
+        used_input_names: set[str] = set()
+        explicit_state_names = {
+            spec.name: in_idx
+            for in_idx, spec in state_map.items()
+            if spec.name is not None
+        }
         sym_counter = 0
         for in_idx, arg in enumerate(hlo_func.arguments):
             shape = arg.type.shape
-            name = arg.get_name()
+            context_name = arg.get_name()
+            state_spec = state_map.get(in_idx)
+            explicit_name = state_spec.name if state_spec is not None else None
+            name = explicit_name or _preferred_argument_name(arg)
+            if explicit_name is not None:
+                if name in used_input_names:
+                    raise ValueError(
+                        f"Core ML state name {name!r} conflicts with another function input"
+                    )
+            else:
+                if name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = context_name.lstrip("%")
+                while name in used_input_names or (
+                    name in explicit_state_names and explicit_state_names[name] != in_idx
+                ):
+                    name = f"{name}_input"
+            used_input_names.add(name)
+            argument_input_names[in_idx] = name
             # Reject dynamic state before constructing MIL Symbols — Symbol
             # names are process-global and would leak if we raise afterwards.
             if in_idx in state_map and any(d == DYNAMIC_DIM_SENTINEL for d in shape):
@@ -306,22 +425,23 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
                         "but Core ML states must be floating point (stored as fp16)"
                     )
                 func_inputs[name] = mb.state_tensor_placeholder(shape=shape, dtype=types.fp16)
-                state_output_index[name] = state_map[in_idx]
+                state_specs[name] = state_map[in_idx]
                 state_compute_dtype[name] = dtype
             else:
                 func_inputs[name] = mb.placeholder(shape=shape, dtype=dtype)
 
         with Function(func_inputs, opset_version=self.opset_version) as ssa_func:
             state_vars = {}
-            for name in func_inputs:
+            for in_idx, arg in enumerate(hlo_func.arguments):
+                name = argument_input_names[in_idx]
                 var = ssa_func.inputs[name]
-                if name in state_output_index:
+                if name in state_specs:
                     state_vars[name] = var
                     var = mb.read_state(input=var)
                     compute_dtype = state_compute_dtype[name]
                     if compute_dtype != types.fp16:
                         var = mb.cast(x=var, dtype=dtype_str(compute_dtype))
-                context.add_variable(name, var)
+                context.add_variable(arg.get_name(), var)
 
             outputs = self.process_block(context, hlo_func.body.blocks[0])
             if outputs is None:
@@ -329,7 +449,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
 
             consumed = set()
             updated_states = []
-            for name, out_idx in state_output_index.items():
+            for name, spec in state_specs.items():
+                if spec.output is None:
+                    continue
+                out_idx = spec.output
                 if not 0 <= out_idx < len(outputs):
                     raise ValueError(
                         f"State output index {out_idx} is out of range for a function "
@@ -346,9 +469,12 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             # coreml_update_state returns the fp16 storage value; cast
             # back to the computation dtype so the result matches HLO.
             final_outputs = [out for i, out in enumerate(outputs) if i not in consumed]
-            if not final_outputs:
+            if not final_outputs and updated_states:
                 final_outputs = []
-                for updated, name in zip(updated_states, state_output_index):
+                updated_state_names = [
+                    name for name, spec in state_specs.items() if spec.output is not None
+                ]
+                for updated, name in zip(updated_states, updated_state_names):
                     compute_dtype = state_compute_dtype[name]
                     if compute_dtype != types.fp16:
                         updated = mb.cast(x=updated, dtype=dtype_str(compute_dtype))

--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import partial, reduce
@@ -116,7 +117,7 @@ _STATE_VALUE_DTYPES = frozenset({types.fp16, types.fp32})
 class StateSpec:
     """Describe how a StableHLO function argument is exposed as Core ML state."""
 
-    output: int | None
+    output: int | str | None
     name: str | None = None
 
 
@@ -189,6 +190,37 @@ def _function_outputs(hlo_func: FuncOp):
     return None
 
 
+def _result_info_aliases(result_info: str) -> set[str]:
+    aliases = {result_info}
+    leaf_match = re.search(r"""\[['"]([^'"]+)['"]\]$""", result_info)
+    if leaf_match is not None:
+        aliases.add(leaf_match.group(1))
+    return aliases
+
+
+def _resolve_state_output(hlo_func: FuncOp, output: int | str | None) -> int | None:
+    if output is None or isinstance(output, int):
+        return output
+
+    matches: dict[str, list[int]] = {}
+    result_attrs = getattr(hlo_func, "result_attrs", ())
+    for index, attrs in enumerate(result_attrs):
+        try:
+            result_info = attrs["jax.result_info"].value
+        except KeyError:
+            continue
+        for alias in _result_info_aliases(result_info):
+            matches.setdefault(alias, []).append(index)
+
+    indices = matches.get(output, [])
+    if len(indices) > 1:
+        raise ValueError(f"State output name {output!r} is ambiguous")
+    if not indices:
+        known = ", ".join(repr(name) for name in sorted(matches)) or "<none>"
+        raise ValueError(f"Unknown state output {output!r}. Known output names: {known}")
+    return indices[0]
+
+
 def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
     if isinstance(value, StateSpec):
         spec = value
@@ -197,8 +229,8 @@ def _coerce_state_spec(value: int | StateSpec) -> StateSpec:
     else:
         spec = StateSpec(output=value)
 
-    if spec.output is not None and (isinstance(spec.output, bool) or not isinstance(spec.output, int)):
-        raise TypeError(f"State output index must be an int or None, got {spec.output!r}")
+    if isinstance(spec.output, bool) or not isinstance(spec.output, (int, str, type(None))):
+        raise TypeError(f"State output must be an int, str, or None, got {spec.output!r}")
     if spec.name is not None and (not isinstance(spec.name, str) or not spec.name):
         raise TypeError(f"State name must be a non-empty str or None, got {spec.name!r}")
     return spec
@@ -219,6 +251,8 @@ def _resolve_state_map(hlo_func: FuncOp, states: StateMapping) -> dict[int, Stat
     state_names: set[str] = set()
     for key, value in states.items():
         spec = _coerce_state_spec(value)
+        out_idx = _resolve_state_output(hlo_func, spec.output)
+        spec = StateSpec(output=out_idx, name=spec.name)
         if isinstance(key, bool) or not isinstance(key, (int, str)):
             raise TypeError(f"State input must be an int index or str name, got {key!r}")
 

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -7,6 +7,7 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export, symbolic_shape
 
+from stablehlo_coreml import StateSpec
 from stablehlo_coreml.converter import convert
 from tests.utils import export_hlo_module, run_and_compare_stateful
 
@@ -29,7 +30,7 @@ def test_accumulator_persists_across_calls():
     run_and_compare_stateful(
         _accumulator,
         initial_inputs=(initial_state, jnp.array([1.0, 2.0, 3.0], dtype=jnp.float32)),
-        states={0: 1},
+        states={"main": {"state": StateSpec(output=1)}},
         extra_nonstate_steps=[
             (jnp.array([0.5, -1.0, 2.0], dtype=jnp.float32),),
             (jnp.array([1.0, 1.0, 1.0], dtype=jnp.float32),),
@@ -105,9 +106,127 @@ def test_state_by_argument_name():
     inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
     hlo_module = export_hlo_module(step, inputs)
     mil_by_index = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 1})
-    # `%arg0` is also accepted without the leading `%`.
-    mil_by_name = convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={"arg0": 1})
+    mil_by_name = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=1)}},
+    )
     assert _instruction_types(mil_by_index) == _instruction_types(mil_by_name)
+    assert list(mil_by_name.functions["main"].inputs) == ["state", "x"]
+
+
+def test_read_only_state():
+    def inspect(state, x):
+        return state + x
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(inspect, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=None)}},
+    )
+
+    op_types = _instruction_types(mil_program)
+    assert "read_state" in op_types
+    assert "coreml_update_state" not in op_types
+    assert len(mil_program.functions["main"].outputs) == 1
+
+
+def test_state_name_override():
+    def step(state, x):
+        new_state = state + x
+        return new_state, new_state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(step, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=1, name="accumulator")}},
+    )
+
+    assert list(mil_program.functions["main"].inputs) == ["accumulator", "x"]
+
+
+def test_state_name_override_takes_precedence_over_jax_argument_name():
+    def inspect(cache, state):
+        return cache + state
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    hlo_module = export_hlo_module(inspect, inputs)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=None, name="cache")}},
+    )
+
+    assert list(mil_program.functions["main"].inputs) == ["arg0", "cache"]
+
+
+def test_function_scoped_states_export_as_multifunction():
+    ctx = jax_mlir.make_ir_context()
+    mlir_text = """
+    module {
+      func.func public @update(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> (tensor<2xf32>, tensor<2xf32>) {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0, %0 : tensor<2xf32>, tensor<2xf32>
+      }
+      func.func public @inspect(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+    }
+    """
+    hlo_module = ir.Module.parse(mlir_text, context=ctx)
+    mil_program = convert(
+        hlo_module,
+        minimum_deployment_target=ct.target.iOS18,
+        states={
+            "update": {"arg0": StateSpec(output=1, name="cache")},
+            "inspect": {"arg1": StateSpec(output=None, name="cache")},
+        },
+    )
+
+    assert mil_program.export_as_multifunction
+    assert mil_program.default_function_name == "update"
+    assert "coreml_update_state" in [
+        op.op_type for op in mil_program.functions["update"].operations
+    ]
+    assert "coreml_update_state" not in [
+        op.op_type for op in mil_program.functions["inspect"].operations
+    ]
+
+    cml_model = ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        skip_model_load=True,
+    )
+    descriptions = {desc.name: desc for desc in cml_model.get_spec().description.functions}
+    assert set(descriptions) == {"update", "inspect"}
+    assert [state.name for state in descriptions["update"].state] == ["cache"]
+    assert [state.name for state in descriptions["inspect"].state] == ["cache"]
+
+
+def test_flat_state_mapping_rejected_for_multiple_functions():
+    ctx = jax_mlir.make_ir_context()
+    hlo_module = ir.Module.parse(
+        """
+        module {
+          func.func public @first(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+            return %arg0 : tensor<2xf32>
+          }
+          func.func public @second(%arg0: tensor<2xf32>) -> tensor<2xf32> {
+            return %arg0 : tensor<2xf32>
+          }
+        }
+        """,
+        context=ctx,
+    )
+
+    with pytest.raises(ValueError, match="flat state mapping"):
+        convert(hlo_module, minimum_deployment_target=ct.target.iOS18, states={0: 0})
 
 
 def test_unknown_state_name():

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -164,6 +164,28 @@ def test_state_name_override_takes_precedence_over_jax_argument_name():
     assert list(mil_program.functions["main"].inputs) == ["arg0", "cache"]
 
 
+@pytest.mark.parametrize("output", ["cache", "result['cache']"])
+def test_state_output_by_jax_result_name(output):
+    def step(state, x):
+        new_state = state + x
+        return {"prediction": new_state * x, "cache": new_state}
+
+    inputs = (jnp.zeros((2,), dtype=jnp.float32), jnp.ones((2,), dtype=jnp.float32))
+    named_program = convert(
+        export_hlo_module(step, inputs),
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=output)}},
+    )
+    indexed_program = convert(
+        export_hlo_module(step, inputs),
+        minimum_deployment_target=ct.target.iOS18,
+        states={"main": {"state": StateSpec(output=0)}},
+    )
+
+    assert _instruction_types(named_program) == _instruction_types(indexed_program)
+    assert len(named_program.functions["main"].outputs) == 1
+
+
 def test_function_scoped_states_export_as_multifunction():
     ctx = jax_mlir.make_ir_context()
     mlir_text = """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Mapping
 
 import coremltools as ct
 import jax
@@ -10,7 +11,7 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export as _jax_export
 
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE
+from stablehlo_coreml import DEFAULT_HLO_PIPELINE, StateSpec
 from stablehlo_coreml.converter import convert
 
 
@@ -285,9 +286,9 @@ def run_and_compare_stateful(
 ):
     """Convert ``jax_func`` with ``states`` and compare multi-step predictions.
 
-    ``states`` maps input indices (or names) to the output index that holds
-    the updated state. ``extra_nonstate_steps`` are tuples of the remaining
-    (non-state) positional arguments for subsequent calls.
+    ``states`` is either a single-function state mapping or a function-scoped
+    mapping. ``extra_nonstate_steps`` are tuples of the remaining (non-state)
+    positional arguments for subsequent calls.
     """
     jax_func = jax.jit(jax_func)
     hlo_module = export_hlo_module(jax_func, initial_inputs)
@@ -296,18 +297,21 @@ def run_and_compare_stateful(
         minimum_deployment_target=ct.target.iOS18,
         states=states,
     )
-    cml_model = _convert_mil_to_coreml(
-        mil_program,
-        max_complexity=max_complexity,
-        compute_units=compute_units,
-    )
+
+    mil_func_name = mil_program.default_function_name
+    function_states = states
+    if states and all(isinstance(value, Mapping) for value in states.values()):
+        function_states = states[mil_func_name]
 
     resolved_states = {}
-    for key, out_idx in states.items():
+    for key, state_spec in function_states.items():
+        out_idx = state_spec.output if isinstance(state_spec, StateSpec) else state_spec
+        if out_idx is None:
+            raise ValueError("run_and_compare_stateful requires updated, not read-only, states")
         if isinstance(key, int):
             resolved_states[key] = out_idx
         else:
-            mil_func = next(iter(mil_program.functions.values()))
+            mil_func = mil_program.functions[mil_func_name]
             for i, name in enumerate(mil_func.inputs):
                 aliases = {name, name.lstrip("%")}
                 if key in aliases:
@@ -315,6 +319,12 @@ def run_and_compare_stateful(
                     break
             else:
                 raise ValueError(f"Could not resolve state input {key!r}")
+
+    cml_model = _convert_mil_to_coreml(
+        mil_program,
+        max_complexity=max_complexity,
+        compute_units=compute_units,
+    )
 
     nonstate_indices = [i for i in range(len(initial_inputs)) if i not in resolved_states]
     state_indices = [i for i in range(len(initial_inputs)) if i in resolved_states]


### PR DESCRIPTION
## Summary

Stacked on #76.

Change state configuration from one mapping applied to every public function to a function-scoped mapping:

```python
states={
    "main": {
        "cache": StateSpec(output="cache"),
    },
    "inspect": {
        "cache": StateSpec(output=None),
    },
}
```

`StateSpec` is conversion metadata rather than an initial array:

- `output` selects the function result that updates the state by index, exact JAX `result_info`, or unique leaf name; `None` makes it read-only
- `name` optionally overrides the Core ML state name
- shape and dtype continue to come from the StableHLO argument

The existing flat `{input: output}` form remains available for single-function modules. Named outputs rely on optional JAX metadata; positional indices remain the portable fallback for other StableHLO producers.

## Other changes

- Preserve JAX argument names from MLIR locations when available, with explicit `StateSpec.name` taking precedence
- Export programs with multiple public functions as Core ML multifunction models and select `main`, or the first public function, as the default
- Allow each function to expose a different state subset, avoiding converter-generated no-op updates and removing the need for #79 for that case
- Validate unknown functions, mixed mapping forms, duplicate outputs, names, shapes, and dtypes
- Document the function-scoped API and add runtime/serialization coverage

One question for review: this establishes independent state interfaces per Core ML function. If sharing the same runtime state object across functions is required, we should separately verify the intended Core ML runtime contract; matching `StateSpec.name` values alone should not be assumed to establish that behavior.

## Validation

- `hatch run +py=3.12 test:pytest -q` — 202 passed, 1 skipped
- `hatch run +py=3.12 test:pytest -q tests/test_stateful.py` — 18 passed
- `hatch run lint:check`
