### PR TITLE
Fuse the RMSNorm chain into l2_norm + a constant mul

### DIFF
--- a/stablehlo_coreml/passes/fuse_rmsnorm.py
+++ b/stablehlo_coreml/passes/fuse_rmsnorm.py
@@ -1,0 +1,245 @@
+"""MIL pass: collapse the RMSNorm elementwise chain onto the ``l2_norm`` op.
+
+RMSNorm is usually written with fp32 statistics over an fp16 activation, which
+the converter (helped by ``fuse_reduce_keep_dims`` and coremltools'
+``fuse_reduce_mean``) lowers to eight ops::
+
+    %x32  = cast(x=%x, dtype=fp32)
+    %sq   = mul(x=%x32, y=%x32)
+    %var  = reduce_mean(x=%sq, axes=[-1], keep_dims=True)
+    %vare = add(x=%var, y=eps)
+    %inv  = rsqrt(x=%vare)
+    %n    = mul(x=%x32, y=%inv)
+    %s    = mul(x=%n, y=const scale)          # absent for a norm without scale
+    %out  = cast(x=%s, dtype=fp16)
+
+Six of those eight ops compute ``x / sqrt(mean(x^2) + eps)``, which is
+``l2_norm`` up to a constant:
+
+.. math::
+   \\frac{x}{\\sqrt{\\frac{1}{d}\\sum x^2 + \\epsilon}}
+   = \\sqrt{d}\\;\\frac{x}{\\sqrt{\\sum x^2 + d\\epsilon}}
+   = \\sqrt{d}\\;\\mathrm{l2\\_norm}(x,\\ \\epsilon' = d\\epsilon)
+
+so the whole chain becomes ``l2_norm`` plus one ``mul`` by the precomputed
+constant ``sqrt(d) * scale`` -- 8 ops down to 4, with the surrounding casts (and
+therefore the fp32/fp16 placement) untouched. The rewrite is exact algebra on
+exact constants; the only numerical difference is a division where the original
+had an ``rsqrt`` multiply, both in fp32.
+
+Why not ``layer_norm``? Every pattern in coremltools'
+``fuse_layernorm_or_instancenorm`` begins ``x -> reduce_mean -> sub``, and the
+op itself is defined as ``gamma * (x - E[x]) / sqrt(Var[x] + eps) + beta``.
+RMSNorm has no mean subtraction, so that op cannot express it without changing
+the numerics, and that pass never matches this chain.
+
+Shape handling: ``l2_norm`` normalizes over the **last three** dimensions and
+treats everything before them as batch, so it computes the right reduction only
+when ``rank >= 3`` and ``x.shape[-2] == x.shape[-3] == 1``. Chains whose input
+is shaped otherwise are left alone.
+
+Off-canonical shapes could be fused too, by reshaping to ``(-1, 1, 1, d)`` and
+back (8 ops down to 6), and that variant was tried. It was measurably worse: in
+a graph where every site is off-canonical it adds two reshapes of the full
+activation per norm, which on a 128-token transformer chunk cost ~0.5 ms
+against both the unfused baseline and this shape-restricted version. Fusing
+only the shapes that need no reshape adds no op anywhere.
+
+What this pass is and is not worth: it shrinks the graph (~15% of the non-const
+ops of a small transformer decoder), which shortens compile time and makes the
+program readable, but it is not a latency win on its own -- Core ML's compute
+plan puts the whole elementwise population of such a graph at a fraction of a
+percent of the estimated cost, against ~21% for the ``matmul``s. Op-count work
+of this kind should be judged on graph size, not on latency.
+"""
+
+import logging
+import math
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import any_symbolic
+
+from .pattern_utils import sole_consumer, uniform_const_operand, uniform_scalar_value
+
+logger = logging.getLogger(__name__)
+
+
+def _matches_scale_shape(val, x_shape) -> bool:
+    """True if the constant ``val`` only broadcasts over the normalized axis.
+
+    Anything else (a scale varying along a batch axis) would not survive being
+    folded into a single per-channel factor.
+    """
+    if val.ndim == 0:
+        return True
+    if val.shape[-1] not in (1, int(x_shape[-1])):
+        return False
+    return all(dim == 1 for dim in val.shape[:-1])
+
+
+def _match(rsqrt_op, block):
+    """Match the RMSNorm chain ending at ``rsqrt_op``.
+
+    Returns ``(x32, eps, tail_op, scale, dead)``: the normalized input, the
+    total epsilon, the last op of the chain (the scale ``mul``, or the
+    normalize ``mul`` when the norm has no learnable scale), that scale's
+    constant value or ``None``, and the ops the rewrite replaces, in removal
+    order.
+    """
+    # rsqrt(x) is 1/sqrt(x + epsilon); fold that epsilon in with the add's.
+    eps = uniform_scalar_value(rsqrt_op.inputs.get("epsilon")) or 0.0
+
+    add_op = rsqrt_op.x.op
+    if add_op is None or add_op.op_type != "add" or add_op.enclosing_block is not block:
+        return None
+    if sole_consumer(rsqrt_op.x) is not rsqrt_op:
+        return None
+    shifted = uniform_const_operand(add_op)
+    if shifted is None:
+        return None
+    eps_add, var_var = shifted
+    eps += eps_add
+
+    mean_op = var_var.op
+    if mean_op is None or mean_op.op_type != "reduce_mean" or mean_op.enclosing_block is not block:
+        return None
+    if sole_consumer(var_var) is not add_op:
+        return None
+    if mean_op.keep_dims is None or mean_op.keep_dims.val is not True:
+        return None
+    if mean_op.axes is None or mean_op.axes.val is None:
+        return None
+    axes = list(np.asarray(mean_op.axes.val).reshape(-1))
+    rank = mean_op.x.rank
+    if len(axes) != 1 or (axes[0] % rank) != rank - 1:
+        return None
+
+    square_op = mean_op.x.op
+    if square_op is None or square_op.op_type != "mul" or square_op.enclosing_block is not block:
+        return None
+    if square_op.x is not square_op.y:
+        return None
+    if sole_consumer(mean_op.x) is not mean_op:
+        return None
+
+    x32 = square_op.x
+    if x32.dtype != rsqrt_op.outputs[0].dtype:
+        return None
+    if x32.rank < 3 or any_symbolic(x32.shape):
+        return None
+    # `l2_norm` reduces over the last three dims; only these shapes make that
+    # the last dim alone.
+    if x32.shape[-2] != 1 or x32.shape[-3] != 1:
+        return None
+
+    # The rsqrt result must feed exactly one mul, against x32 itself.
+    norm_mul = sole_consumer(rsqrt_op.outputs[0])
+    if norm_mul is None or norm_mul.op_type != "mul" or norm_mul.enclosing_block is not block:
+        return None
+    if {id(norm_mul.x), id(norm_mul.y)} != {id(x32), id(rsqrt_op.outputs[0])}:
+        return None
+
+    # x32 is read by the square (twice) and by the normalize mul, nothing else.
+    if {id(op) for op in x32.child_ops} != {id(square_op), id(norm_mul)}:
+        return None
+
+    # Optionally absorb a following multiply by a constant scale.
+    tail_op, scale = norm_mul, None
+    scale_mul = sole_consumer(norm_mul.outputs[0])
+    if scale_mul is not None and scale_mul.op_type == "mul" and scale_mul.enclosing_block is block:
+        other = scale_mul.y if scale_mul.x is norm_mul.outputs[0] else scale_mul.x
+        if other is not norm_mul.outputs[0] and other.val is not None:
+            val = np.asarray(other.val)
+            if _matches_scale_shape(val, x32.shape):
+                tail_op, scale = scale_mul, val
+
+    # Reverse topological order, so `remove_ops` never sees a live consumer.
+    dead = [norm_mul, rsqrt_op, add_op, mean_op, square_op]
+    if tail_op is not norm_mul:
+        dead.insert(0, tail_op)
+
+    return x32, eps, tail_op, scale, dead
+
+
+@block_context_manager
+def _fuse_rmsnorm(block) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_rmsnorm(nested_block)
+        if len(op.blocks) > 0 or op.op_type != "rsqrt":
+            continue
+
+        match = _match(op, block)
+        if match is None:
+            continue
+        x32, eps, tail_op, scale, dead = match
+
+        d = int(x32.shape[-1])
+        np_dtype = types.nptype_from_builtin(x32.dtype)
+
+        normalized = mb.l2_norm(
+            x=x32, epsilon=np_dtype(d * eps), before_op=tail_op, name=tail_op.name + "_l2"
+        )
+        # The `sqrt(d)` the identity above pulls out, folded into the scale.
+        factor = math.sqrt(d) if scale is None else np.sqrt(d) * scale.astype(np.float64)
+        rescaled = mb.mul(x=normalized, y=np_dtype(factor), before_op=tail_op, name=tail_op.name)
+
+        block.replace_uses_of_var_after_op(
+            anchor_op=tail_op,
+            old_var=tail_op.outputs[0],
+            new_var=rescaled,
+        )
+        block.remove_ops(dead)
+        fused += 1
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_rmsnorm(AbstractGraphPass):
+    """
+    Fuse the eight-op RMSNorm chain into ``l2_norm`` + a constant ``mul``.
+
+    ``x / sqrt(mean(x^2) + eps)`` equals ``sqrt(d) * l2_norm(x, d * eps)``,
+    where ``d`` is the size of the normalized (last) axis, so the reduction and
+    the elementwise arithmetic collapse into a single op and the learnable
+    scale is folded into the ``sqrt(d)`` factor.
+
+    The rewrite applies when
+
+    1. the reduction is a ``reduce_mean`` with ``keep_dims=True`` over the last
+       axis of a ``mul(x, x)`` square,
+    2. every intermediate value of the chain has exactly one consumer, and
+    3. the input has a static shape with ``rank >= 3`` and
+       ``shape[-2] == shape[-3] == 1`` -- the shapes for which ``l2_norm``'s
+       last-three-dimensions reduction is the last dimension alone. Other
+       shapes would need a reshape around the op, which costs more than the
+       ops it saves.
+
+    Given:
+        %1 = mul(x=%0, y=%0)
+        %2 = reduce_mean(x=%1, axes=[-1], keep_dims=True)
+        %3 = add(x=%2, y=1e-6)
+        %4 = rsqrt(x=%3)
+        %5 = mul(x=%0, y=%4)
+        %6 = mul(x=%5, y=<const scale>)          # optional
+
+    Result:
+        %5 = l2_norm(x=%0, epsilon=d * 1e-6)
+        %6 = mul(x=%5, y=<const sqrt(d) * scale>)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_rmsnorm(f)
+            if fused:
+                logger.debug("fuse_rmsnorm: fused %d RMSNorm chain(s)", fused)

--- a/stablehlo_coreml/passes/fuse_rmsnorm.py
+++ b/stablehlo_coreml/passes/fuse_rmsnorm.py
@@ -13,7 +13,29 @@ the converter (helped by ``fuse_reduce_keep_dims`` and coremltools'
     %s    = mul(x=%n, y=const scale)          # absent for a norm without scale
     %out  = cast(x=%s, dtype=fp16)
 
-Six of those eight ops compute ``x / sqrt(mean(x^2) + eps)``, which is
+That is only one of the spellings the libraries emit. Everything up to and
+including the ``rsqrt`` is common to all of them; the tail is reassociated
+differently, so the pass walks forward from the ``rsqrt`` and tolerates, in any
+order, at most one broadcast ``reshape`` and at most one multiply by a constant
+scale before the ``mul`` that normalizes ``x``. The three shapes that occur in
+practice are:
+
+* hand-written (the chain above): ``mul(x32, rsqrt)`` and then, optionally,
+  ``mul(., scale)``;
+* ``flax.nnx.RMSNorm``, whose ``_normalize`` computes ``mul = rsqrt(var + eps)``,
+  then ``mul *= scale``, then ``y = x * mul`` -- the scale lands on the *rsqrt*
+  result, before the normalize ``mul``;
+* ``equinox.nn.RMSNorm``, whose ``jnp.mean(x**2)`` has no axis argument, so it
+  reduces to a scalar and JAX broadcasts *after* the ``rsqrt``: a ``reshape``
+  sits between the ``rsqrt`` and the normalize ``mul``, and the trailing weight
+  multiply has the constant on the left.
+
+A scale on either side of the normalize ``mul`` (or on both) folds into the same
+single constant. The reduction itself may keep its dimensions or not: what the
+pass validates is the shape the statistic actually has where it broadcasts
+against ``x`` (see ``_is_broadcast_partner``), which covers both.
+
+Six of the eight ops above compute ``x / sqrt(mean(x^2) + eps)``, which is
 ``l2_norm`` up to a constant:
 
 .. math::
@@ -82,14 +104,87 @@ def _matches_scale_shape(val, x_shape) -> bool:
     return all(dim == 1 for dim in val.shape[:-1])
 
 
+def _is_broadcast_partner(stat_shape, x_shape) -> bool:
+    """True if a statistic of ``stat_shape`` normalizes ``x_shape`` row-wise.
+
+    NumPy broadcasting right-aligns the operands, so ``stat_shape`` is padded
+    with leading 1s to ``x``'s rank. The padded shape must then agree with ``x``
+    on every axis but the last (otherwise the elementwise ``mul`` would either
+    fail or replicate ``x`` along a batch axis instead of scaling it), and its
+    last entry must be 1 or the full normalized size -- i.e. one statistic per
+    row, or the reduced axis already broadcast back to full width.
+
+    This is what makes ``keep_dims=False`` acceptable: a squeezed ``(1, 1)``
+    statistic of a ``(1, 1, d)`` input pads to ``(1, 1, 1)``, which is exactly
+    the keep-dims shape. A reshape that permutes non-unit axes always changes
+    the shape tuple in a way this rejects, so the walk below never has to reason
+    about reshape orderings.
+    """
+    if stat_shape is None or any_symbolic(stat_shape):
+        return False
+    if len(stat_shape) > len(x_shape):
+        return False
+    padded = (1,) * (len(x_shape) - len(stat_shape)) + tuple(stat_shape)
+    if [int(dim) for dim in padded[:-1]] != [int(dim) for dim in x_shape[:-1]]:
+        return False
+    return int(padded[-1]) in (1, int(x_shape[-1]))
+
+
+def _walk_to_normalize_mul(rsqrt_op, x32, block):
+    """Walk from the ``rsqrt`` result to the ``mul`` that normalizes ``x32``.
+
+    Different RMSNorm implementations reassociate the tail of the chain: flax
+    folds the learnable scale onto the ``rsqrt`` result *before* multiplying by
+    ``x``, and equinox reduces to a scalar and broadcasts the statistic back with
+    a ``reshape`` after the ``rsqrt``. The walk therefore tolerates, in any
+    order, at most one ``reshape`` and at most one multiply by a constant scale
+    on the way to the normalize ``mul``.
+
+    Returns ``(norm_mul, pre_scale, walked)`` -- the normalize ``mul``, the
+    constant the walk absorbed (or ``None``), and the ops it consumed in walk
+    order -- or ``None`` when the chain is anything else.
+    """
+    stat = rsqrt_op.outputs[0]
+    pre_scale = None
+    reshaped = False
+    walked = []
+
+    while True:
+        consumer = sole_consumer(stat)
+        if consumer is None or consumer.enclosing_block is not block:
+            return None
+
+        if consumer.op_type == "mul" and {id(consumer.x), id(consumer.y)} == {id(x32), id(stat)}:
+            if not _is_broadcast_partner(stat.shape, x32.shape):
+                return None
+            return consumer, pre_scale, walked
+
+        if consumer.op_type == "reshape":
+            if reshaped or not _is_broadcast_partner(consumer.outputs[0].shape, x32.shape):
+                return None
+            reshaped = True
+        elif consumer.op_type == "mul":
+            other = consumer.y if consumer.x is stat else consumer.x
+            if pre_scale is not None or other is stat or other.val is None:
+                return None
+            val = np.asarray(other.val)
+            if not _matches_scale_shape(val, x32.shape):
+                return None
+            pre_scale = val
+        else:
+            return None
+
+        walked.append(consumer)
+        stat = consumer.outputs[0]
+
+
 def _match(rsqrt_op, block):
     """Match the RMSNorm chain ending at ``rsqrt_op``.
 
     Returns ``(x32, eps, tail_op, scale, dead)``: the normalized input, the
