### PR TITLE
Emit the chlo.erfc literal in the operand dtype

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -321,7 +321,10 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         x = context[op.inputs[0].get_name()]
         # erfc(x) = 1 - erf(x). Keeping the `1 - erf(...)` shape also lets the
         # `fuse_gelu_erfc` MIL pass recognise an exact GELU.
-        context.add_result(op.results[0], mb.sub(x=1.0, y=mb.erf(x=x)))
+        # The literal has to carry the operand dtype: MIL's `sub` requires both
+        # inputs to have the same dtype, so a bare `1.0` (fp32) rejects an fp16 x.
+        one = get_numpy_type(x)(1.0)
+        context.add_result(op.results[0], mb.sub(x=one, y=mb.erf(x=x)))
 
     @register_composite_op("chlo.asin")
     def _op_composite_chlo_asin(self, context: TranslationContext, op: CompositeOp):

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -4,6 +4,7 @@ import coremltools as ct
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import (
@@ -178,11 +179,20 @@ class TestFuseGeluErfc:
 class TestFuseGeluErfcEndToEnd:
     """End-to-end tests going through the real converter + pipeline."""
 
-    def test_exact_gelu_via_jit_lowering(self):
-        """The `jax.jit(...).lower()` path keeps `chlo.erfc`, which becomes `1 - erf`."""
-        inputs = (jax.random.normal(jax.random.PRNGKey(0), (4, 16), dtype=jnp.float32),)
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+    def test_exact_gelu_via_jit_lowering(self, dtype):
+        """The `jax.jit(...).lower()` path keeps `chlo.erfc`, which becomes `1 - erf`.
+
+        The fp16 case additionally covers the composite handler emitting its `1`
+        in the operand dtype; with an fp32 literal the model does not convert.
+        """
+        inputs = (jax.random.normal(jax.random.PRNGKey(0), (4, 16), dtype=dtype),)
+        precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
         cml_model = run_and_compare_jit_lowering(
-            lambda x: jax.nn.gelu(x, approximate=False), inputs
+            lambda x: jax.nn.gelu(x, approximate=False),
+            inputs,
+            atol=1e-04 * precision_loss,
+            rtol=1e-05 * precision_loss,
         )
         ops = get_model_instruction_types(cml_model)
         assert ops.count("gelu") == 1

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -500,19 +500,30 @@ def test_erf():
         assert len([op for op in ops if op != "const"]) == 1
 
 
-def test_erfc():
-    """`chlo.erfc` maps to `1 - erf(x)` when it survives as a composite."""
-    inputs = (jnp.linspace(-3, 3, 30, dtype=jnp.float32).reshape(5, 6),)
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+def test_erfc(dtype):
+    """`chlo.erfc` maps to `1 - erf(x)` when it survives as a composite.
 
-    cml_model = run_and_compare_jit_lowering(jax.lax.erfc, inputs)
+    The `1` has to be emitted in the operand dtype: MIL's `sub` requires both
+    of its inputs to have the same dtype, so an fp32 literal rejects an fp16 x.
+    """
+    inputs = (jnp.linspace(-3, 3, 30, dtype=dtype).reshape(5, 6),)
+    # fp16 carries ~3 decimal digits; scale the tolerances by the ratio of the
+    # machine epsilons, the way `test_trigonometry` does for the atan2 case.
+    precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
+    tolerances = {"atol": 1e-04 * precision_loss, "rtol": 1e-05 * precision_loss}
+
+    cml_model = run_and_compare_jit_lowering(jax.lax.erfc, inputs, **tolerances)
     ops = get_model_instruction_types(cml_model)
     assert ops.count("erf") == 1
     assert ops.count("sub") == 1
+    # The subtraction happens in the operand dtype, without an fp32 detour.
+    assert "cast" not in ops
 
     # `jax.export` expands `chlo.erfc` before we get to see the module (unlike
     # `chlo.erf`, it has no composite representation there), so that path keeps
     # the polynomial. Only the numerics are checked.
-    run_and_compare_specific_input(jax.lax.erfc, inputs)
+    run_and_compare_specific_input(jax.lax.erfc, inputs, **tolerances)
 
 
 def test_composite_ops_via_jit_lowering():


### PR DESCRIPTION
`_op_composite_chlo_erfc` builds `mb.sub(x=1.0, y=erf(x))` with a bare Python float, which MIL types as fp32 — so any fp16 `chlo.erfc` (notably what `jax.nn.gelu(approximate=False)` traces to) fails conversion with:

```
ValueError: In op, of type sub, ... y has dtype fp16 whereas x has dtype fp32.
```

Fix: emit the literal via `get_numpy_type(x)(1.0)`, the same idiom `op_log1p`/`op_neg`/`op_atan2` already use.

Tests: `test_erfc` and `test_exact_gelu_via_jit_lowering` parametrized over fp32/fp16 (tolerances scaled by the epsilon ratio, mirroring the existing atan2 fp16 case), plus an assertion that no stray `cast` appears and the fp16 exact GELU still fuses to a single `gelu` op. Full core suite: 425 passed, 1 skipped; ruff clean.

Found while exporting a Gemma model with fp16 activations in kasper0406/gemma-coreml-chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSuo4pE3Kr3GWNwcLKLn5v