### PR TITLE
Stop remove_noop_slice_update from aborting the conversion

### DIFF
--- a/stablehlo_coreml/passes/remove_noop_slice_update.py
+++ b/stablehlo_coreml/passes/remove_noop_slice_update.py
@@ -1,4 +1,15 @@
+"""MIL pass: drop ``slice_update`` ops that overwrite the whole destination tensor.
+
+The converter builds several results by allocating a buffer and writing into it
+with ``slice_update`` (``op_dynamic_update_slice``, and the accumulator loops in
+``reductions.py`` / ``DotGeneralOp``). When the written slice happens to cover
+the entire buffer the write is just a copy, and the update tensor can be used
+directly.
+"""
+
 import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import Function
 from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
@@ -6,6 +17,9 @@ from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
 def _match_pattern(op):
     if op.op_type == "slice_update":
+        if op.x.shape is None or op.update.shape is None:
+            return False
+
         x_rank = len(op.x.shape)
 
         x_and_update_shape_matches = op.x.shape == op.update.shape
@@ -24,11 +38,45 @@ def _match_pattern(op):
     return False
 
 
+def _renames_function_input(slice_update_op, new_var) -> bool:
+    """True if replacing the op's output by ``new_var`` would rename a function input.
+
+    When the replaced var is an output of the enclosing block, coremltools
+    carries the old name over to the replacement so that the model keeps its
+    output names (``Block.replace_block_output_var``). For a ``Function`` it
+    refuses to do that to an input var and raises ``ValueError: It is not
+    allowed to modify function inputs name.`` -- which aborts the whole
+    conversion. That happens for e.g. ``lax.dynamic_update_slice(buffer, x, 0)``
+    returned as-is, where ``update`` is a function argument.
+    """
+    block = slice_update_op.enclosing_block
+    if not isinstance(block, Function):
+        return False
+    out_var = slice_update_op.outputs[0]
+    if out_var not in block.outputs:
+        return False
+    return new_var in block.inputs.values() and new_var.name != out_var.name
+
+
 def _try_to_transform(slice_update_op):
-    # Replace occurences of the `slice_update_op` output with the `slice_update_op.update` variable
-    slice_update_op.enclosing_block.replace_uses_of_var_after_op(
-        anchor_op=slice_update_op, old_var=slice_update_op.outputs[0], new_var=slice_update_op.update
-    )
+    block = slice_update_op.enclosing_block
+    out_var = slice_update_op.outputs[0]
+
+    new_var = slice_update_op.update
+    if _renames_function_input(slice_update_op, new_var):
+        # The function input cannot be renamed, so route the output through an
+        # `identity` that can take over the name instead. The `slice_update` --
+        # the op this pass is here to remove -- still goes away.
+        new_var = mb.identity(x=new_var, before_op=slice_update_op)
+
+    # Replace occurences of the `slice_update_op` output with `new_var`.
+    # `try_...` rather than the unguarded variant: the update may descend from a
+    # var coremltools refuses to replace (a `constexpr_*` weight, say), in which
+    # case the rewrite is skipped instead of raising.
+    if not block.try_replace_uses_of_var_after_op(
+        anchor_op=slice_update_op, old_var=out_var, new_var=new_var
+    ):
+        return False
     slice_update_op.remove_from_block()
     return True
 

--- a/tests/passes/test_remove_noop_slice_update.py
+++ b/tests/passes/test_remove_noop_slice_update.py
@@ -22,6 +22,63 @@ class TestRemoveNoopSliceUpdate:
             return x
         self.__test_program(prog, should_remove=True)
 