-    total epsilon, the last op of the chain (the scale ``mul``, or the
-    normalize ``mul`` when the norm has no learnable scale), that scale's
-    constant value or ``None``, and the ops the rewrite replaces, in removal
-    order.
+    total epsilon, the last op of the chain (the trailing scale ``mul``, or the
+    normalize ``mul`` when there is none), the single constant factor to fold in
+    (or ``None``), and the ops the rewrite replaces, in removal order.
     """
     # rsqrt(x) is 1/sqrt(x + epsilon); fold that epsilon in with the add's.
     eps = uniform_scalar_value(rsqrt_op.inputs.get("epsilon")) or 0.0
@@ -110,7 +205,10 @@ def _match(rsqrt_op, block):
         return None
     if sole_consumer(var_var) is not add_op:
         return None
-    if mean_op.keep_dims is None or mean_op.keep_dims.val is not True:
+    # `keep_dims` may be either way -- what matters is the shape the statistic
+    # has when it reaches the normalize `mul`, which `_is_broadcast_partner`
+    # checks there. Its value does have to be known at compile time.
+    if mean_op.keep_dims is None or mean_op.keep_dims.val is None:
         return None
     if mean_op.axes is None or mean_op.axes.val is None:
         return None
@@ -137,29 +235,35 @@ def _match(rsqrt_op, block):
     if x32.shape[-2] != 1 or x32.shape[-3] != 1:
         return None
 
-    # The rsqrt result must feed exactly one mul, against x32 itself.
-    norm_mul = sole_consumer(rsqrt_op.outputs[0])
-    if norm_mul is None or norm_mul.op_type != "mul" or norm_mul.enclosing_block is not block:
+    # The rsqrt result must reach a single mul against x32 itself, possibly via
+    # a broadcast reshape and/or a scale that was reassociated onto it.
+    walk = _walk_to_normalize_mul(rsqrt_op, x32, block)
+    if walk is None:
         return None
-    if {id(norm_mul.x), id(norm_mul.y)} != {id(x32), id(rsqrt_op.outputs[0])}:
-        return None
+    norm_mul, scale, walked = walk
 
-    # x32 is read by the square (twice) and by the normalize mul, nothing else.
-    if {id(op) for op in x32.child_ops} != {id(square_op), id(norm_mul)}:
-        return None
+    # Note there is deliberately no check that x32 is read *only* by the chain.
+    # The rewrite never removes the op producing it, and none of the ops in
+    # `dead` other than the square and the normalize mul read it, so any other
+    # reader keeps working against an unchanged value. Requiring exclusivity
+    # would decline every RMSNorm on a residual path (`x + attn(rmsnorm(x))`) in
+    # an fp32 graph, where no cast insulates the input from the residual add.
 
-    # Optionally absorb a following multiply by a constant scale.
-    tail_op, scale = norm_mul, None
+    # Optionally absorb a following multiply by a constant scale. Both scales
+    # fold into the same factor when the chain has one on either side.
+    tail_op = norm_mul
     scale_mul = sole_consumer(norm_mul.outputs[0])
     if scale_mul is not None and scale_mul.op_type == "mul" and scale_mul.enclosing_block is block:
         other = scale_mul.y if scale_mul.x is norm_mul.outputs[0] else scale_mul.x
         if other is not norm_mul.outputs[0] and other.val is not None:
             val = np.asarray(other.val)
             if _matches_scale_shape(val, x32.shape):
-                tail_op, scale = scale_mul, val
+                tail_op = scale_mul
+                scale = val if scale is None else scale.astype(np.float64) * val
 
     # Reverse topological order, so `remove_ops` never sees a live consumer.
-    dead = [norm_mul, rsqrt_op, add_op, mean_op, square_op]
+    # The walked ops sit between the rsqrt and the normalize mul.
+    dead = [norm_mul, *reversed(walked), rsqrt_op, add_op, mean_op, square_op]
     if tail_op is not norm_mul:
         dead.insert(0, tail_op)
 
@@ -207,7 +311,7 @@ def _fuse_rmsnorm(block) -> int:
 @register_pass(namespace="common")
 class fuse_rmsnorm(AbstractGraphPass):
     """
