### PR TITLE
Fuse attention to SDPA when the query sequence length is 1

### DIFF
--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -25,9 +25,19 @@ result axes of ``matmul_0``, and the pass tracks that re-grouping symbolically
 * how a mask expressed in softmax space maps onto SDPA's ``[..., L, S]``
   attention scores.
 
-Whenever that cannot be established (symbolic dimensions where concrete ones
-are needed, a result axis split across the softmax axis, an intermediate value
-that is consumed elsewhere, ...) the pass leaves the graph alone.
+Size-1 axes are the one thing the re-grouping cannot pin down: a reshape that
+introduces or drops one next to another (``[H, L, S] -> [H, L, 1, S]``, which
+the converter emits to restore a batch axis) may attach it to either, and a
+following transpose then moves the two apart. It also makes no difference --
+an axis of size 1 is always indexed 0, so it never reorders elements -- and
+layouts are therefore compared by their non-unit atoms only (see
+:func:`_ordering`). Without that, a query sequence length of 1, i.e. every
+autoregressive decode step, would never fuse.
+
+Whenever the re-grouping cannot be established (symbolic dimensions where
+concrete ones are needed, a result axis split across the softmax axis, an
+intermediate value that is consumed elsewhere, ...) the pass leaves the graph
+alone.
 
 PyTorch's ``_safe_softmax`` wrapper -- ``select(row_is_all_neg_inf, 0.0,
 softmax(x))``, which several HuggingFace models lower literally -- is peeled off
@@ -192,6 +202,30 @@ def _track_layout(layout: list[list[_Atom]], ops) -> list[list[_Atom]] | None:
 def _expand(dim) -> list[_Atom]:
     """Expand a dimension's atoms to their (current) leaves."""
     return [leaf for atom in dim for leaf in atom.leaves()]
+
+
+def _ordering(atoms) -> list[_Atom]:
+    """The atoms of ``atoms`` that carry ordering information: the non-unit ones.
+
+    An axis of size 1 always has index 0, so it contributes nothing to the
+    flattened element offset -- two atom sequences describe the same element
+    order exactly when their non-unit atoms agree. Dimension sizes are not lost
+    either: a unit atom multiplies a group's size by 1.
+
+    That matters because a reshape which introduces or removes a size-1 axis
+    next to another one is genuinely ambiguous. ``[H, 1, S] -> [H, 1, 1, S]``
+    (the reshape the converter emits around ``dot_general`` when the query
+    sequence length is 1) can put the query atom in either unit axis, and a
+    following transpose then moves the two apart. Comparing layouts by their
+    ordering atoms makes that choice irrelevant instead of a match failure.
+    """
+    return [atom for atom in atoms if atom.size != 1]
+
+
+def _same_ordering(a, b) -> bool:
+    """True when two atom sequences describe the same element order."""
+    a, b = _ordering(a), _ordering(b)
+    return len(a) == len(b) and all(x is y for x, y in zip(a, b))
 
 
 def _leads_to_matmul(var, depth: int = 12) -> bool:
@@ -420,8 +454,9 @@ class _Space:
         self.s_atom = s_atom
         self.l_atom = l_atom
         self.batch_atoms = batch_atoms
+        # Every layout kept here holds ordering atoms only (see `_ordering`).
         self.softmax_layout = softmax_layout
-        self.l_leaves = None if l_atom is None else l_atom.leaves()
+        self.l_leaves = None if l_atom is None else _ordering(l_atom.leaves())
         self.l_prime = l_prime
 
     @property
@@ -433,8 +468,8 @@ class _Space:
         """The atom order of SDPA's ``[batch..., L, S]`` score space."""
         order = []
         for atom in self.batch_atoms:
-            order.extend(atom.leaves())
-        return order + list(self.l_leaves) + [self.s_atom]
+            order.extend(_ordering(atom.leaves()))
+        return order + list(self.l_leaves) + _ordering([self.s_atom])
 
     @property
     def is_score_space(self) -> bool:
