### PR TITLE
Replace the masked softmax that jax.nn.softmax(where=...) emits

### DIFF
--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -23,6 +23,12 @@ constant along ``axis`` and is not a statically known non-finite value --
 softmax is invariant under such a shift, so the whole ``reduce_max``/
 ``maximum``/``reshape`` chain becomes dead. That covers the ``maximum(-inf,
 .)`` clamps and the permuted layouts for free.
+
+``jax.nn.softmax(x, where=mask)`` additionally wraps the summand in
+``select(mask, ., 0)`` and the quotient in ``select(mask, ., 0)``, having
+first replaced the masked lanes of ``x`` with ``-inf``. Those masked lanes
+exponentiate to exactly 0, so the ``select`` inside the sum is redundant and
+the whole thing is ``select(mask, softmax(select(mask, x, -inf)), 0)``.
 """
 
 import logging
@@ -40,6 +46,7 @@ from .pattern_utils import (
     normalize_axis,
     shapes_equal,
     sole_consumer,
+    uniform_scalar_value,
 )
 
 logger = logging.getLogger(__name__)
@@ -98,19 +105,33 @@ def _match(real_div_op):
     if axis is None:
         return None
 
-    # `reduce_sum` must consume the exp output, possibly through an fp32 cast.
+    # `reduce_sum` must consume the exp output, possibly through an fp32 cast
+    # and/or the `select(mask, ., 0)` that `jax.nn.softmax(where=...)` puts
+    # inside the sum.
     sum_input = reduce_sum_op.inputs["x"]
     matched += chain
     matched.append(reduce_sum_op)
-    if sum_input is not numerator:
-        cast_op = getattr(sum_input, "op", None)
-        if cast_op is None or cast_op.op_type != "cast":
+    consumer = reduce_sum_op
+    mask = None
+    seen_cast = False
+    while sum_input is not numerator:
+        op = getattr(sum_input, "op", None)
+        if op is None or sole_consumer(sum_input) is not consumer:
             return None
-        if cast_op.inputs["x"] is not numerator:
+        if op.op_type == "cast" and not seen_cast:
+            seen_cast = True
+            next_input = op.inputs["x"]
+        elif op.op_type == "select" and mask is None:
+            zero = uniform_scalar_value(op.inputs["b"])
+            if zero is None or zero != 0.0:
+                return None
+            mask = _mask_source(op.inputs["cond"])
+            next_input = op.inputs["a"]
+        else:
             return None
-        if sole_consumer(sum_input) is not reduce_sum_op:
-            return None
-        matched.append(cast_op)
+        matched.append(op)
+        consumer = op
+        sum_input = next_input
 
     # The intermediate values must be a plain "broadcast the sum back" chain.
     keep_dims_shape = full_shape[:axis] + (1,) + full_shape[axis + 1:]
@@ -143,7 +164,68 @@ def _match(real_div_op):
     ):
         softmax_input = sub_op.inputs["x"]
 
+    if mask is not None and not _is_masked_softmax(real_div_op, softmax_input, mask):
+        return None
+
     return softmax_input, axis
+
+
+def _mask_source(var):
+    """Peel broadcasting ``tile``s off a mask so that equal masks compare equal.
+
+    JAX materialises the same ``where=`` mask once per use, and the converter
+    tiles each of those up to the operand shape separately, so the three masks
+    of a masked softmax are distinct ``Var``s over one common source.
+    """
+    while True:
+        op = getattr(var, "op", None)
+        if op is None or not is_broadcast_tile(op):
+            return var
+        var = op.inputs["x"]
+
+
+def _select_over(var, mask):
+    """Return the ``select`` op if ``var`` is ``select(mask, ., .)``, else ``None``."""
+    op = getattr(var, "op", None)
+    if op is None or op.op_type != "select":
+        return None
+    if _mask_source(op.inputs["cond"]) is not mask:
+        return None
+    return op
+
+
+def _is_masked_softmax(real_div_op, softmax_input, mask) -> bool:
+    """True if dropping the ``select`` inside the sum leaves the result unchanged.
+
+    ``jax.nn.softmax(x, where=mask)`` is::
+
+        x_safe = select(mask, x, -inf)
+        result = select(mask, exp(x_safe - m) / sum(select(mask, exp(...), 0)), 0)
+
+    Summing ``exp`` directly instead of the masked copy is exact as long as the
+    masked lanes of ``x_safe`` are ``-inf``: ``exp(-inf - m) == 0`` for any finite
+    ``m``, so those terms contribute nothing either way. When a whole row is
+    masked ``m`` is ``-inf`` too and both spellings produce NaN, but the outer
+    ``select`` then replaces the entire row with zeros -- which is why that
+    ``select`` has to be present for the rewrite to be sound.
+    """
+    fill_select = _select_over(softmax_input, mask)
+    if fill_select is None:
+        return False
+    fill = uniform_scalar_value(fill_select.inputs["b"])
+    if fill is None or not (np.isinf(fill) and fill < 0):
+        return False
+
+    result = real_div_op.outputs[0]
+    out_select = sole_consumer(result)
+    if out_select is None or out_select.op_type != "select":
+        return False
+    if _mask_source(out_select.inputs["cond"]) is not mask:
+        return False
+    if out_select.inputs["a"] is not result:
+        return False
+    zero = uniform_scalar_value(out_select.inputs["b"])
+    return zero is not None and zero == 0.0
 
 
 def _is_constant_along(var, axis: int, rank: int) -> bool:
@@ -228,7 +310,23 @@ class replace_decomposed_softmax(AbstractGraphPass):
 
     ``tile`` ops broadcasting the sum back to the input shape and the ``cast``
     pair that JAX adds around ``reduce_sum`` for fp16 inputs are matched as
-    well. The subtraction is only peeled off when the subtrahend is constant
+    well, as is the masked form ``jax.nn.softmax(x, where=mask)``:
+
+        %safe = select(cond=%mask, a=%x, b=-inf)
+        ...
+        %exp = exp(x=sub(%safe, %kd))
+        %masked = select(cond=%mask, a=%exp, b=0.0)
+        %sum = reduce_sum(x=%masked, axes=[a], keep_dims=True)
+        %div = real_div(x=%exp, y=%sum)
+        %out = select(cond=%mask, a=%div, b=0.0)     # required
+
+    becomes ``%out = select(cond=%mask, a=softmax(x=%safe, axis=a), b=0.0)``.
+    All three masks must come from one source (broadcasting ``tile``s aside),
+    the fill of ``%safe`` must be ``-inf`` so that the masked lanes of ``%exp``
+    are exactly zero, and the outer ``select`` must be there -- it is what
+    makes an entirely masked row come out as zeros rather than NaN.
+
+    The subtraction is only peeled off when the subtrahend is constant
     along the softmax axis (which is what makes softmax invariant under it)
     and is not statically known to contain NaN or infinity; otherwise the
     ``sub`` output becomes the softmax input.

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -1,4 +1,6 @@
 import coremltools as ct
+import equinox as eqx
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -10,8 +12,13 @@ from coremltools.converters.mil.testing_utils import (
     assert_model_is_valid,
     get_op_types_in_program,
 )
+from flax import nnx
 
-from tests.utils import get_model_instruction_types, run_and_compare
+from tests.utils import (
+    get_model_instruction_types,
+    run_and_compare,
+    run_and_compare_specific_input,
+)
 
 PASS_NAME = "common::replace_decomposed_softmax"
 DCE_PASS_NAME = "common::dead_code_elimination"
@@ -52,6 +59,28 @@ def _decomposed_softmax(x, axis, shape, *, clamps=1, keep_dims=False, tile=False
         total = mb.tile(x=total, reps=reps)
 
     return mb.real_div(x=exponentiated, y=total)
+
+
+def _masked_softmax(x, mask, axis, shape, *, fill=NEG_INF, out_fill=0.0, sum_fill=0.0):
+    """Build the op chain JAX emits for ``softmax(x, axis, where=mask)``.
+
+    JAX materialises the mask once per use, so each ``select`` gets its own
+    ``cond`` var; here they share one, which is the shape the converter produces
+    for an unbroadcast mask.
+    """
+    keep_dims_shape = list(shape)
+    keep_dims_shape[axis] = 1
+
+    safe = mb.select(cond=mask, a=x, b=np.full(shape, fill, dtype=np.float32))
+    maximum = mb.reduce_max(x=safe, axes=[axis], keep_dims=False)
+    maximum = mb.maximum(x=NEG_INF, y=maximum)
+    maximum = mb.reshape(x=maximum, shape=keep_dims_shape)
+
+    exponentiated = mb.exp(x=mb.sub(x=safe, y=maximum))
+    masked = mb.select(cond=mask, a=exponentiated, b=np.full(shape, sum_fill, dtype=np.float32))
+    total = mb.reduce_sum(x=masked, axes=[axis], keep_dims=True)
+    quotient = mb.real_div(x=exponentiated, y=total)
+    return mb.select(cond=mask, a=quotient, b=np.full(shape, out_fill, dtype=np.float32))
 
 
 class TestReplaceDecomposedSoftmax:
@@ -125,6 +154,140 @@ class TestReplaceDecomposedSoftmax:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["softmax"]
+
+    def test_handles_the_where_mask(self):
+        """`jax.nn.softmax(where=mask)` puts a `select` inside the sum."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            return _masked_softmax(x, mask, 1, (2, 4))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["select", "softmax", "select"]
+        softmax_op = next(
+            op for op in prog.functions["main"].operations if op.op_type == "softmax"
+        )
+        assert softmax_op.axis.val == 1
+        # The softmax runs on the -inf-filled input, not on the raw one.
+        assert softmax_op.x.op.op_type == "select"
+
+    def test_handles_the_where_mask_with_the_fp16_cast_pair(self):
+        """In fp16 the cast to fp32 sits between the `exp` and the mask `select`."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4), dtype=types.fp16),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            safe = mb.select(cond=mask, a=x, b=np.full((2, 4), -np.inf, dtype=np.float16))
+            maximum = mb.reduce_max(x=safe, axes=[1], keep_dims=True)
+            exponentiated = mb.exp(x=mb.sub(x=safe, y=maximum))
+            promoted = mb.cast(x=exponentiated, dtype="fp32")
+            masked = mb.select(cond=mask, a=promoted, b=np.zeros((2, 4), dtype=np.float32))
+            total = mb.reduce_sum(x=masked, axes=[1], keep_dims=True)
+            demoted = mb.cast(x=total, dtype="fp16")
+            quotient = mb.real_div(x=exponentiated, y=demoted)
+            return mb.select(cond=mask, a=quotient, b=np.zeros((2, 4), dtype=np.float16))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["select", "softmax", "select"]
+
+    def test_handles_a_where_mask_broadcast_by_separate_tiles(self):
+        """The converter tiles the mask up to the operand shape once per use."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 3, 4)),
+            mb.TensorSpec(shape=(2, 1, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            fill = np.full((2, 3, 4), -np.inf, dtype=np.float32)
+            zeros = np.zeros((2, 3, 4), dtype=np.float32)
+            safe = mb.select(cond=mb.tile(x=mask, reps=[1, 3, 1]), a=x, b=fill)
+            maximum = mb.reduce_max(x=safe, axes=[2], keep_dims=True)
+            exponentiated = mb.exp(x=mb.sub(x=safe, y=maximum))
+            masked = mb.select(cond=mb.tile(x=mask, reps=[1, 3, 1]), a=exponentiated, b=zeros)
+            total = mb.reduce_sum(x=masked, axes=[2], keep_dims=True)
+            quotient = mb.real_div(x=exponentiated, y=total)
+            return mb.select(cond=mb.tile(x=mask, reps=[1, 3, 1]), a=quotient, b=zeros)
+
+        _apply(prog)
+        assert "softmax" in get_op_types_in_program(prog)
+        assert "real_div" not in get_op_types_in_program(prog)
+
+    def test_keeps_a_masked_sum_when_the_fill_is_finite(self):
+        """Only `-inf` guarantees the masked lanes of `exp` are exactly zero.
+
+        With a finite fill (``jnp.finfo.min``, as flax spells it) the masked
+        terms are tiny but non-zero, so dropping the `select` would change the
+        denominator.
+        """
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            return _masked_softmax(x, mask, 1, (2, 4), fill=np.finfo(np.float32).min)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_keeps_a_masked_sum_without_the_outer_select(self):
+        """The outer `select` is what turns an entirely masked row into zeros."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            safe = mb.select(cond=mask, a=x, b=np.full((2, 4), -np.inf, dtype=np.float32))
+            maximum = mb.reduce_max(x=safe, axes=[1], keep_dims=True)
+            exponentiated = mb.exp(x=mb.sub(x=safe, y=maximum))
+            masked = mb.select(cond=mask, a=exponentiated, b=np.zeros((2, 4), dtype=np.float32))
+            total = mb.reduce_sum(x=masked, axes=[1], keep_dims=True)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_keeps_a_masked_sum_for_a_different_mask(self):
+        """All three masks must come from one source."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask, other):
+            safe = mb.select(cond=other, a=x, b=np.full((2, 4), -np.inf, dtype=np.float32))
+            maximum = mb.reduce_max(x=safe, axes=[1], keep_dims=True)
+            exponentiated = mb.exp(x=mb.sub(x=safe, y=maximum))
+            masked = mb.select(cond=mask, a=exponentiated, b=np.zeros((2, 4), dtype=np.float32))
+            total = mb.reduce_sum(x=masked, axes=[1], keep_dims=True)
+            quotient = mb.real_div(x=exponentiated, y=total)
+            return mb.select(cond=mask, a=quotient, b=np.zeros((2, 4), dtype=np.float32))
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_keeps_a_masked_sum_when_the_summand_fill_is_not_zero(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            return _masked_softmax(x, mask, 1, (2, 4), sum_fill=1.0)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_keeps_a_masked_sum_when_the_output_fill_is_not_zero(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(2, 4), dtype=types.bool),
+        ])
+        def prog(x, mask):
+            return _masked_softmax(x, mask, 1, (2, 4), out_fill=1.0)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
 
     def test_handles_symbolic_batch_dim(self):
         batch = get_new_symbol()
@@ -299,3 +462,128 @@ class TestReplaceDecomposedSoftmaxEndToEnd:
         assert ops.count("softmax") == 1
         assert "real_div" not in ops
         assert "reduce_sum" not in ops
+
+    def test_flax_softmax(self):
+        cml_model = run_and_compare(nnx.softmax, [jax.ShapeDtypeStruct((3, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+    def test_jax_softmax_with_a_where_mask(self, dtype):
+        """`where=` masks the summand and the quotient with a `select` each.
+
+        The mask deliberately blanks out one row entirely: JAX answers that row
+        with zeros (the outer `select` swallows the NaN), and the fused model
+        has to do the same.
+        """
+        x = jax.random.normal(jax.random.PRNGKey(0), (3, 16), dtype)
+        mask = jax.random.bernoulli(jax.random.PRNGKey(1), 0.6, (3, 16)).at[1].set(False)
+        precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
+
+        cml_model = run_and_compare_specific_input(
+            lambda a, m: jax.nn.softmax(a, axis=-1, where=m),
+            (x, mask),
+            atol=1e-04 * precision_loss,
+            rtol=1e-05 * precision_loss,
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        for op_type in ("reduce_max", "reduce_sum", "exp", "real_div"):
+            assert op_type not in ops
+
+    def test_jax_softmax_with_a_broadcast_where_mask(self):
+        """A mask of a lower rank is tiled up to the operand shape once per use."""
+        x = jax.random.normal(jax.random.PRNGKey(0), (2, 4, 8, 8), jnp.float32)
+        mask = jax.random.bernoulli(jax.random.PRNGKey(1), 0.7, (2, 1, 1, 8))
+
+        cml_model = run_and_compare_specific_input(
+            lambda a, m: jax.nn.softmax(a, axis=-1, where=m), (x, mask)
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+
+    def test_jax_softmax_with_a_where_mask_on_a_middle_axis(self):
+        x = jax.random.normal(jax.random.PRNGKey(0), (2, 5, 4), jnp.float32)
+        mask = jax.random.bernoulli(jax.random.PRNGKey(1), 0.7, (2, 5, 4))
+
+        cml_model = run_and_compare_specific_input(
+            lambda a, m: jax.nn.softmax(a, axis=1, where=m), (x, mask)
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+
+    def test_masked_softmax_as_flax_and_equinox_write_it(self):
+        """Both libraries fill the masked logits themselves, then call `softmax`.
+
+        `flax.nnx.dot_product_attention` and `equinox.nn.MultiheadAttention`
+        both use `jnp.where(mask, logits, finfo.min)`, so no `select` ends up
+        inside the sum and the plain decomposition is what reaches MIL.
+        """
+        x = jax.random.normal(jax.random.PRNGKey(0), (2, 4, 8, 8), jnp.float32)
+        mask = jax.random.bernoulli(jax.random.PRNGKey(1), 0.7, (2, 1, 8, 8))
+
+        cml_model = run_and_compare_specific_input(
+            lambda a, m: jax.nn.softmax(
+                jnp.where(m, a, jnp.finfo(jnp.float32).min), axis=-1
+            ),
+            (x, mask),
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("softmax") == 1
+        assert "real_div" not in ops
+
+    def test_flax_multi_head_attention(self):
+        """The softmax inside `nnx.MultiHeadAttention` must be recognised.
+
+        `fuse_attention_to_sdpa` then absorbs it, so what is asserted is that
+        nothing of the decomposition survives.
+        """
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=8, qkv_features=16, decode=False, rngs=nnx.Rngs(0)
+        )
+        layer.eval()
+        causal = nnx.make_causal_mask(jnp.ones((2, 6)))
+
+        cml_model = run_and_compare(
+            nnx.jit(lambda x: layer(x, mask=causal)),
+            [jax.ShapeDtypeStruct((2, 6, 8), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        for op_type in ("reduce_max", "reduce_sum", "exp", "real_div"):
+            assert op_type not in ops
+
+    def test_equinox_multihead_attention(self):
+        layer = eqx.nn.MultiheadAttention(
+            num_heads=2, query_size=8, key=jax.random.PRNGKey(0)
+        )
+        layer = eqx.nn.inference_mode(layer)
+        mask = jnp.tril(jnp.ones((6, 6), dtype=bool))
+
+        cml_model = run_and_compare(
+            eqxi.finalise_fn(lambda x: layer(x, x, x, mask=mask)),
+            [jax.ShapeDtypeStruct((6, 8), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        for op_type in ("reduce_max", "reduce_sum", "exp", "real_div"):
+            assert op_type not in ops
+
+    def test_log_softmax_is_left_alone(self):
+        """MIL has no `log_softmax`, and `log(softmax(x))` is not the same op."""
+        cml_model = run_and_compare(
+            jax.nn.log_softmax, [jax.ShapeDtypeStruct((3, 16), jnp.float32)]
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert "softmax" not in ops
+        assert ops.count("log") == 1
+
+    @pytest.mark.parametrize("axis", [None, (1, 2)])
+    def test_multi_axis_softmax_is_left_alone(self, axis):
+        """`softmax` reduces over a single axis, so a multi-axis sum cannot fuse."""
+        cml_model = run_and_compare(
+            lambda x: jax.nn.softmax(x, axis=axis),
+            [jax.ShapeDtypeStruct((2, 3, 4), jnp.float32)],
+        )
+        assert "softmax" not in get_model_instruction_types(cml_model)


### PR DESCRIPTION
## Problem

Auditing `replace_decomposed_softmax` against the spellings real libraries use (converting each through the real converter + `DEFAULT_HLO_PIPELINE` and reading the MIL), one public JAX API never fused: **`jax.nn.softmax(x, where=mask)`** — and therefore `flax.nnx.softmax(x, where=mask)`, which is the same function.

| spelling | before |
| --- | --- |
| `jax.nn.softmax(x, axis=-1 / 1 / 0)` | fused |
| `flax.nnx.softmax(x)` | fused |
| `jnp.where(mask, x, finfo.min)` then `softmax` (how flax + equinox mask) | fused |
| `nnx.MultiHeadAttention`, `equinox.nn.MultiheadAttention` (masked and not) | fused, then absorbed by SDPA |
| **`jax.nn.softmax(x, where=mask)`** | **not fused** |
| `jax.nn.log_softmax` | not fused — MIL has no `log_softmax` op, correct |
| `jax.nn.softmax(x, axis=None / (1,2))` | not fused — `softmax` takes one axis, correct |

## Root cause

The matcher requires the `reduce_sum` to consume the very same `exp` output the division does (optionally through the fp32 `cast` JAX inserts for fp16). `where=` passes the mask down into both reductions, so a `select` lands in between. Here is the MIL immediately before the pass runs, for `jax.nn.softmax(x, axis=-1, where=m)`:

```
%select_0: (3, 16, fp32) = select(cond=%m, a=%x, b=%tile_0)          # tile_0 = -inf
%reduce_max_0: (3, fp32) = reduce_max(x=%select_0, axes=[1], keep_dims=False)
%maximum_0:    (3, fp32) = maximum(x=[-inf], y=%reduce_max_0)
%reshape_5: (3, 1, fp32) = reshape(x=%maximum_0, shape=[3, 1])
%select_1: (3, 16, fp32) = select(cond=%m, a=%x, b=%tile_2)          # tile_2 = -inf
%sub_0:    (3, 16, fp32) = sub(x=%select_1, y=%reshape_5)
%exp_0:    (3, 16, fp32) = exp(x=%sub_0)
%select_2: (3, 16, fp32) = select(cond=%m, a=%exp_0, b=%tile_4)      # <-- blocker, tile_4 = 0
%reshape_8: (3, 1, fp32) = reduce_sum(x=%select_2, axes=[1], keep_dims=True)
%real_div_0: (3, 16, fp32) = real_div(x=%exp_0, y=%reshape_8)
%select_3: (3, 16, fp32) = select(cond=%m, a=%real_div_0, b=%tile_6)
```

`sum_input` is `%select_2`, not `%exp_0` and not a `cast` of it, so `_match` returns `None` and all eleven ops reach the model. In fp16 the `cast` is stacked on top of the `select` (`exp -> cast -> select -> reduce_sum`), and with a lower-rank mask the converter materialises `%m` and tiles it up to the operand shape **once per use**, so the three `cond` vars are three distinct `tile` outputs.

That also costs the SDPA fusion layered on top of the softmax, so an attention block written with `where=` loses both rewrites.

## Fix

The `select` inside the sum is redundant, which is what makes removing it exact: `%select_1` is `-inf` on the masked lanes and the shift is finite, so those lanes of `%exp_0` are exactly `0` and contribute nothing to the sum either way.

The one case where they are not `0` is a row masked in its entirety — then the maximum is `-inf` too, `-inf - -inf` is NaN, and `%exp_0` is NaN across the row. But `%select_3` overwrites that whole row with zeros, so both spellings still agree. That is why the pass now **requires** the outer `select` rather than assuming it.

Concretely, the denominator walk accepts one `cast` and one `select(mask, ., 0)` in either order, and a matched mask brings three obligations:
- the softmax input must be `select(mask, ., -inf)` — a finite fill (flax's `finfo.min`) does not give exactly-zero lanes and is rejected;
- the division's sole consumer must be `select(mask, ., 0)`;
- all three masks must come from one source, compared through broadcasting `tile`s (`_mask_source`) rather than by identity.

The result is `select(mask, softmax(select(mask, x, -inf), axis), 0)` — 11 ops down to 3.

## Tests

Hand-built MIL: the masked chain; the fp16 variant with the `cast` between `exp` and `select`; a mask broadcast by three separate `tile` ops. Negatives: a finite (`finfo.min`) fill, a missing outer `select`, a mismatched mask, a non-zero fill on the summand `select`, a non-zero fill on the output `select`.

End to end: `where=` in fp32 and fp16 with a **deliberately fully-masked row** so the NaN path is checked against the JAX reference, a rank-4 broadcast mask, a middle axis, `flax.nnx.softmax`, the `jnp.where(mask, x, finfo.min)` form flax and equinox write by hand, `nnx.MultiHeadAttention` (causal mask), `equinox.nn.MultiheadAttention` (causal mask), plus assertions that `log_softmax` and multi-axis softmax stay unfused.

## Verification

Full suite (excluding `tests/pytorch`): 444 passed. `ruff check .` clean. Every `where=` case now fuses to exactly one `softmax`, with numerics matching JAX including the fully-masked row.

One gap I found but deliberately left alone: a hand-written `jnp.exp(x) / jnp.sum(jnp.exp(x), ...)` lowers to **two** separate `exp` ops over the same input, and the matcher requires one shared var — so it does not fuse. That is not a library spelling and the relaxation is orthogonal to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E