-    Fuse the eight-op RMSNorm chain into ``l2_norm`` + a constant ``mul``.
+    Fuse the RMSNorm elementwise chain into ``l2_norm`` + a constant ``mul``.
 
     ``x / sqrt(mean(x^2) + eps)`` equals ``sqrt(d) * l2_norm(x, d * eps)``,
     where ``d`` is the size of the normalized (last) axis, so the reduction and
@@ -216,16 +320,22 @@ class fuse_rmsnorm(AbstractGraphPass):
 
     The rewrite applies when
 
-    1. the reduction is a ``reduce_mean`` with ``keep_dims=True`` over the last
-       axis of a ``mul(x, x)`` square,
-    2. every intermediate value of the chain has exactly one consumer, and
-    3. the input has a static shape with ``rank >= 3`` and
+    1. the reduction is a ``reduce_mean`` over the last axis of a ``mul(x, x)``
+       square (``keep_dims`` either way, as long as it is known at compile time),
+    2. the ``rsqrt`` result reaches the ``mul`` that normalizes ``x`` through at
+       most one ``reshape`` and at most one multiply by a constant scale, and
+       the statistic broadcasts against ``x`` as one value per row,
+    3. every intermediate value of the chain has exactly one consumer -- the
+       normalized input itself is exempt, so a residual path reading ``x``
+       alongside the norm does not block the rewrite, and
+    4. the input has a static shape with ``rank >= 3`` and
        ``shape[-2] == shape[-3] == 1`` -- the shapes for which ``l2_norm``'s
        last-three-dimensions reduction is the last dimension alone. Other
        shapes would need a reshape around the op, which costs more than the
        ops it saves.
 
-    Given:
+    Given (hand-written spelling; flax puts the scale on ``%4`` instead, and
+    equinox reshapes ``%4`` before ``%5``):
         %1 = mul(x=%0, y=%0)
         %2 = reduce_mean(x=%1, axes=[-1], keep_dims=True)
         %3 = add(x=%2, y=1e-6)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -59,7 +59,17 @@ FUSION_PASSES: list[str] = [
 # that is the pass that turns the converter's `reduce_sum -> mul(1/N)` into the
 # `reduce_mean` they match (StableHLO has no mean instruction). That is still
 # before `add_fp16_cast`, so the graph is fp32 there as well.
+#
+# `fuse_reduce_keep_dims` runs a *second* time here (it is also in
+# `CLEANUP_PASSES`). A `jnp.mean(x, axis, keepdims=True)` lowers to
+# `reduce_sum -> mul(1/N) -> reshape`, so in the cleanup slot the reduction is not
+# yet adjacent to its keep-dims reshape and the pass cannot see the pair. Only
+# after `common::fuse_reduce_mean` has folded `reduce_sum -> mul(1/N)` into a
+# single `reduce_mean` does the reshape sit directly on the reduction -- which is
+# exactly the position this group runs in.
 LATE_FUSION_PASSES: list[str] = [
+    "common::fuse_reduce_keep_dims",
+    _DCE,
     "common::fuse_rmsnorm",
     _DCE,
 ]
@@ -82,16 +92,17 @@ def _insert_passes(
     """Insert ``pass_names`` (in order) at the first ``anchor`` pass.
 
     The group goes immediately before ``anchor``, or immediately after it when
-    ``after`` is set. Our own passes are only inserted when they are not in the
-    pipeline yet, so re-inserting into a pipeline that already has them is a
-    no-op. The ``dead_code_elimination`` entries are always inserted along with
-    them: coremltools' default pipeline runs those elsewhere too, but we need
-    them right between our own passes. If ``anchor`` is not part of the
-    pipeline, ``fallback_index`` is used instead (``None`` meaning "append at
-    the end").
+    ``after`` is set. The group is inserted as a whole, ``dead_code_elimination``
+    entries included: coremltools' default pipeline runs those elsewhere too, but
+    we need them right between our own passes. A pass may legitimately appear in
+    more than one group (``fuse_reduce_keep_dims`` runs both in ``CLEANUP_PASSES``
+    and in ``LATE_FUSION_PASSES``), so "already inserted" is decided per group --
+    the group is skipped only when it already occupies the slot next to its
+    anchor, which is what makes re-inserting into a pipeline that already has the
+    groups a no-op. If ``anchor`` is not part of the pipeline, ``fallback_index``
+    is used instead (``None`` meaning "append at the end").
     """
-    to_insert = [name for name in pass_names if name == _DCE or name not in pipeline.passes]
-    if all(name == _DCE for name in to_insert):
+    if len(pass_names) == 0:
         return
 
     if anchor in pipeline.passes:
@@ -101,7 +112,14 @@ def _insert_passes(
     else:
         index = fallback_index
 
-    for offset, pass_name in enumerate(to_insert):
+    if after:
+        occupied = pipeline.passes[index:index + len(pass_names)]
+    else:
+        occupied = pipeline.passes[max(index - len(pass_names), 0):index]
+    if occupied == pass_names:
+        return
+
+    for offset, pass_name in enumerate(pass_names):
         pipeline.insert_pass(index=index + offset, pass_name=pass_name)
 
 

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -15,6 +15,7 @@ from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
 from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
 from . import fuse_logit_softcap as _fuse_logit_softcap  # noqa: F401
 from . import fuse_reduce_keep_dims as _fuse_reduce_keep_dims  # noqa: F401
+from . import fuse_rmsnorm as _fuse_rmsnorm  # noqa: F401
 from . import remove_broadcast_tiles as _remove_broadcast_tiles  # noqa: F401
 from . import remove_noop_slice_update as _remove_noop_slice_update  # noqa: F401
 from . import replace_decomposed_softmax as _replace_decomposed_softmax  # noqa: F401
@@ -54,28 +55,47 @@ FUSION_PASSES: list[str] = [
     _DCE,
 ]
 
+# Late fusion passes. They run right *after* `common::fuse_reduce_mean`, because
+# that is the pass that turns the converter's `reduce_sum -> mul(1/N)` into the
+# `reduce_mean` they match (StableHLO has no mean instruction). That is still
+# before `add_fp16_cast`, so the graph is fp32 there as well.
+LATE_FUSION_PASSES: list[str] = [
+    "common::fuse_rmsnorm",
+    _DCE,
+]
+
 # The pass the CLEANUP group is inserted before (fallback: the front of the pipeline).
 _CLEANUP_ANCHOR = "common::const_elimination"
 # The pass the FUSION group is inserted before (fallback: the end of the pipeline).
 _FUSION_ANCHOR = "common::fuse_matmul_weight_bias"
+# The pass the LATE_FUSION group is inserted after (fallback: the end of the pipeline).
+_LATE_FUSION_ANCHOR = "common::fuse_reduce_mean"
 
 
-def _insert_passes(pipeline: ct.PassPipeline, pass_names: list[str], anchor: str, fallback_index: int | None) -> None:
-    """Insert ``pass_names`` (in order) immediately before the first ``anchor`` pass.
+def _insert_passes(
+    pipeline: ct.PassPipeline,
+    pass_names: list[str],
+    anchor: str,
+    fallback_index: int | None,
+    after: bool = False,
+) -> None:
+    """Insert ``pass_names`` (in order) at the first ``anchor`` pass.
 
-    Our own passes are only inserted when they are not in the pipeline yet, so
-    re-inserting into a pipeline that already has them is a no-op. The
-    ``dead_code_elimination`` entries are always inserted along with them:
-    coremltools' default pipeline runs those elsewhere too, but we need them
-    right between our own passes. If ``anchor`` is not part of the pipeline,
-    ``fallback_index`` is used instead (``None`` meaning "append at the end").
+    The group goes immediately before ``anchor``, or immediately after it when
+    ``after`` is set. Our own passes are only inserted when they are not in the
+    pipeline yet, so re-inserting into a pipeline that already has them is a
+    no-op. The ``dead_code_elimination`` entries are always inserted along with
+    them: coremltools' default pipeline runs those elsewhere too, but we need
+    them right between our own passes. If ``anchor`` is not part of the
+    pipeline, ``fallback_index`` is used instead (``None`` meaning "append at
+    the end").
     """
     to_insert = [name for name in pass_names if name == _DCE or name not in pipeline.passes]
     if all(name == _DCE for name in to_insert):
         return
 
     if anchor in pipeline.passes:
-        index = pipeline.passes.index(anchor)
+        index = pipeline.passes.index(anchor) + (1 if after else 0)
     elif fallback_index is None:
         index = len(pipeline.passes)
     else:
@@ -97,6 +117,7 @@ def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
 
     _insert_passes(pipeline, CLEANUP_PASSES, _CLEANUP_ANCHOR, fallback_index=0)
     _insert_passes(pipeline, FUSION_PASSES, _FUSION_ANCHOR, fallback_index=None)
+    _insert_passes(pipeline, LATE_FUSION_PASSES, _LATE_FUSION_ANCHOR, fallback_index=None, after=True)
 
     return pipeline
 

--- a/tests/passes/test_fuse_rmsnorm.py
+++ b/tests/passes/test_fuse_rmsnorm.py
@@ -1,6 +1,8 @@
 import math
 
 import coremltools as ct
+import equinox as eqx
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -12,6 +14,7 @@ from coremltools.converters.mil.testing_utils import (
     assert_model_is_valid,
     get_op_types_in_program,
 )
+from flax import nnx
 
 from tests.utils import get_model_instruction_types, run_and_compare
 
@@ -20,6 +23,8 @@ DCE_PASS_NAME = "common::dead_code_elimination"
 # `mb.rsqrt`'s own epsilon, folded into the one the `add` contributes.
 RSQRT_EPSILON = 1e-12
 EPSILON = 1e-6
+# The normalized size used by the end-to-end library tests.
+D = 16
 
 
 def _apply(prog):
@@ -178,20 +183,39 @@ class TestFuseRmsNorm:
         _apply(prog)
         assert "l2_norm" not in get_op_types_in_program(prog)
 
-    def test_extra_consumer_of_the_input_is_left_alone(self):
-        """The normalized value must be read by the chain and nothing else.
-
-        Conservative: the rewrite would in fact be safe here (it never removes
-        the op producing the input), but requiring the chain to own its input
-        keeps the match to the shape RMSNorm actually has.
-        """
+    def test_extra_consumer_of_the_input_is_fused(self):
+        """The chain need not own its input: the rewrite never removes the op
+        producing it, and no removed op other than the square and the normalize
+        mul reads it."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
         def prog(x):
             scaled = mb.mul(x=x, y=2.0)
             return _rmsnorm(scaled), mb.add(x=scaled, y=1.0)
 
         _apply(prog)
-        assert "l2_norm" not in get_op_types_in_program(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops.count("l2_norm") == 1
+        assert "rsqrt" not in ops
+        # The extra reader still sees the unchanged input.
+        assert "add" in ops
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_residual_path_reading_the_input_is_fused(self):
+        """`h = x + f(rmsnorm(x))` is the shape every transformer block has. In an
+        fp32 graph no cast insulates `x` from the residual add, so the norm's input
+        has a third reader at every site."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return mb.add(x=x, y=_rmsnorm(x))
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops == ["l2_norm", "mul", "add"]
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
 
     def test_scale_varying_over_a_batch_axis_is_not_absorbed(self):
         """Such a scale cannot become part of the single folded factor, but the
@@ -206,11 +230,121 @@ class TestFuseRmsNorm:
         assert get_op_types_in_program(prog) == ["l2_norm", "mul", "mul"]
         assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
 
-    def test_keep_dims_false_is_left_alone(self):
-        """Without `keep_dims` the `mul` broadcasts differently; not this pattern."""
+    def test_keep_dims_false_is_fused(self):
+        """A squeezed `(1, 1)` statistic left-pads to the keep-dims `(1, 1, 1)`,
+        so it broadcasts exactly like the keep-dims one."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
         def prog(x):
             return _rmsnorm(x, keep_dims=False)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_scale_applied_to_the_rsqrt_is_fused(self):
+        """flax's `_normalize` computes `mul = rsqrt(var + eps); mul *= scale`,
+        so the scale lands *before* the normalize mul."""
+        scale = np.linspace(0.5, 1.5, 16, dtype=np.float32).reshape(1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            inv = mb.mul(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), y=scale)
+            return mb.mul(x=x, y=inv)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        factor = _ops_of_type(prog, "mul")[0].y.val
+        np.testing.assert_allclose(factor, math.sqrt(16) * scale, rtol=1e-6)
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_reshaped_statistic_is_fused(self):
+        """equinox's `jnp.mean(x**2)` reduces to a scalar, so JAX broadcasts the
+        statistic back with a `reshape` between the rsqrt and the normalize mul."""
+        weight = np.linspace(0.5, 1.5, 16, dtype=np.float32).reshape(1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=False)
+            inv = mb.reshape(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), shape=[1, 1, 1])
+            return mb.mul(x=weight, y=mb.mul(x=inv, y=x))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        factor = _ops_of_type(prog, "mul")[0].y.val
+        np.testing.assert_allclose(factor, math.sqrt(16) * weight, rtol=1e-6)
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_scales_on_both_sides_are_folded_into_one_constant(self):
+        pre = np.linspace(0.5, 1.5, 16, dtype=np.float32).reshape(1, 1, 16)
+        post = np.linspace(2.0, 3.0, 16, dtype=np.float32).reshape(1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            inv = mb.mul(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), y=pre)
+            return mb.mul(x=mb.mul(x=x, y=inv), y=post)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        factor = _ops_of_type(prog, "mul")[0].y.val
+        np.testing.assert_allclose(factor, math.sqrt(16) * pre * post, rtol=1e-6)
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_reshape_that_is_not_a_broadcast_partner_is_left_alone(self):
+        """A reshape that permutes a non-unit batch axis makes the statistic
+        broadcast against a different axis than the one that was reduced."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            inv = mb.reshape(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), shape=[1, 2, 1, 1])
+            return mb.mul(x=x, y=inv)
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_pre_scale_varying_over_a_batch_axis_is_left_alone(self):
+        """Unlike a trailing scale, one folded onto the rsqrt cannot be left
+        behind -- the whole chain is skipped instead."""
+        scale = np.linspace(0.5, 1.5, 32, dtype=np.float32).reshape(2, 1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            inv = mb.mul(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), y=scale)
+            return mb.mul(x=x, y=inv)
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_two_reshapes_on_the_walk_are_left_alone(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=False)
+            inv = mb.reshape(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), shape=[1, 1])
+            return mb.mul(x=x, y=mb.reshape(x=inv, shape=[1, 1, 1]))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_two_constant_muls_on_the_walk_are_left_alone(self):
+        first = np.linspace(0.5, 1.5, 16, dtype=np.float32).reshape(1, 1, 16)
+        second = np.linspace(2.0, 3.0, 16, dtype=np.float32).reshape(1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            inv = mb.mul(x=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)), y=first)
+            return mb.mul(x=x, y=mb.mul(x=inv, y=second))
 
         _apply(prog)
         assert "l2_norm" not in get_op_types_in_program(prog)
@@ -222,9 +356,10 @@ class TestFuseRmsNorm:
                 return _rmsnorm(x)
 
             def false_fn():
-                # Not `identity(x)`: another reader of `x` blocks the rewrite
-                # (see `test_extra_consumer_of_the_input_is_left_alone`).
-                return mb.fill(shape=[1, 1, 16], value=1.0)
+                # Also a reader of `x`, from a sibling block -- which no longer
+                # blocks the rewrite (see
+                # `test_extra_consumer_of_the_input_is_fused`).
+                return mb.identity(x=x)
 
             return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
 
@@ -303,3 +438,137 @@ class TestFuseRmsNormEndToEnd:
             rtol=1e-02,
         )
         assert get_model_instruction_types(cml_model).count("l2_norm") == 2
+
+
+
+def _model_ops_of_type(cml_model, op_type):
+    return [
+        op
+        for func in cml_model._mil_program.functions.values()
+        for op in func.operations
+        if op.op_type == op_type
+    ]
+
+
+def _assert_norm_is_fused(cml_model):
+    """The whole statistics chain is gone, replaced by a single `l2_norm`."""
+    ops = get_model_instruction_types(cml_model)
+    assert ops.count("l2_norm") == 1
+    for op_type in ("reduce_mean", "reduce_sum", "rsqrt", "reshape"):
+        assert op_type not in ops, f"unfused RMSNorm leftover: {op_type}"
+
+
+def _assert_norm_is_not_fused(cml_model):
+    ops = get_model_instruction_types(cml_model)
+    assert "l2_norm" not in ops
+    assert ops.count("reduce_mean") == 1
+    assert ops.count("rsqrt") == 1
+
+
+def _flax_rmsnorm(use_scale=True):
+    """A flax RMSNorm with a *non-unit* scale.
+
+    With the default all-ones scale coremltools' `noop_elimination` deletes the
+    scale `mul` before this pass runs, so the reassociation flax actually emits
+    (`mul = rsqrt(var + eps); mul *= scale; y = x * mul`) would never be exercised.
+    """
+    return nnx.RMSNorm(
+        num_features=D,
+        use_scale=use_scale,
+        scale_init=nnx.initializers.normal(),
+        rngs=nnx.Rngs(0),
+    )
+
+
+def _equinox_rmsnorm(shape, use_bias=False):
+    """An equinox RMSNorm with a non-unit weight, vmapped up to ``shape``.
+
+    `eqx.nn.RMSNorm` normalizes a single vector, and its `jnp.mean(x**2)` takes
+    no axis, so it reduces to a scalar and JAX broadcasts the statistic back
+    with a `reshape` placed after the `rsqrt`.
+    """
+    model = eqx.nn.RMSNorm(shape=(D,), use_bias=use_bias)
+    weight = jnp.asarray(np.linspace(0.5, 1.5, D, dtype=np.float32))
+    model = eqx.tree_at(lambda m: m.weight, model, weight)
+
+    fn = eqxi.finalise_fn(eqx.nn.inference_mode(model))
+    for _ in range(len(shape) - 1):
+        fn = jax.vmap(fn)
+    return fn
+
+
+class TestFuseRmsNormLibraryLayers:
+    """End-to-end tests driving the actual flax / equinox RMSNorm layers.
+
+    Each library reassociates the tail of the chain its own way, which is what
+    the forward walk from the `rsqrt` exists to absorb.
+    """
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+    def test_flax_nnx_rmsnorm_is_fused(self, dtype):
+        cml_model = run_and_compare(
+            nnx.jit(_flax_rmsnorm()),
+            [jax.ShapeDtypeStruct((1, 1, D), dtype)],
+            atol=1e-02,
+            rtol=1e-02,
+        )
+        _assert_norm_is_fused(cml_model)
+        # The scale flax folded onto the rsqrt is part of the single constant.
+        factor = _model_ops_of_type(cml_model, "mul")[0].y.val
+        assert factor.shape == (1, 1, D)
+
+    def test_flax_nnx_rmsnorm_without_a_scale_is_fused(self):
+        cml_model = run_and_compare(
+            nnx.jit(_flax_rmsnorm(use_scale=False)),
+            [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
+        )
+        _assert_norm_is_fused(cml_model)
+        assert np.isclose(_model_ops_of_type(cml_model, "mul")[0].y.val, math.sqrt(D))
+
+    def test_equinox_rmsnorm_is_fused(self):
+        cml_model = run_and_compare(
+            _equinox_rmsnorm((1, 1, D)),
+            [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
+        )
+        _assert_norm_is_fused(cml_model)
+        factor = _model_ops_of_type(cml_model, "mul")[0].y.val
+        assert factor.shape == (1, 1, D)
+
+    def test_equinox_rmsnorm_with_a_bias_is_fused(self):
+        """The bias `add` is not absorbed -- it simply stays after the fused norm."""
+        cml_model = run_and_compare(
+            _equinox_rmsnorm((1, 1, D), use_bias=True),
+            [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
+        )
+        _assert_norm_is_fused(cml_model)
+        assert get_model_instruction_types(cml_model).count("add") == 1
+
+    def test_flax_nnx_rmsnorm_off_canonical_shape_is_left_alone(self):
+        cml_model = run_and_compare(
+            nnx.jit(_flax_rmsnorm()),
+            [jax.ShapeDtypeStruct((1, 4, 8, D), jnp.float32)],
+        )
+        _assert_norm_is_not_fused(cml_model)
+
+    def test_equinox_rmsnorm_off_canonical_shape_is_left_alone(self):
+        cml_model = run_and_compare(
+            _equinox_rmsnorm((1, 8, D)),
+            [jax.ShapeDtypeStruct((1, 8, D), jnp.float32)],
+        )
+        _assert_norm_is_not_fused(cml_model)
+
+    def test_flax_rmsnorm_on_a_residual_path_is_fused(self):
+        """The shape a transformer block actually has. In an fp32 graph there is
+        no cast between the block input and the residual `add`, so the norm's
+        input has a reader outside the chain at every site."""
+        norm = _flax_rmsnorm()
+        linear = nnx.Linear(in_features=D, out_features=D, rngs=nnx.Rngs(1))
+
+        cml_model = run_and_compare(
+            nnx.jit(lambda x: x + linear(norm(x))),
+            [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("l2_norm") == 1
+        for op_type in ("reduce_mean", "reduce_sum", "rsqrt"):
+            assert op_type not in ops, f"unfused RMSNorm leftover: {op_type}"

--- a/tests/passes/test_fuse_rmsnorm.py
+++ b/tests/passes/test_fuse_rmsnorm.py
@@ -1,0 +1,305 @@
+import math
+
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from tests.utils import get_model_instruction_types, run_and_compare
+
+PASS_NAME = "common::fuse_rmsnorm"
+DCE_PASS_NAME = "common::dead_code_elimination"
+# `mb.rsqrt`'s own epsilon, folded into the one the `add` contributes.
+RSQRT_EPSILON = 1e-12
+EPSILON = 1e-6
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME)
+    # The pass removes the chain itself, but leaves its constants behind.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
+
+
+def _rmsnorm(x, scale=None, axes=(-1,), keep_dims=True, epsilon=EPSILON):
+    """Build `x * rsqrt(mean(x*x, axes) + epsilon) * scale` in the current block."""
+    variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=list(axes), keep_dims=keep_dims)
+    normalized = mb.mul(x=x, y=mb.rsqrt(x=mb.add(x=variance, y=epsilon)))
+    if scale is None:
+        return normalized
+    return mb.mul(x=normalized, y=scale)
+
+
+def _ops_of_type(prog, op_type):
+    return [op for op in prog.functions["main"].operations if op.op_type == op_type]
+
+
+def _expected_epsilon(d, epsilon=EPSILON):
+    """`l2_norm` sums the squares where the chain averaged them, so eps' = d * eps."""
+    return d * (epsilon + RSQRT_EPSILON)
+
+
+class TestFuseRmsNorm:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_chain_with_a_constant_scale_is_fused(self):
+        scale = np.linspace(0.5, 1.5, 16, dtype=np.float32).reshape(1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, scale)
+
+        assert get_op_types_in_program(prog) == ["mul", "reduce_mean", "add", "rsqrt", "mul", "mul"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+
+        l2_norm = _ops_of_type(prog, "l2_norm")[0]
+        assert np.isclose(l2_norm.epsilon.val, _expected_epsilon(16))
+        # The `sqrt(d)` of the identity is folded into the scale constant.
+        factor = _ops_of_type(prog, "mul")[0].y.val
+        np.testing.assert_allclose(factor, math.sqrt(16) * scale, rtol=1e-6)
+        assert_model_is_valid(
+            prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_chain_without_a_scale_is_fused(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+
+    def test_batch_dimensions_are_fused(self):
+        """`l2_norm` treats everything before the last three dims as batch."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 2, 1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+
+    def test_scalar_scale_is_absorbed(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, np.float32(2.0))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
+        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, 2.0 * math.sqrt(16))
+
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 16), (1, 8, 16), (4, 16)])
+    def test_off_canonical_shape_is_left_alone(self, shape):
+        """`l2_norm` reduces the last three dims, so anything but `(..., 1, 1, d)`
+        would need a reshape around the op -- more ops than the rewrite saves."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=shape)])
+        def prog(x):
+            return _rmsnorm(x)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert "l2_norm" not in ops
+        assert ops.count("reduce_mean") == 1
+        assert ops.count("rsqrt") == 1
+
+    def test_reduction_over_another_axis_is_left_alone(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, axes=(0,))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_reduction_over_several_axes_is_left_alone(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, axes=(1, 2))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_reduce_sum_is_left_alone(self):
+        """Only the mean form is the identity below; a plain sum is not."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_sum(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            return mb.mul(x=x, y=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_squares_of_different_vars_are_left_alone(self):
+        """`mul(x, y)` is not `x**2`, so the reduction is not the RMS of `x`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16)), mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x, y):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=y), axes=[-1], keep_dims=True)
+            return mb.mul(x=x, y=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_normalizing_another_var_is_left_alone(self):
+        """The statistics and the value being scaled must be the same tensor."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16)), mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x, y):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            return mb.mul(x=y, y=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_non_uniform_epsilon_is_left_alone(self):
+        """A per-element shift is not an epsilon and does not fold into `l2_norm`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            shift = np.linspace(1e-6, 1e-3, 16, dtype=np.float32).reshape(1, 1, 16)
+            return mb.mul(x=x, y=mb.rsqrt(x=mb.add(x=variance, y=shift)))
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_shared_variance_is_left_alone(self):
+        """The chain may not be rewritten while another consumer observes it."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            variance = mb.reduce_mean(x=mb.mul(x=x, y=x), axes=[-1], keep_dims=True)
+            normalized = mb.mul(x=x, y=mb.rsqrt(x=mb.add(x=variance, y=EPSILON)))
+            return normalized, variance
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_extra_consumer_of_the_input_is_left_alone(self):
+        """The normalized value must be read by the chain and nothing else.
+
+        Conservative: the rewrite would in fact be safe here (it never removes
+        the op producing the input), but requiring the chain to own its input
+        keeps the match to the shape RMSNorm actually has.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            scaled = mb.mul(x=x, y=2.0)
+            return _rmsnorm(scaled), mb.add(x=scaled, y=1.0)
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_scale_varying_over_a_batch_axis_is_not_absorbed(self):
+        """Such a scale cannot become part of the single folded factor, but the
+        chain around it still fuses."""
+        scale = np.linspace(0.5, 1.5, 32, dtype=np.float32).reshape(2, 1, 1, 16)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, scale)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["l2_norm", "mul", "mul"]
+        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+
+    def test_keep_dims_false_is_left_alone(self):
+        """Without `keep_dims` the `mul` broadcasts differently; not this pattern."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x, keep_dims=False)
+
+        _apply(prog)
+        assert "l2_norm" not in get_op_types_in_program(prog)
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                return _rmsnorm(x)
+
+            def false_fn():
+                # Not `identity(x)`: another reader of `x` blocks the rewrite
+                # (see `test_extra_consumer_of_the_input_is_left_alone`).
+                return mb.fill(shape=[1, 1, 16], value=1.0)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog, recurse=True)
+        assert "l2_norm" in ops
+        assert "rsqrt" not in ops
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 16))])
+        def prog(x):
+            return _rmsnorm(x)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+def _jax_rmsnorm(x, scale=None, epsilon=EPSILON):
+    """RMSNorm as a decoder writes it: fp32 statistics over an fp16 activation."""
+    x32 = x.astype(jnp.float32)
+    normalized = x32 * jax.lax.rsqrt(jnp.mean(jnp.square(x32), axis=-1, keepdims=True) + epsilon)
+    if scale is not None:
+        normalized = normalized * scale.astype(jnp.float32)
+    return normalized.astype(x.dtype)
+
+
+class TestFuseRmsNormEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_rmsnorm_fuses_to_l2_norm(self):
+        """`(1, 1, D)` needs no reshape: for that shape `l2_norm`'s last-three-dims
+        reduction is exactly the last one."""
+        scale = jnp.asarray(np.full((16,), 0.5, np.float16))
+
+        cml_model = run_and_compare(
+            lambda x: _jax_rmsnorm(x, scale),
+            [jax.ShapeDtypeStruct((1, 1, 16), jnp.float16)],
+            atol=1e-02,
+            rtol=1e-02,
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("l2_norm") == 1
+        for op_type in ("reduce_mean", "reduce_sum", "rsqrt", "reshape"):
+            assert op_type not in ops, f"unfused RMSNorm leftover: {op_type}"
+        # cast(fp32) -> l2_norm -> mul(sqrt(d) * scale) -> cast(fp16), nothing else.
+        assert [op for op in ops if op != "const"] == ["cast", "l2_norm", "mul", "cast"]
+
+    def test_epsilon_is_scaled_by_the_normalized_size(self):
+        """`l2_norm` sums the squares where the chain averaged them."""
+        cml_model = run_and_compare(
+            _jax_rmsnorm, [jax.ShapeDtypeStruct((1, 1, 64), jnp.float32)]
+        )
+        mil_program = cml_model._mil_program
+        l2_norm = next(
+            op for op in mil_program.functions["main"].operations if op.op_type == "l2_norm"
+        )
+        assert np.isclose(l2_norm.epsilon.val, 64 * EPSILON, rtol=1e-5)
+
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 16), (1, 8, 16)])
+    def test_off_canonical_shape_is_left_alone(self, shape):
+        cml_model = run_and_compare(_jax_rmsnorm, [jax.ShapeDtypeStruct(shape, jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert "l2_norm" not in ops
+        assert ops.count("reduce_mean") == 1
+        assert ops.count("rsqrt") == 1
+
+    def test_adjacent_rmsnorms_are_both_fused(self):
+        scale = jnp.asarray(np.full((16,), 0.5, np.float16))
+
+        cml_model = run_and_compare(
+            lambda x: _jax_rmsnorm(_jax_rmsnorm(x, scale), scale),
+            [jax.ShapeDtypeStruct((1, 1, 16), jnp.float16)],
+            atol=1e-02,
+            rtol=1e-02,
+        )
+        assert get_model_instruction_types(cml_model).count("l2_norm") == 2

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -2,13 +2,18 @@ import coremltools as ct
 import pytest
 
 from stablehlo_coreml import build_pass_pipeline
-from stablehlo_coreml.passes.utils import CLEANUP_PASSES, DEFAULT_HLO_PIPELINE, FUSION_PASSES
+from stablehlo_coreml.passes.utils import (
+    CLEANUP_PASSES,
+    DEFAULT_HLO_PIPELINE,
+    FUSION_PASSES,
+    LATE_FUSION_PASSES,
+)
 
 DCE_PASS_NAME = "common::dead_code_elimination"
 # The groups interleave coremltools' DCE with our own passes, so the same name
 # appears several times; only our own passes are expected in the pipeline exactly
 # once.
-ALL_PASSES = list(dict.fromkeys(CLEANUP_PASSES + FUSION_PASSES))
+ALL_PASSES = list(dict.fromkeys(CLEANUP_PASSES + FUSION_PASSES + LATE_FUSION_PASSES))
 OUR_PASSES = [name for name in ALL_PASSES if name != DCE_PASS_NAME]
 
 
@@ -33,6 +38,13 @@ def test_fusion_passes_run_before_fuse_matmul_weight_bias():
     passes = build_pass_pipeline().passes
     anchor = passes.index("common::fuse_matmul_weight_bias")
     assert passes[anchor - len(FUSION_PASSES):anchor] == FUSION_PASSES
+
+
+def test_late_fusion_passes_run_after_fuse_reduce_mean():
+    """`fuse_rmsnorm` needs the `reduce_mean` that coremltools' pass creates."""
+    passes = build_pass_pipeline().passes
+    anchor = passes.index("common::fuse_reduce_mean") + 1
+    assert passes[anchor:anchor + len(LATE_FUSION_PASSES)] == LATE_FUSION_PASSES
 
 
 def test_build_pass_pipeline_returns_distinct_objects():
@@ -67,7 +79,10 @@ def test_build_pass_pipeline_with_base_missing_the_anchors():
 
     pipeline = build_pass_pipeline(base)
     assert pipeline.passes == (
-        CLEANUP_PASSES + ["common::noop_elimination", DCE_PASS_NAME] + FUSION_PASSES
+        CLEANUP_PASSES
+        + ["common::noop_elimination", DCE_PASS_NAME]
+        + FUSION_PASSES
+        + LATE_FUSION_PASSES
     )
 
 

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import coremltools as ct
 import pytest
 
@@ -15,6 +17,12 @@ DCE_PASS_NAME = "common::dead_code_elimination"
 # once.
 ALL_PASSES = list(dict.fromkeys(CLEANUP_PASSES + FUSION_PASSES + LATE_FUSION_PASSES))
 OUR_PASSES = [name for name in ALL_PASSES if name != DCE_PASS_NAME]
+# Most of our passes run once, but a pass may belong to more than one group:
+# `fuse_reduce_keep_dims` runs in the cleanup slot and again in the late-fusion
+# slot, where `fuse_reduce_mean` has just made new reduce/reshape pairs visible.
+EXPECTED_PASS_COUNTS = Counter(
+    name for name in CLEANUP_PASSES + FUSION_PASSES + LATE_FUSION_PASSES if name != DCE_PASS_NAME
+)
 
 
 @pytest.mark.parametrize("pass_name", ALL_PASSES)
@@ -24,8 +32,18 @@ def test_pass_is_registered(pass_name):
 
 
 @pytest.mark.parametrize("pass_name", OUR_PASSES)
-def test_default_pipeline_contains_each_pass_exactly_once(pass_name):
-    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == 1
+def test_default_pipeline_contains_each_pass_once_per_group(pass_name):
+    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == EXPECTED_PASS_COUNTS[pass_name]
+
+
+def test_fuse_reduce_keep_dims_runs_again_in_the_late_fusion_group():
+    """The keep-dims reshape only becomes adjacent to its reduction once
+    `fuse_reduce_mean` has folded `reduce_sum -> mul(1/N)` into one op."""
+    passes = build_pass_pipeline().passes
+    occurrences = [i for i, name in enumerate(passes) if name == "common::fuse_reduce_keep_dims"]
+    assert len(occurrences) == 2
+    assert occurrences[0] < passes.index("common::fuse_reduce_mean") < occurrences[1]
+    assert occurrences[1] < passes.index("common::fuse_rmsnorm")
 
 
 def test_cleanup_passes_run_before_first_const_elimination():
@@ -92,3 +110,21 @@ def test_build_pass_pipeline_preserves_pass_options():
 
     pipeline = build_pass_pipeline(base)
     assert "common::const_elimination" in pipeline._pass_options
+
+
+def test_group_is_inserted_even_when_the_base_already_has_one_of_its_passes():
+    """Insertion is decided per group, not per pass.
+
+    A pass may belong to two groups (`fuse_reduce_keep_dims`), so "already in the
+    pipeline" cannot mean "skip it". The group is skipped only when it already
+    occupies the slot next to its anchor -- which is what keeps
+    `build_pass_pipeline` idempotent. A stray copy elsewhere in the base is
+    therefore left where it is and the group is inserted anyway; our passes are
+    idempotent, so the duplicate is harmless.
+    """
+    base = ct.PassPipeline.EMPTY
+    base.passes = ["common::fuse_reduce_keep_dims", "common::const_elimination"]
+
+    passes = build_pass_pipeline(base).passes
+    assert passes[: len(CLEANUP_PASSES) + 1] == ["common::fuse_reduce_keep_dims"] + CLEANUP_PASSES
+    assert passes.count("common::fuse_reduce_keep_dims") == 3


### PR DESCRIPTION
Adds `common::fuse_rmsnorm`: rewrites the RMSNorm elementwise chain into `l2_norm` + one constant `mul`, using the exact identity `x/sqrt(mean(x²)+ε) = √d · l2_norm(x, ε′=dε)` with `√d·scale` folded into a single constant. Only canonical shapes fuse (`l2_norm` reduces the last three dims); a reshape-based variant for off-canonical sites was measured to cost more than it saves and is deliberately excluded (rationale in the module docstring). `layer_norm` cannot express this — every pattern in coremltools' `fuse_layernorm_or_instancenorm` starts `x -> reduce_mean -> sub`, and RMSNorm has no mean subtraction.

Registration: a new `LATE_FUSION_PASSES` group inserted immediately **after** `common::fuse_reduce_mean` — that coremltools pass is what creates the `reduce_mean` this pattern matches (verified by dumping MIL at both candidate cut points; anchoring in `FUSION_PASSES` would make the pass a no-op). `_insert_passes` gains an `after` flag.

Ported from kasper0406/gemma-coreml-chat where it cut a 35-layer decode graph by ~17% ops (measured perf-neutral on GPU — Core ML attributes ~95% of decode cost to matmuls — but it shrinks graphs and ANE compile time, which scales with op count).

## Second commit: match the spellings the libraries actually emit

Review caught that the first commit fused only the hand-written spelling its own tests used. Driving the real layers through the converter, **both** library layers this repo already tests against came out completely unfused, at 6–7 ops each.

`flax.nnx.RMSNorm` on `(1, 1, 16)` fp32 reached the final MIL as:

```
%mul_0     : (1,1,16) = mul(x=%x, y=%x)
%reduce    : (1,1)    = reduce_mean(x=%mul_0, axes=[2], keep_dims=False)
%reshape_6 : (1,1,1)  = reshape(x=%reduce, shape=[1,1,1])
%add_0     : (1,1,1)  = add(x=%reshape_6, y=1e-6)
%rsqrt_0   : (1,1,1)  = rsqrt(x=%add_0)
%mul_1     : (1,1,16) = mul(x=%rsqrt_0, y=<const scale>)
%mul_2     : (1,1,16) = mul(x=%x, y=%mul_1)
```

`equinox.nn.RMSNorm(shape=(16,))` double-vmapped to `(1, 1, 16)`:

```
%mul_0     : (1,1,16) = mul(x=%x, y=%x)
%reduce    : (1,1)    = reduce_mean(x=%mul_0, axes=[2], keep_dims=False)
%add_0     : (1,1)    = add(x=%reduce, y=1e-5)
%rsqrt_0   : (1,1)    = rsqrt(x=%add_0)
%reshape_5 : (1,1,1)  = reshape(x=%rsqrt_0, shape=[1,1,1])
%mul_1     : (1,1,16) = mul(x=%reshape_5, y=%x)
%mul_2     : (1,1,16) = mul(x=<const weight>, y=%mul_1)
```

Four blockers, each fixed:

**1. `fuse_reduce_keep_dims` never saw flax's keep-dims reshape.** flax writes `x.mean(axes)` and *then* `var.reshape(stats_shape)`, so HLO is `reduce_sum -> mul(1/N) -> reshape` — the reduction is not adjacent to the reshape. It only becomes adjacent once `common::fuse_reduce_mean` folds the `reduce_sum -> mul` pair, long after the `CLEANUP_PASSES` slot the pass runs in. It now runs a second time at the front of `LATE_FUSION_PASSES`, which is anchored exactly there.

**2. `_insert_passes` would have silently dropped that second run.** Its dedup filter was per-pass (`name not in pipeline.passes`), so the pipeline change alone was a no-op. "Already inserted" is now decided **per group**: a group is skipped only when it already occupies the slot next to its anchor, which is what keeps `build_pass_pipeline` idempotent. Behaviour change worth noting: a stray copy of one of our passes elsewhere in a caller's base pipeline no longer suppresses the whole group. Our passes are idempotent so the duplicate is harmless, and there's now a test pinning this.

**3. Both libraries reassociate the tail, differently.** flax's `_normalize` computes `mul = rsqrt(var+eps); mul *= scale; y = x * mul` — the scale lands on the *rsqrt* result. equinox's `jnp.mean(x**2)` takes no axis, so it reduces to a scalar and JAX broadcasts the statistic back with a `reshape` between the `rsqrt` and the normalize `mul`. The rigid `sole_consumer(rsqrt) == mul(x32, rsqrt)` check matched neither. Replaced by a bounded forward walk tolerating, in any order, at most one `reshape` and at most one multiply by a constant scale before the normalize `mul`. Scales on either side (or both) fold into one constant, `sqrt(d) * pre * post`.

That also lets `keep_dims` be either way. The property that actually has to hold belongs to the statistic where it broadcasts against `x`, not to the reduction: left-pad its shape to `x`'s rank; the leading entries must equal `x.shape[:-1]`, the last must be 1 or the full width (`_is_broadcast_partner`). A squeezed `(1,1)` statistic left-pads to `(1,1,1)` — exactly the keep-dims shape. Conversely a reshape that permutes a non-unit axis always changes the shape tuple in a way this rejects, so the walk never has to reason about reshape orderings.

**4. The chain no longer has to own its input.** `x32.child_ops` had to be exactly the square and the normalize mul. That guard was never needed for correctness — the rewrite does not remove the op producing the input, and no op it does remove other than those two reads it — and it declined every RMSNorm on a residual path (`h = x + f(rmsnorm(x))`) in an fp32 graph, where no cast insulates the input from the residual add. That is every site in a transformer block, so the pass was close to inert on fp32 decoders.

Both layers now come out as `l2_norm -> mul`, and a flax norm inside a residual block fuses with the residual `add` left untouched. Off-canonical shapes are still left alone for both.

## Tests

Unit cases for each spelling (flax pre-scale, equinox reshaped statistic, `keep_dims=False` with no reshape, scales on both sides) with the folded constant asserted; negatives for a reshape that is not a valid broadcast partner, a pre-scale varying over a batch axis, and two reshapes / two constant muls on the walk.

Two existing tests asserted the opposite of the new behaviour and are **inverted rather than deleted** — `test_keep_dims_false_is_left_alone` and `test_extra_consumer_of_the_input_is_left_alone` — joined by a residual-path case.

New `TestFuseRmsNormLibraryLayers` drives the real layers end to end: flax at fp32 and fp16 with a non-unit scale (with the default all-ones scale, `noop_elimination` deletes the scale mul before this pass runs and the reassociation would not be exercised at all), flax without a scale, equinox with and without a bias, a flax residual block, and off-canonical shapes for both.

`test_pass_pipeline.py` gains the second-run placement test and one pinning the new per-group insertion semantics.

Full suite: **470 passed**; `hatch -e lint run check` clean. Rebased onto current `main` (#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