@@ -444,11 +479,11 @@ class _Space:
         if len(self.softmax_layout) != self.n_batch + 2:
             return False
         for atom, dim in zip(self.batch_atoms, self.softmax_layout):
-            if [id(a) for a in dim] != [id(a) for a in atom.leaves()]:
+            if not _same_ordering(dim, atom.leaves()):
                 return False
-        if self.softmax_layout[-1] != [self.s_atom]:
+        if not _same_ordering(self.softmax_layout[-1], [self.s_atom]):
             return False
-        return [id(a) for a in self.softmax_layout[-2]] == [id(a) for a in self.l_leaves]
+        return _same_ordering(self.softmax_layout[-2], self.l_leaves)
 
 
 def _match_backward(softmax_op, pattern, ignored=()) -> bool:
@@ -574,6 +609,26 @@ def _match_forward(softmax_op, pattern, safe_softmax=None) -> bool:
     return True
 
 
+def _softmax_axis_atom(dim, m_atom: _Atom, n_atom: _Atom) -> _Atom | None:
+    """The result axis of ``matmul_0`` that the softmax axis ``dim`` is made of.
+
+    ``None`` when the softmax axis is not exactly one whole result axis: it
+    reduces over a batch axis, over several axes at once, or over only part of
+    one. Unit atoms that drifted into the axis are ignored -- they add nothing
+    to it -- unless the axis is degenerate and consists of nothing else.
+    """
+    ordering = _ordering(dim)
+    if len(ordering) > 1:
+        return None
+    if ordering:
+        atom = ordering[0]
+        return atom if atom is m_atom or atom is n_atom else None
+    # Every atom of the axis has size 1, so there is a single key and no
+    # ordering to compare. Fall back to the axis being a result axis verbatim.
+    whole = [atom for atom in dim if atom is m_atom or atom is n_atom]
+    return whole[0] if len(whole) == 1 else None
+
+
 def _analyse_space(pattern) -> _Space | None:
     """Work out the S/L roles and the row permutation between the two matmuls."""
     scores_shape = tuple(pattern.matmul_0.outputs[0].shape)
@@ -592,17 +647,14 @@ def _analyse_space(pattern) -> _Space | None:
     batch_atoms, m_atom, n_atom = atoms[:n_batch], atoms[-2], atoms[-1]
 
     layout = _track_layout([[atom] for atom in atoms], pattern.back_layout_ops)
-    if not layout or len(layout[-1]) != 1:
+    if not layout:
         return None
 
-    s_atom = layout[-1][0]
-    if s_atom is m_atom:
-        l_atom = n_atom
-    elif s_atom is n_atom:
-        l_atom = m_atom
-    else:
+    s_atom = _softmax_axis_atom(layout[-1], m_atom, n_atom)
+    if s_atom is None:
         # Softmax reduces over a batch axis, or over only part of a result axis.
         return None
+    l_atom = n_atom if s_atom is m_atom else m_atom
 
     weights_layout = _track_layout(layout, pattern.fwd_layout_ops)
     if weights_layout is None or len(weights_layout) != n_batch + 2:
@@ -613,15 +665,15 @@ def _analyse_space(pattern) -> _Space | None:
     if s_atom.children is not None:
         # The key axis itself was split; it is no longer a single SDPA axis.
         return None
-    if _expand(weights_layout[-1]) != [s_atom]:
+    if not _same_ordering(_expand(weights_layout[-1]), [s_atom]):
         return None
     for atom, dim in zip(batch_atoms, weights_layout):
         # The batch layout of both matmuls has to agree: SDPA keeps it as is.
-        if _expand(dim) != atom.leaves():
+        if not _same_ordering(_expand(dim), atom.leaves()):
             return None
 
-    l_leaves = l_atom.leaves()
-    l_prime = _expand(weights_layout[n_batch])
+    l_leaves = _ordering(l_atom.leaves())
+    l_prime = _ordering(_expand(weights_layout[n_batch]))
     if len(l_prime) != len(l_leaves) or {id(a) for a in l_prime} != {id(a) for a in l_leaves}:
         return None
 