+    def test_removed_when_update_is_a_function_input(self):
+        """The converter never names the `slice_update` after the function input.
+
+        Replacing the (function output) `slice_update` result by the `update`
+        var makes coremltools carry the output name over to it, which it
+        refuses to do for a function input -- it raises
+        `ValueError: It is not allowed to modify function inputs name.`
+        and aborts the conversion. The `slice_update` still has to go.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((10, 20), dtype=np.float32)
+            return mb.slice_update(
+                x=buffer, update=x, begin=[0, 0], end=buffer.shape, name="slice_update_0"
+            )
+
+        assert get_op_types_in_program(prog) == ["slice_update"]
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_slice_update")
+        apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+
+        assert get_op_types_in_program(prog) == ["identity"]
+        # The model output keeps its name; the function input keeps its own.
+        assert [output.name for output in prog.functions["main"].outputs] == ["slice_update_0"]
+        assert list(prog.functions["main"].inputs) == ["x"]
+
+        assert_model_is_valid(
+            prog,
+            {"x": (10, 20)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32")
+        )
+
+    def test_removed_outright_when_result_is_not_a_function_output(self):
+        """No `identity` is needed when nothing has to take over an output name."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
+        def prog(x):
+            buffer = np.zeros((10, 20), dtype=np.float32)
+            updated = mb.slice_update(
+                x=buffer, update=x, begin=[0, 0], end=buffer.shape, name="slice_update_0"
+            )
+            return mb.mul(x=updated, y=np.float32(2.0))
+
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
+
+        apply_pass_and_basic_check(prog, "common::remove_noop_slice_update")
+        apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+
+        assert get_op_types_in_program(prog) == ["mul"]
+
+        assert_model_is_valid(
+            prog,
+            {"x": (10, 20)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32")
+        )
+
     def test_not_removed_if_non_zero_begin_shape(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
         def prog(x):

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -1298,6 +1298,17 @@ def test_dynamic_update_slice_oob():
     run_and_compare_specific_input(dynamic_update_slice, (operand, update, jnp.array([10, 10], dtype=jnp.int32)))
 
 
+def test_dynamic_update_slice_full_tensor():
+    # An update covering the whole operand is a plain copy, which
+    # `remove_noop_slice_update` rewrites away. Returning it directly makes the
+    # rewritten var a function output while the update is a function input.
+    def dynamic_update_slice(operand, update):
+        return jax.lax.dynamic_update_slice(operand, update, (0, 0))
+
+    model = run_and_compare(dynamic_update_slice, (jnp.zeros((4, 8)), jnp.zeros((4, 8))))
+    assert "slice_update" not in get_model_instruction_types(model)
+
+
 def test_transposed_conv_large_padding():
     input_shape = (1, 1, 4, 4)
     kernel_shape = (1, 1, 3, 3)


### PR DESCRIPTION
`remove_noop_slice_update` does not merely fail to fire on a real JAX spelling -- it aborts the conversion. Any model whose result is a full-tensor `jax.lax.dynamic_update_slice` dies with `ValueError: It is not allowed to modify function inputs name.`

Minimal reproducer (fails on `main`):

```python
run_and_compare(lambda buf, upd: jax.lax.dynamic_update_slice(buf, upd, (0, 0)),
                (jnp.zeros((4, 8)), jnp.zeros((4, 8))))
```

## Root cause

The converter emits, before the pipeline runs:

```
main[CoreML8](%buf: (4, 8, fp32)(Tensor),
              %upd: (4, 8, fp32)(Tensor)) {
  block0() {
    %reshape_0: (1,int32)*(Tensor) = reshape(x=0, shape=(1,), name="reshape_0")
    %concat_0: (2,int32)*(Tensor) = concat(values=(%reshape_0, %reshape_0), axis=0, interleave=False, name="concat_0")
    %shape_0: (2,int32)*(Tensor) = shape(x=%buf, name="shape_0")
    %shape_1: (2,int32)*(Tensor) = shape(x=%upd, name="shape_1")
    %sub_0: (2,int32)*(Tensor) = sub(x=%shape_0, y=%shape_1, name="sub_0")
    %minimum_0: (2,int32)*(Tensor) = minimum(x=%concat_0, y=%sub_0, name="minimum_0")
    %maximum_0: (2,int32)*(Tensor) = maximum(x=%minimum_0, y=0, name="maximum_0")
    %add_0: (2,int32)*(Tensor) = add(x=%maximum_0, y=[4, 8], name="add_0")
    %slice_update_0: (4, 8, fp32)(Tensor) = slice_update(x=%buf, update=%upd, begin=%maximum_0, end=%add_0, name="slice_update_0")
  } -> (%slice_update_0)
}
```

The pattern matches -- `begin` is `[0, 0]`, `end` is `[4, 8] == x.shape`, unit strides -- so the pass calls `replace_uses_of_var_after_op(old_var=%slice_update_0, new_var=%upd)`. `%slice_update_0` is a *function output*, so coremltools routes through `Block.replace_block_output_var`, which carries the old output's name over to the replacement so the model keeps its output names:

```python
if isinstance(self, Function):
    if new_var in self.inputs.values() and new_var.name != old_var.name:
        raise ValueError("It is not allowed to modify function inputs name.")
    new_var.name = old_var.name
```

`%upd` is a function input, and it is named `upd`, not `slice_update_0`. Hard error, conversion over.

The existing unit test never caught it because it hand-builds the op already named after the function input that replaces it, with a comment noting exactly that workaround:

```python
# Because this function ends up being a complete no-op, we need to ensure the naming of inputs and outputs
x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, name="x")
```

With `name="x"` we have `new_var.name == old_var.name` and the guard is never reached. The converter names the op `slice_update_0`.

## Fix

Route the output through an `identity` when -- and only when -- the replacement would rename a function input: the result is an output of a `Function`, the update is one of that function's inputs, and the names differ. The `identity` output is not a function input, so it can take over the name, and the `slice_update` -- the op this pass exists to remove -- still goes away. Every other case is untouched: a result that is not a function output, or an update that is not a function input, is still replaced outright with no `identity` added.

Two smaller robustness changes ride along. `try_replace_uses_of_var_after_op` replaces the unguarded variant, so an update descending from a var coremltools refuses to replace (a `constexpr_*` weight, say) skips the rewrite instead of raising. And `_match_pattern` guards `x.shape` / `update.shape` against `None`, which `len()` would otherwise trip over.

The reproducer now converts to:

```
main[CoreML8](%buf: (4, 8, fp32)(Tensor),
              %upd: (4, 8, fp32)(Tensor)) {
  block0() {
    %slice_update_0: (4, 8, fp32)(Tensor) = identity(x=%upd, name="identity_0")
    %buf_tmp: (4, 8, fp32)(Tensor) = identity(x=%buf, name="buf_tmp")
  } -> (%slice_update_0)
}
```

The second `identity` is coremltools' own passthrough for the now-unused `buf` input.

## Tests

- `test_removed_when_update_is_a_function_input` -- hand-built MIL in the spelling the converter actually produces (op named `slice_update_0`, update is the function input `x`, result is the function output). Asserts the pass does not raise, the `slice_update` is gone, the output keeps its name and the input keeps its own, and the model is valid. Fails on the pre-fix code with the `ValueError`.
- `test_removed_outright_when_result_is_not_a_function_output` -- same update var, result consumed by a `mul`: removed with no `identity` left behind.
- `tests/test_jax.py::test_dynamic_update_slice_full_tensor` -- end-to-end through `jax.lax.dynamic_update_slice`, numerics compared against JAX, asserts no `slice_update` survives in the converted model.

## Verification

Full suite on this branch: `428 passed, 1 skipped` (`python -m pytest tests/`). `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E
