### PR TITLE
Match the expand_dims spelling of keep-dims in fuse_reduce_keep_dims

### DIFF
--- a/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
+++ b/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
@@ -1,4 +1,4 @@
-"""MIL pass: fold a keep-dims ``reshape`` back into the reduction that feeds it.
+"""MIL pass: fold a keep-dims ``reshape``/``expand_dims`` back into its reduction.
 
 StableHLO's ``reduce`` always drops the reduced dimensions, so JAX's
 ``jnp.sum(x, axis, keepdims=True)`` lowers to a ``reduce`` followed by a
@@ -14,6 +14,16 @@ into that single op is not just cosmetic: several of coremltools' own fusions
 to be directly followed by the arithmetic that consumes it, and the intervening
 ``reshape`` blocks them. With this pass in place an RMSNorm
 (``x * rsqrt(mean(x**2, -1, keepdims=True) + eps)``) becomes a ``reduce_mean``.
+
+Under symbolic (dynamic) shapes the very same JAX source lowers to
+``stablehlo.dynamic_broadcast_in_dim`` instead, and ``op_dynamic_broadcast_in_dim``
+re-inserts the axes with ``expand_dims`` rather than ``reshape`` (a ``reshape``
+would need the runtime shape as an operand)::
+
+    %r = reduce_sum(x=%x, axes=[1], keep_dims=False)   # %x: (dim_0, 8) -> (dim_0,)
+    %o = expand_dims(x=%r, axes=[1])                   # (dim_0, 1)
+
+so both spellings are matched.
 """
 
 import logging
@@ -73,9 +83,17 @@ def _keep_dims_shape(x_shape, axes: list[int]) -> tuple:
     return tuple(shape)
 
 
+# The ops that can spell out "re-insert the axes the reduction dropped": a
+# `reshape` to the keep-dims shape (static shapes) or an `expand_dims` on the
+# reduced axes (dynamic shapes, from `op_dynamic_broadcast_in_dim`). Both are
+# order-preserving, so matching the output shape is enough to prove either is
+# the keep-dims shape -- see `_match`.
+_RESTORE_OPS = frozenset({"reshape", "expand_dims"})
+
+
 def _match(reshape_op, block):
     """Return ``(reduce_op, axes)`` if ``reshape_op`` only re-inserts the reduced axes."""
-    if reshape_op.op_type != "reshape":
+    if reshape_op.op_type not in _RESTORE_OPS:
         return None
 
     reduce_op = reshape_op.x.op
@@ -147,17 +165,21 @@ def _fuse_reduce_keep_dims(block) -> int:
 @register_pass(namespace="common")
 class fuse_reduce_keep_dims(AbstractGraphPass):
     """
-    Fuse ``reduce_*(keep_dims=False) -> reshape(<keep-dims shape>)`` into a
-    single ``reduce_*(keep_dims=True)``.
+    Fuse ``reduce_*(keep_dims=False) -> reshape/expand_dims(<keep-dims shape>)``
+    into a single ``reduce_*(keep_dims=True)``.
 
     The rewrite applies when
 
     1. the reduce is one of the ops whose builder takes ``axes`` + ``keep_dims``
        (the arg-reductions are excluded),
     2. ``axes`` is known at compile time, and
-    3. the reshape output shape is exactly the reduce input shape with the
-       reduced axes set to 1 (compared symbolically, so dynamic dimensions are
-       preserved).
+    3. the ``reshape``/``expand_dims`` output shape is exactly the reduce input
+       shape with the reduced axes set to 1 (compared symbolically, so dynamic
+       dimensions are preserved).
+
+    Neither ``reshape`` nor ``expand_dims`` reorders elements, so an output
+    shape equal to the keep-dims shape is enough to prove the op is the identity
+    on the reduction's result.
 
     When the reduce has consumers besides the reshape it is kept for them and
     only the reshape is replaced.
@@ -168,6 +190,13 @@ class fuse_reduce_keep_dims(AbstractGraphPass):
 
     Result:
         %2 = reduce_sum(x=%0, axes=[2], keep_dims=True)