@@ -632,7 +684,7 @@ def _analyse_space(pattern) -> _Space | None:
         s_atom=s_atom,
         l_atom=l_atom,
         batch_atoms=batch_atoms,
-        softmax_layout=[_expand(dim) for dim in layout],
+        softmax_layout=[_ordering(_expand(dim)) for dim in layout],
         l_prime=l_prime,
     )
 
@@ -722,7 +774,11 @@ def _mask_to_sdpa_space(mask_var, space, softmax_shape, seq_len, before_op, name
         var = mb.tile(x=var, reps=reps, before_op=before_op, name=name + "_tile")
 
     # Split softmax space into one axis per atom, then reorder to [batch..., L, S].
+    # The layout holds ordering atoms only, so the split drops the size-1 axes;
+    # the final reshape below puts the [batch..., L, S] shape back.
     flat_atoms = [atom for dim in space.softmax_layout for atom in dim]
+    if not flat_atoms:
+        return None
     var = mb.reshape(
         x=var,
         shape=[atom.size for atom in flat_atoms],

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -69,6 +69,33 @@ def _qkv_specs():
     ]
 
 
+def _predict(prog, **inputs):
+    """Convert ``prog`` and run it; returns the single output as an ndarray."""
+    model = ct.convert(
+        prog,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+        # Keep fp32 throughout; the default pipeline would otherwise downcast and
+        # leave only ~1e-3 of accuracy to compare against.
+        compute_precision=ct.precision.FLOAT32,
+    )
+    names = [feature.name for feature in model.get_spec().description.input]
+    result = model.predict({name: inputs[name] for name in names})
+    return np.array(next(iter(result.values())))
+
+
+def _reference_attention(q, k, v, mask=None, fill=-1e9):
+    """``softmax(q @ k^T [+ mask]) @ v`` in numpy, over the last two axes."""
+    scores = np.matmul(q, np.swapaxes(k, -2, -1))
+    if mask is not None:
+        scores = np.where(mask, scores, np.float32(fill))
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    weights = np.exp(scores)
+    weights /= weights.sum(axis=-1, keepdims=True)
+    return np.matmul(weights, v)
+
+
 class TestFuseAttentionToSdpa:
     """Unit tests on hand-built MIL programs."""
 
@@ -554,6 +581,165 @@ class TestFuseAttentionToSdpa:
         assert get_op_types_in_program(prog) == ops_after_first
 
 
+class TestUnitQueryLength:
+    """The autoregressive decode step: a single query row.
+
+    ``dot_general`` on a ``[1, H, 1, E] x [1, H, S, E]`` pair lowers to a rank-3
+    ``matmul`` over ``[H, 1, S]``, and the converter puts the leading batch axis
+    back afterwards with ``reshape [H, 1, 1, S] -> transpose [1, H, 1, S]``.
+
+    That reshape places a *second* size-1 axis right next to the query axis, so
+    which of the two holds the query rows cannot be decided from the sizes -- and
+    the transpose then moves the two apart, dropping the query axis into the
+    batch position. It makes no difference to the elements (a size-1 axis is
+    always indexed 0), and the pass must not be confused by it.
+    """
+
+    HEADS, KEYS, EMBED = 3, 7, 4
+
+    @classmethod
+    def _specs(cls, *extra):
+        return [
+            mb.TensorSpec(shape=(cls.HEADS, 1, cls.EMBED)),
+            mb.TensorSpec(shape=(cls.HEADS, cls.KEYS, cls.EMBED)),
+            mb.TensorSpec(shape=(cls.HEADS, cls.KEYS, cls.EMBED)),
+            *extra,
+        ]
+
+    def test_unit_query_axis_is_fused(self):
+        heads, keys, embedding = self.HEADS, self.KEYS, self.EMBED
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=self._specs())
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)              # [H, 1, S]
+            split = mb.reshape(x=scores, shape=[heads, 1, 1, keys])     # [H, 1, 1, S]
+            moved = mb.transpose(x=split, perm=[2, 0, 1, 3])            # [1, H, 1, S]
+            weights = mb.softmax(x=moved, axis=-1)
+            merged = mb.reshape(x=weights, shape=[heads, 1, keys])      # [H, 1, S]
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "softmax" not in ops
+        assert "matmul" not in ops
+        assert_model_is_valid(
+            prog,
+            {"q": (heads, 1, embedding), "k": (heads, keys, embedding), "v": (heads, keys, embedding)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_unit_query_axis_with_key_mask_is_fused(self):
+        """The decode mask is one flag per key, shared by every head."""
+        heads, keys = self.HEADS, self.KEYS
+        mask_spec = mb.TensorSpec(shape=(1, 1, 1, keys), dtype=types.bool)
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=self._specs(mask_spec))
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            split = mb.reshape(x=scores, shape=[heads, 1, 1, keys])
+            moved = mb.transpose(x=split, perm=[2, 0, 1, 3])
+            masked = mb.select(cond=mask, a=moved, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            merged = mb.reshape(x=weights, shape=[heads, 1, keys])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        assert "softmax" not in ops
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        # A pure key mask collapses to [1, 1, S] in the rank-3 matmul space.
+        assert tuple(sdpa.attn_mask.shape) == (1, 1, keys)
+
+    def test_unit_query_axis_with_per_head_mask_is_fused(self):
+        """A mask that varies per head has to be re-laid out in matmul space."""
+        heads, keys = self.HEADS, self.KEYS
+        mask_spec = mb.TensorSpec(shape=(1, heads, 1, keys), dtype=types.bool)
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=self._specs(mask_spec))
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            split = mb.reshape(x=scores, shape=[heads, 1, 1, keys])
+            moved = mb.transpose(x=split, perm=[2, 0, 1, 3])
+            masked = mb.select(cond=mask, a=moved, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            merged = mb.reshape(x=weights, shape=[heads, 1, keys])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("scaled_dot_product_attention") == 1
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert tuple(sdpa.attn_mask.shape) == (heads, 1, keys)
+
+    def test_unit_query_axis_keeps_the_original_numerics(self):
+        heads, keys, embedding = self.HEADS, self.KEYS, self.EMBED
+        mask_spec = mb.TensorSpec(shape=(1, 1, 1, keys), dtype=types.bool)
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=self._specs(mask_spec))
+        def prog(q, k, v, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            split = mb.reshape(x=scores, shape=[heads, 1, 1, keys])
+            moved = mb.transpose(x=split, perm=[2, 0, 1, 3])
+            masked = mb.select(cond=mask, a=moved, b=FINITE_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            merged = mb.reshape(x=weights, shape=[heads, 1, keys])
+            return mb.matmul(x=merged, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog).count("scaled_dot_product_attention") == 1
+
+        rng = np.random.RandomState(0)
+        q = rng.randn(heads, 1, embedding).astype(np.float32)
+        k = rng.randn(heads, keys, embedding).astype(np.float32)
+        v = rng.randn(heads, keys, embedding).astype(np.float32)
+        mask = (np.arange(keys) < keys - 2).reshape(1, 1, 1, keys)
+
+        expected = _reference_attention(q, k, v, mask.reshape(1, 1, keys), fill=float(FINITE_FILL))
+        # Core ML has no boolean model input; it exposes the mask as fp32.
+        got = _predict(prog, q=q, k=k, v=v, mask=mask.astype(np.float32))
+        np.testing.assert_allclose(got, expected, atol=1e-4, rtol=1e-4)
+
+    def test_not_fused_when_a_transpose_permutes_real_batch_axes(self):
+        """A unit query axis must not make a genuine batch permutation look free."""
+        b0, b1, keys, embedding = 2, 3, 7, 4
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(b0, b1, 1, embedding)),
+            mb.TensorSpec(shape=(b0, b1, keys, embedding)),
+            mb.TensorSpec(shape=(b1, b0, keys, embedding)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)      # [b0, b1, 1, S]
+            swapped = mb.transpose(x=scores, perm=[1, 0, 2, 3])  # [b1, b0, 1, S]
+            weights = mb.softmax(x=swapped, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_not_fused_when_the_softmax_axis_merges_a_real_batch_axis(self):
+        """``[B, 1, S] -> [1, B * S]`` reduces over more than the key axis."""
+        batch, keys, embedding = 2, 7, 4
+
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(batch, 1, embedding)),
+            mb.TensorSpec(shape=(batch, keys, embedding)),
+            mb.TensorSpec(shape=(batch, keys, embedding)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)             # [B, 1, S]
+            merged = mb.reshape(x=scores, shape=[1, 1, batch * keys])  # [1, 1, B * S]
+            weights = mb.softmax(x=merged, axis=-1)
+            split = mb.reshape(x=weights, shape=[batch, 1, keys])
+            return mb.matmul(x=split, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+
 class TestSafeSoftmaxWrapper:
     """`torch._safe_softmax` zeroes rows that are entirely -inf; peel that."""
 
@@ -757,6 +943,18 @@ class TestRegroup:
         assert self._sizes(_regroup(atoms, [4, 1])) == [[1, 4], [1]]
         assert self._sizes(_regroup([_Atom(1), _Atom(4), _Atom(1)], [4])) == [[1, 4, 1]]
 
+    def test_a_unit_atom_lands_in_an_arbitrary_unit_dimension(self):
+        """`[H, 1, S] -> [H, 1, 1, S]` cannot tell the two size-1 axes apart.
+
+        The query atom ends up in the *second* of them; a following transpose may
+        then carry it anywhere. Matching therefore compares layouts by their
+        non-unit atoms only -- a size-1 axis never reorders elements.
+        """
+        atoms = [_Atom(3), _Atom(1), _Atom(7)]
+        grouped = _regroup(atoms, [3, 1, 1, 7])
+        assert self._sizes(grouped) == [[3], [], [1], [7]]
+        assert grouped[2][0] is atoms[1]
+
     def test_axes_are_split_and_merged(self):
         atoms = [_Atom(2), _Atom(15)]
         assert self._sizes(_regroup(atoms, [6, 5])) == [[2, 3], [5]]
@@ -802,6 +1000,46 @@ class TestFuseAttentionToSdpaEndToEnd:
             jax.ShapeDtypeStruct((1, 7, 2, 4), jnp.float32),      # b s k h
             jax.ShapeDtypeStruct((1, 7, 2, 4), jnp.float32),      # b s k h
             jax.ShapeDtypeStruct((1, 5, 7), jnp.bool_),           # b t s
+        ])
+        self._assert_fused(cml_model)
+
+    def test_decode_step_attention_with_unit_query_length(self):
+        """One query row against the whole cache -- the autoregressive hot path."""
+        def attention(q, k, v, valid):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0)
+            scores = jnp.where(valid[:, None, None, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            return jnp.einsum("bhls,bhsd->bhld", weights, v)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((1, 3, 1, 4), jnp.float32),
+            jax.ShapeDtypeStruct((1, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((1, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((1, 7), jnp.bool_),
+        ])
+        self._assert_fused(cml_model)
+
+    def test_gqa_decode_step_attention(self):
+        """A Gemma-style decode step: one query row, grouped KV heads."""
+        heads, kv_heads, keys, embedding = 4, 2, 7, 4
+
+        def attention(q, k, v, valid):
+            k = jnp.repeat(k, heads // kv_heads, axis=2)
+            v = jnp.repeat(v, heads // kv_heads, axis=2)
+            scores = jnp.matmul(
+                jnp.transpose(q, (0, 2, 1, 3)),
+                jnp.swapaxes(jnp.transpose(k, (0, 2, 1, 3)), -2, -1),
+            )
+            scores = jnp.where(valid[None, None, None, :], scores, -1e9)
+            weights = jax.nn.softmax(scores, axis=-1)
+            out = jnp.matmul(weights, jnp.transpose(v, (0, 2, 1, 3)))
+            return jnp.transpose(out, (0, 2, 1, 3)).reshape(1, 1, heads * embedding)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((1, 1, heads, embedding), jnp.float32),
+            jax.ShapeDtypeStruct((1, keys, kv_heads, embedding), jnp.float32),
+            jax.ShapeDtypeStruct((1, keys, kv_heads, embedding), jnp.float32),
+            jax.ShapeDtypeStruct((keys,), jnp.bool_),
         ])
         self._assert_fused(cml_model)
 


### PR DESCRIPTION
`fuse_attention_to_sdpa` (from #78) gives up on every autoregressive decode step: with a query sequence length of 1 the block keeps its softmax and two matmuls instead of fusing to `scaled_dot_product_attention`. Found while adopting 0.1.4 in gemma-coreml-chat (its decode hot path regressed vs the local pass it replaced). Reproduces under jax 0.9.1 (which downstream pins); jax 0.11 happens to lower `dot_general` differently and dodges it.

## Root cause

Under jax 0.9.1 the converter emits, between `matmul_0` and the softmax:

```
matmul_0                  -> [H, L, S]        (L = 1)
reshape                   -> [H, L, 1, S]     # restore the batch axis
transpose perm=[2,0,1,3]  -> [1, H, L, S]
softmax(axis=-1) ; reshape -> [H, L, S] ; matmul_1
```

The reshape places a second size-1 axis next to the query axis. `_regroup` must pick which unit axis receives the query atom; `_spare_unit_atoms` reserves it for the *later* one — exactly the axis the transpose then moves to the front. `_analyse_space` subsequently sees the query atom inside the batch slot (`[[L, H], [], [S]]` instead of `[[H], [L], [S]]`), fails the batch and query-row comparisons, and rejects the block. With L > 1 the greedy reservation happens to pick the right axis, which is why only L == 1 broke.

## Fix

Which of two adjacent size-1 axes an atom lands on is not decidable from sizes — and does not need to be: a size-1 axis is always indexed 0, so it contributes nothing to element ordering, and a dimension's size is the product of its non-unit atoms alone. Two atom layouts describe the same tensor exactly when their non-unit atoms agree. So:

- `_ordering(atoms)` / `_same_ordering(a, b)` compare layouts by their non-unit atoms (identity-wise);
- `_analyse_space` uses them for the key axis, batch axes, and query rows; `_Space` keeps ordering atoms only;
- `_softmax_axis_atom` picks the softmax axis by its single ordering atom, falling back to the verbatim match for wholly-degenerate axes (keeps `test_degenerate_single_query_and_key` intact).

This is a general unit-axis rule, not an `L == 1` special case. Everything that *does* carry ordering is as strict as before: a transpose permuting real batch axes, a softmax axis merging a non-unit batch axis, and a split key axis are all still rejected (covered by new negative tests).

## Tests

`TestUnitQueryLength` builds the decode chain directly in MIL (version-independent): unmasked, key-masked (asserts `attn_mask` collapses to `(1,1,S)`), per-head-masked (asserts `(H,1,S)`), and a numerical-parity case vs a numpy softmax reference; plus the two negatives above, a `_regroup` case documenting the ambiguity, and end-to-end JAX decode / GQA-decode steps through `run_and_compare`. The four positive MIL tests fail on the pre-fix code.

## Verification

- `tests/passes/test_fuse_attention_to_sdpa.py`: 60 passed (was 51); `tests/passes`: 199 passed; full suite: 422 passed. `ruff check .` clean.
- Real Gemma decode graph (JAX 0.9.1 → converter → `build_pass_pipeline()`), C ∈ {1,2,4} × kv_rep ∈ {1,2}: all fuse to exactly one `scaled_dot_product_attention` (`softmax=0`, `matmul=0`), max abs error vs JAX ≤ 7e-8.
- Downstream check: gemma-coreml-chat's `test_decode_attention_fuses_to_sdpa` (a strict xfail against 0.1.4) flips to XPASS with this branch on `PYTHONPATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXBmYgwYbJMbruk25LLG7b