### PR TITLE
Scale the logit-softcap tolerance with the operand dtype

### DIFF
--- a/stablehlo_coreml/passes/fuse_logit_softcap.py
+++ b/stablehlo_coreml/passes/fuse_logit_softcap.py
@@ -30,15 +30,37 @@ from .pattern_utils import sole_consumer, uniform_const_operand
 
 logger = logging.getLogger(__name__)
 
-# Absolute tolerance on `alpha * beta == 1`.
+# Absolute tolerance on `alpha * beta == 1`, for constants that carry full fp32
+# precision. It is a lower bound only: `_tolerance` widens it for narrower
+# element types, where `1 / cap` cannot be represented anywhere near this well.
 _TOLERANCE = 1e-4
+# How many ulps of the operand type the product may be away from 1. Both `alpha`
+# and `beta` are rounded to that type, and JAX already evaluates `1 / cap` in it,
+# so the product drifts by a small multiple of the type's epsilon.
+_TOLERANCE_ULPS = 4.0
+
+
+def _dtype_epsilon(var) -> float:
+    """Machine epsilon of ``var``'s element type (``0.0`` if it is not a float)."""
+    if var is None:
+        return 0.0
+    dtype = getattr(var, "dtype", None)
+    if dtype is None or not types.is_float(dtype):
+        return 0.0
+    return float(np.finfo(types.nptype_from_builtin(dtype)).eps)
+
+
+def _tolerance(*vars_) -> float:
+    """Tolerance on ``alpha * beta == 1`` for constants stored in these vars' types."""
+    epsilon = max((_dtype_epsilon(var) for var in vars_), default=0.0)
+    return max(_TOLERANCE, _TOLERANCE_ULPS * epsilon)
 
 
 def _scalar_operand(op):
     """Like :func:`uniform_const_operand`, but only for single-element constants.
 
-    Returns ``(const_value, other_var)``, or ``None`` when no operand is a
-    uniform compile-time constant or when that constant is not rank-0/1 (a
+    Returns ``(const_value, other_var, const_var)``, or ``None`` when no operand
+    is a uniform compile-time constant or when that constant is not rank-0/1 (a
     constant with a real shape would broadcast the output, which ``scaled_tanh``
     cannot do).
     """
@@ -49,33 +71,38 @@ def _scalar_operand(op):
     const = op.y if op.x is other else op.x
     if const.shape is not None and int(np.prod(const.shape)) != 1:
         return None
-    return value, other
+    return value, other, const
 
 
 def _inner_scale(tanh_op):
-    """Return ``(x, beta)`` for ``tanh(x * beta)``, peeling a ``mul``/``real_div`` by a constant."""
+    """Return ``(x, beta, beta_const)`` for ``tanh(x * beta)``.
+
+    A ``mul``/``real_div`` by a compile-time constant is peeled off the ``tanh``
+    argument; ``beta_const`` is the ``Var`` holding that constant, or ``None``
+    when nothing was peeled (``beta == 1``).
+    """
     inner = tanh_op.x.op
     if inner is None or inner.enclosing_block is not tanh_op.enclosing_block:
-        return tanh_op.x, 1.0
+        return tanh_op.x, 1.0, None
     if sole_consumer(tanh_op.x) is not tanh_op:
         # The scaled value is used elsewhere, so removing the scaling op would
         # not pay off (and it has to stay in the graph anyway).
-        return tanh_op.x, 1.0
+        return tanh_op.x, 1.0, None
 
     if inner.op_type == "mul":
         scalar = _scalar_operand(inner)
         if scalar is not None:
-            beta, operand = scalar
-            return operand, beta
-        return tanh_op.x, 1.0
+            beta, operand, const = scalar
+            return operand, beta, const
+        return tanh_op.x, 1.0, None
 
     if inner.op_type == "real_div":
         # Only `x / c` is a scaling; `c / x` is not.
         scalar = _scalar_operand(inner)
         if scalar is not None and scalar[1] is inner.x and scalar[0] != 0.0:
-            return inner.x, 1.0 / scalar[0]
+            return inner.x, 1.0 / scalar[0], scalar[2]
 
-    return tanh_op.x, 1.0
+    return tanh_op.x, 1.0, None
 
 
 def _match(mul_op, block):
@@ -96,10 +123,10 @@ def _match(mul_op, block):
         scalar = _scalar_operand(mul_op)
         if scalar is None or scalar[1] is not tanh_var:
             continue
-        alpha = scalar[0]
+        alpha, _, alpha_const = scalar
 
-        x, beta = _inner_scale(tanh_op)
-        if abs(alpha * beta - 1.0) > _TOLERANCE:
+        x, beta, beta_const = _inner_scale(tanh_op)
+        if abs(alpha * beta - 1.0) > _tolerance(x, alpha_const, beta_const):
             continue
 
         return x, alpha, beta
@@ -149,6 +176,11 @@ class fuse_logit_softcap(AbstractGraphPass):
     scaling may be written as ``mul(x, beta)`` or ``real_div(x, 1/beta)``.
     The scaling constants must be uniform, single-element, compile-time
     constants, and the ``tanh`` output must have exactly one consumer.
+
+    ``alpha * beta == 1`` is checked with a tolerance that grows with the
+    element type of the operands: for an fp16 model ``1 / cap`` is rounded to
+    fp16 before it ever reaches MIL, so the product is only unity to within a
+    few fp16 ulps (``30.0 * fp16(1/30) == 0.99976``).
 
     Given:
         %1 = real_div(x=%0, y=30.0)

--- a/tests/passes/test_fuse_logit_softcap.py
+++ b/tests/passes/test_fuse_logit_softcap.py
@@ -2,6 +2,7 @@ import coremltools as ct
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import (
@@ -74,6 +75,49 @@ class TestFuseLogitSoftcap:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+    @pytest.mark.parametrize("cap", [30.0, 50.0])
+    def test_fp16_reciprocal_rounding_is_still_fused(self, cap):
+        """``1 / cap`` is rounded to fp16 long before MIL sees it.
+
+        ``fp16(1/30) * 30 == 0.99976``, which is 2.4e-4 away from unity -- more
+        than the fp32 tolerance allows, but well inside one fp16 ulp.
+        """
+        beta = np.float16(1.0) / np.float16(cap)
+        assert abs(float(beta) * cap - 1.0) > 1e-4
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8), dtype=types.fp16)])
+        def prog(x):
+            scaled = mb.mul(x=x, y=beta)
+            return mb.mul(x=mb.tanh(x=scaled), y=np.float16(cap))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+        fused = _scaled_tanh_ops(prog)[0]
+        assert fused.alpha.val.dtype == np.float16
+        assert np.isclose(fused.alpha.val, cap)
+        assert fused.beta.val == beta
+
+    def test_fp32_keeps_the_tight_tolerance(self):
+        """The widened tolerance is fp16-only; fp32 constants stay tightly checked."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
+        def prog(x):
+            scaled = mb.mul(x=x, y=np.float32(1.0 / 30.0))
+            # 5e-4 off unity: representable in fp32, so not a rounding artifact.
+            return mb.mul(x=mb.tanh(x=scaled), y=np.float32(30.0 * 1.0005))
+
+        _apply(prog)
+        assert "scaled_tanh" not in get_op_types_in_program(prog)
+
+    def test_not_fused_in_fp16_when_the_product_is_far_from_one(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8), dtype=types.fp16)])
+        def prog(x):
+            scaled = mb.mul(x=x, y=np.float16(1.0 / 30.0))
+            return mb.mul(x=mb.tanh(x=scaled), y=np.float16(20.0))
+
+        _apply(prog)
+        assert "scaled_tanh" not in get_op_types_in_program(prog)
 
     def test_not_fused_when_product_is_not_one(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
@@ -181,3 +225,53 @@ class TestFuseLogitSoftcapEndToEnd:
         ops = get_model_instruction_types(cml_model)
         assert "scaled_tanh" not in ops
         assert ops.count("tanh") == 1
+
+    @pytest.mark.parametrize("cap", [30.0, 50.0])
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            pytest.param(lambda x, cap: cap * jnp.tanh(x / cap), id="cap_times_tanh_of_div"),
+            pytest.param(lambda x, cap: jnp.tanh(x / cap) * cap, id="tanh_of_div_times_cap"),
+            pytest.param(lambda x, cap: cap * jnp.tanh(x * (1.0 / cap)), id="cap_times_tanh_of_mul"),
+            pytest.param(
+                lambda x, cap: jnp.asarray(cap, x.dtype) * jnp.tanh(x / jnp.asarray(cap, x.dtype)),
+                id="cap_as_traced_array",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+    def test_gemma_style_softcap_spellings(self, spelling, cap, dtype):
+        """Every way Gemma-2 writes ``cap * tanh(logits / cap)`` must fuse.
+
+        The fp16 cases matter: JAX folds ``1 / cap`` in the operand dtype, so
+        ``alpha * beta`` only reaches unity to within an fp16 ulp.
+        """
+        precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
+        cml_model = run_and_compare(
+            lambda x: spelling(x, cap),
+            [jax.ShapeDtypeStruct((4, 16), dtype)],
+            atol=1e-04 * precision_loss,
+            rtol=1e-05 * precision_loss,
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_tanh") == 1
+        assert "tanh" not in ops
+
+    def test_attention_logit_softcap(self):
+        """Gemma-2 softcaps the attention logits, right before the softmax."""
+        def f(query, key):
+            logits = jnp.einsum("qd,kd->qk", query, key)
+            logits = 50.0 * jnp.tanh(logits / 50.0)
+            return jax.nn.softmax(logits, axis=-1)
+
+        cml_model = run_and_compare(
+            f,
+            [
+                jax.ShapeDtypeStruct((6, 4), jnp.float32),
+                jax.ShapeDtypeStruct((6, 4), jnp.float32),
+            ],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_tanh") == 1
+        assert ops.count("softmax") == 1
+        assert "tanh" not in ops


### PR DESCRIPTION
## Problem

`fuse_logit_softcap` fuses `alpha * tanh(beta * x)` into `scaled_tanh` only when `alpha * beta` is within `1e-4` of 1. In fp32 that gate is comfortable, but **no fp16 softcap has ever fused**, including both of the caps Gemma-2 actually uses.

Auditing the pass against the real spellings (converting through the real converter + `DEFAULT_HLO_PIPELINE` and reading the resulting MIL):

| spelling | fp32 | fp16 |
| --- | --- | --- |
| `cap * jnp.tanh(x / cap)` | fused | **not fused** |
| `jnp.tanh(x / cap) * cap` | fused | **not fused** |
| `cap * jnp.tanh(x * (1/cap))` | fused | **not fused** |
| cap as a traced `jnp` scalar | fused | **not fused** |

## Root cause

JAX constant-folds `1 / cap` **in the operand dtype**, so what reaches MIL is already rounded to fp16. The converted program for `50.0 * jnp.tanh(x / 50.0)` on an fp16 input:

```
main[CoreML8](%x: (4, 16, fp16)(Tensor)) {
  block30() {
    %_inversed_real_div_0: (4, 16, fp16)(Tensor) = mul(x=%x, y=[[0.0200042724609375]], name="_inversed_real_div_0")
    %tanh_0: (4, 16, fp16)(Tensor) = tanh(x=%_inversed_real_div_0, name="tanh_0")
    %mul_0: (4, 16, fp16)(Tensor) = mul(x=[[50.0]], y=%tanh_0, name="mul_0")
  } -> (%mul_0)
}
```

`50 * 0.0200042724609375 == 1.000213623046875`, i.e. `2.1e-4` off unity — about a quarter of one fp16 ulp (`eps(fp16) == 9.8e-4`), but more than twice the `1e-4` absolute tolerance. Narrowed to a hand-built MIL program and confirmed by applying the pass directly:

```
cap=30.0: beta(fp16)=0.0333251953125 alpha*beta-1=-2.441e-04  ->  ['mul', 'tanh', 'mul']
cap=50.0: beta(fp16)=0.0200042724609375 alpha*beta-1=2.136e-04  ->  ['mul', 'tanh', 'mul']
```

So the fp32 spelling of a model fused and the fp16 spelling of the exact same model did not — the wrong way round, since the fp16 model is the one that ships.

## Fix

The tolerance is derived from the element type of the operands instead of being a fixed absolute number: it stays at `1e-4` when full fp32 precision is available, and otherwise widens to four ulps of the narrowest type involved (the `x` being capped, and the two scaling constants). Four ulps covers the rounding of `alpha`, of `beta`, and of the reciprocal JAX evaluated to produce `beta`, with margin — while staying far too tight to admit a scaling that is not a softcap (at fp16 it accepts products within 0.4% of one).

Mechanically this required threading the constant `Var`s out of `_scalar_operand` / `_inner_scale`; the values themselves were already widened to Python floats, which is exactly what hid the dtype.

Note this loosening cannot change numerics: `scaled_tanh(x, alpha, beta)` reproduces `alpha * tanh(beta * x)` with the very same `alpha`/`beta`, stored in the very same dtype. The gate only decides whether the rewrite is recognisably a softcap.

## Tests

Hand-built MIL unit tests:
- `test_fp16_reciprocal_rounding_is_still_fused[30.0/50.0]` — asserts the product really is outside the old `1e-4` gate, then that the fuse happens and `alpha`/`beta` come out as fp16.
- `test_fp32_keeps_the_tight_tolerance` — an fp32 product `5e-4` off unity is still rejected, so the widening is fp16-only.
- `test_not_fused_in_fp16_when_the_product_is_far_from_one` — `20 * tanh(x/30)` in fp16 stays rejected.

End-to-end through the real converter (these are the library-coverage tests the suite was missing — it previously exercised a single spelling):
- `test_gemma_style_softcap_spellings` — 4 Gemma-2 spellings x 2 caps x {fp32, fp16} = 16 cases.
- `test_attention_logit_softcap` — softcap on einsum attention logits feeding a softmax; asserts `scaled_tanh` and `softmax` both fire.

## Verification

`tests/passes` — 221 passed. `ruff check .` — clean. All 10 softcap spellings I audited now fire; before the change the 2 fp16 ones did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E