+
+    Given:
+        %1 = reduce_sum(x=%0, axes=[1], keep_dims=False)   # %0: (dim_0, 8)
+        %2 = expand_dims(x=%1, axes=[1])
+
+    Result:
+        %2 = reduce_sum(x=%0, axes=[1], keep_dims=True)
     """
 
     def apply(self, prog):

--- a/tests/passes/test_fuse_reduce_keep_dims.py
+++ b/tests/passes/test_fuse_reduce_keep_dims.py
@@ -92,6 +92,79 @@ class TestFuseReduceKeepDims:
         assert get_op_types_in_program(prog) == ["reduce_sum"]
         assert prog.functions["main"].outputs[0].shape == (batch, 8, 1)
 
+    @pytest.mark.parametrize("reduce_op", sorted(_REDUCE_OPS))
+    def test_expand_dims_is_fused(self, reduce_op):
+        """`op_dynamic_broadcast_in_dim` spells the keep-dims axis as `expand_dims`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = getattr(mb, reduce_op)(x=x, axes=[2], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[2])
+
+        assert get_op_types_in_program(prog) == [reduce_op, "expand_dims"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == [reduce_op]
+
+        fused = _ops_of_type(prog, reduce_op)
+        assert len(fused) == 1
+        assert fused[0].keep_dims.val
+        assert prog.functions["main"].outputs[0].shape == (2, 8, 1)
+        assert_model_is_valid(
+            prog, {"x": (2, 8, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_expand_dims_with_negative_axes_is_fused(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[-1], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[-1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (2, 8, 1)
+
+    def test_expand_dims_over_multiple_axes_is_fused(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[0, 2], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[0, 2])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (1, 8, 1)
+
+    def test_expand_dims_with_symbolic_dims_is_fused(self):
+        """The shape the dynamic lowering actually produces: a symbolic leading dim."""
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 8))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[1])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum"]
+        assert prog.functions["main"].outputs[0].shape == (batch, 1)
+
+    def test_expand_dims_in_the_wrong_place_is_untouched(self):
+        """`(2, 8, 16) -> reduce axis 1 -> (2, 16)` expanded at axis 2, not axis 1."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[1], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[2])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "expand_dims"]
+
+    def test_expand_dims_adding_an_extra_axis_is_untouched(self):
+        """Two inserted axes for a single reduced one is not the keep-dims shape."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
+        def prog(x):
+            reduced = mb.reduce_sum(x=x, axes=[2], keep_dims=False)
+            return mb.expand_dims(x=reduced, axes=[0, 3])
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "expand_dims"]
+
     def test_keep_dims_already_true_is_untouched(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8, 16))])
         def prog(x):
@@ -237,3 +310,24 @@ class TestFuseReduceKeepDimsEndToEnd:
         ops = get_model_instruction_types(cml_model)
         assert ops.count("reduce_sum") == 1
         assert "reshape" not in ops
+        # Under symbolic shapes the keep-dims axis arrives as an `expand_dims`,
+        # not a `reshape`.
+        assert "expand_dims" not in ops
+
+    def test_symbolic_batch_dim_with_downstream_consumer(self):
+        """The `expand_dims` sits between the reduce and the op consuming it."""
+        symbolic_shape = jax.export.symbolic_shape("(b, 8)")
+
+        def f(x):
+            return x - jnp.max(x, axis=-1, keepdims=True)
+
+        from tests.utils import run_and_compare_symbolic  # noqa: PLC0415
+
+        cml_model = run_and_compare_symbolic(
+            f,
+            [jax.ShapeDtypeStruct(symbolic_shape, jnp.float32)],
+            [(np.zeros((3, 8), dtype=np.float32),), (np.ones((5, 8), dtype=np.float32),)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("reduce_max") == 1
+        assert "expand_dims" not in ops


### PR DESCRIPTION
`fuse_reduce_keep_dims` folds `reduce_*(keep_dims=False) -> reshape(<keep-dims shape>)` back into a single `reduce_*(keep_dims=True)`. It matched exactly one spelling of the re-inserted axes -- a `reshape` -- which is what `op_broadcast_in_dim` emits, but only for static shapes.

## Root cause

Under symbolic (dynamic) shapes JAX lowers the same source to `stablehlo.dynamic_broadcast_in_dim`, and `op_dynamic_broadcast_in_dim` deliberately re-inserts the axes with `expand_dims` rather than `reshape` (a `reshape` would need the runtime shape as an operand; `expand_dims` is axis-based and needs no shape values at all):

```python
# Uses expand_dims (axis-based, no shape values) instead of reshape
# to handle inputs with symbolic dimensions.
axes_to_add = [d for d in range(output_rank) if d not in broadcast_dims]
if axes_to_add:
    x = mb.expand_dims(x=x, axes=axes_to_add)
```

The pass never sees a `reshape` there, so it is a silent no-op. `jnp.sum(x, axis=-1, keepdims=True)` over a `(b, 8, 16)` input converts, on `main`, to a final model of:

```
main[CoreML8](%arg0: (dim_0, 8, 16, fp32)(Tensor)) {
  block0() {
    %reduce_sum_0: (dim_0, 8, fp32)(Tensor) = reduce_sum(x=%arg0, axes=[2], keep_dims=False, name="reduce_sum_0")
    %expand_dims_0: (dim_0, 8, 1, fp32)(Tensor) = expand_dims(x=%reduce_sum_0, axes=[2], name="expand_dims_0")
  } -> (%expand_dims_0)
}
```

Beyond the extra op, this is exactly the blocker the pass exists to remove: coremltools' `fuse_reduce_mean` and `fuse_layernorm_or_instancenorm` need the reduction to be directly followed by the arithmetic that consumes it, and the `expand_dims` sits in between. On a symbolic-shape RMSNorm (`x * rsqrt(mean(x*x, -1, keepdims=True) + eps)`, input `(b, 8)`) the whole chain survives on `main`:

```
%reduce_sum_0_cast_fp16: (dim_0,fp16) = reduce_sum(x=%mul_0_cast_fp16, axes=[1], keep_dims=False)
%expand_dims_0_cast_fp16: (dim_0, 1, fp16) = expand_dims(x=%reduce_sum_0_cast_fp16, axes=[1])
%fill_0_cast_fp16: (dim_0, 1, fp16) = fill(shape=%concat_1, value=8.0)
%real_div_0_cast_fp16: (dim_0, 1, fp16) = real_div(x=%expand_dims_0_cast_fp16, y=%fill_0_cast_fp16)
...
```

where the static version of the same function collapses to a single `reduce_mean`.

The existing `test_symbolic_batch_dim` did not catch it: it asserts `"reshape" not in ops`, which is true -- the leftover op is an `expand_dims`.

## Fix

Accept `expand_dims` alongside `reshape` in `_match`. The existing correctness argument carries over unchanged and no new checks are needed: neither op reorders elements, so an output shape equal to the reduce *input* shape with the reduced axes set to 1 already proves the op is the identity on the reduction's result. (Two adjacent size-1 axes make the axis assignment ambiguous -- `reduce (2,1,8) over axis 2` then `expand_dims axes=[1]` gives `(2,1,1)`, same as `axes=[2]` -- but both describe the identical tensor, so it does not matter which was meant.)

After the fix the model above is:

```
main[CoreML8](%arg0: (dim_0, 8, 16, fp32)(Tensor)) {
  block0() {
    %expand_dims_0: (dim_0, 8, 1, fp32)(Tensor) = reduce_sum(x=%arg0, axes=[2], keep_dims=True, name="expand_dims_0")
  } -> (%expand_dims_0)
}
```

Measured over the symbolic-shape probes (input `(b, 8)`, full `build_pass_pipeline()`), final op counts before -> after:

| case | before | after |
| --- | --- | --- |
| `sum(x, -1, keepdims=True) * x` | `reduce_sum, expand_dims, mul` (+ shape/slice/reshape/concat chain, 11 ops) | `reduce_sum, mul` (4 ops) |
| `max(x, -1, keepdims=True) - x` | `reduce_max, expand_dims, sub` | `reduce_max, sub` |
| `mean(x, -1, keepdims=True) * x` | `reduce_sum, expand_dims, fill, real_div, tile, mul, ...` (13 ops) | same minus the `expand_dims` |
| symbolic RMSNorm | 15 ops | 14 ops, reduce now `keep_dims=True` |

## Tests

Unit (hand-built MIL):

- `test_expand_dims_is_fused`, parametrized over every op in `_REDUCE_OPS`.
- `test_expand_dims_with_negative_axes_is_fused`, `test_expand_dims_over_multiple_axes_is_fused`, `test_expand_dims_with_symbolic_dims_is_fused`.
- Negatives: `test_expand_dims_in_the_wrong_place_is_untouched` (reduce axis 1, expand at axis 2) and `test_expand_dims_adding_an_extra_axis_is_untouched` (two inserted axes for one reduced axis).

End-to-end:

- `test_symbolic_batch_dim` additionally asserts `"expand_dims" not in ops`.
- `test_symbolic_batch_dim_with_downstream_consumer` -- `x - max(x, -1, keepdims=True)` over `(b, 8)`, so the fused op has a real consumer; numerics checked against JAX at two concrete batch sizes.

15 of the new assertions fail on the pre-fix pass.

## Verification

Full suite on this branch: `441 passed, 1 skipped` (`python -m pytest tests/`). `ruff check .` clean.

## Note on a separate gap

While auditing this pass I confirmed the ordering gap in `CLEANUP_PASSES` that @kasper0406 is fixing on the `fuse_rmsnorm` branch: `common::fuse_reduce_mean` (pipeline index 52) turns `reduce_sum -> mul(1/N)` into `reduce_mean(keep_dims=False)`, only *then* making the reduce adjacent to a keep-dims `reshape`, and `fuse_reduce_keep_dims` last ran at index 11. E.g. `jnp.mean(x, -1).reshape(4, 1) * x` ends as `reduce_mean(keep_dims=False) -> reshape([4,1]) -> mul`; flax's `LayerNorm` and `RMSNorm` leave 2 and 1 such reshapes respectively. This PR deliberately does not touch the pipeline -- it is orthogonal to the `expand_dims` spelling above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E
