### PR TITLE
Fuse attention with both an additive bias and a select mask

### DIFF
--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -51,6 +51,7 @@ as well, but only when the matched mask proves that no row can be entirely
 -inf; otherwise the wrapper is not an identity and the block is left alone.
 """
 
+import dataclasses
 import logging
 import math
 
@@ -832,6 +833,24 @@ def _mask_to_sdpa_space(mask_var, space, softmax_shape, seq_len, before_op, name
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class _Options:
+    """The pass options, see :class:`fuse_attention_to_sdpa`."""
+
+    finite_fill_mask: str = "additive"
+    max_head_dim: int | None = None
+    max_key_len: int | None = None
+
+
+def _within_bound(dim, bound: int | None) -> bool:
+    """True when ``dim`` is known not to exceed ``bound`` (a symbolic ``dim`` is not)."""
+    if bound is None:
+        return True
+    if is_symbolic(dim):
+        return False
+    return int(dim) <= bound
+
+
 def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
     """Build SDPA's ``attn_mask`` from the matched additive / ``select`` masks.
 
@@ -941,7 +960,7 @@ def _validate_operands(query, key, value, n_batch: int) -> bool:
     return dims_equal(key.shape[-2], value.shape[-2])
 
 
-def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
+def _try_fuse(softmax_op, block, options: _Options) -> bool:
     out_rank = len(softmax_op.outputs[0].shape)
     if normalize_axis(softmax_op.axis.val, out_rank) != out_rank - 1:
         return False
@@ -1006,9 +1025,12 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
     embedding = int(embedding)
     seq_len = key.shape[-2]
 
+    if not _within_bound(embedding, options.max_head_dim) or not _within_bound(seq_len, options.max_key_len):
+        return False
+
     attn_mask = None
     if pattern.has_mask:
-        attn_mask = _build_mask(pattern, space, matmul_1, seq_len, query, finite_fill_mask)
+        attn_mask = _build_mask(pattern, space, matmul_1, seq_len, query, options.finite_fill_mask)
         if attn_mask is None:
             return False
 
@@ -1072,14 +1094,14 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
 
 
 @block_context_manager
-def _fuse_attention_to_sdpa(block, finite_fill_mask: str) -> int:
+def _fuse_attention_to_sdpa(block, options: _Options) -> int:
     fused = 0
     for op in list(block.operations):
         if op.enclosing_block is None:
             continue
 
         for nested_block in op.blocks:
-            fused += _fuse_attention_to_sdpa(nested_block, finite_fill_mask)
+            fused += _fuse_attention_to_sdpa(nested_block, options)
         if len(op.blocks) > 0:
             continue
 
@@ -1087,7 +1109,7 @@ def _fuse_attention_to_sdpa(block, finite_fill_mask: str) -> int:
             continue
         # `_try_fuse` may build some replacement ops before a late check makes it
         # give up; those are left dead in the block for `dead_code_elimination`.
-        if _try_fuse(op, block, finite_fill_mask):
+        if _try_fuse(op, block, options):
             fused += 1
 
     return fused
@@ -1107,6 +1129,21 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
       stays finite, exactly like the original graph; ``"bool"`` emits the
       boolean condition instead, which is cheaper but turns such rows into NaN.
       Only a fill of exactly ``-inf`` maps to a boolean mask unconditionally.
+    - ``max_head_dim`` / ``max_key_len``: leave an attention block unfused when
+      its head dimension ``E``, respectively its key length ``S``, is larger
+      than the bound (or symbolic, i.e. unknown). ``None`` (the default) fuses
+      everything. On macOS 26.x / coremltools 9.0 a fused SDPA with a large
+      head dimension and a long key length has been reported to break the ANE
+      partitioner (``ANECCompile`` fails, the model silently runs on CPU) and to
+      crash the BNNS fp16 kernel for query lengths >= 2; the decomposed form is
+      fine on every backend and costs nothing measurable on the GPU. Consumers
+      targeting the ANE or the CPU can keep the small, sliding-window sites
+      fused and opt the global ones out with these bounds.
+
+    Options are set on the pipeline::
+
+        pipeline = build_pass_pipeline()
+        pipeline.set_options("common::fuse_attention_to_sdpa", {"max_key_len": 4096})
 
     Given:
         %scores = matmul(x=%q, y=%k, transpose_y=True)
@@ -1120,6 +1157,8 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
     """
 
     _finite_fill_mask = "additive"
+    _max_head_dim = None
+    _max_key_len = None
 
     @property
     def finite_fill_mask(self) -> str:
@@ -1131,8 +1170,39 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
             raise ValueError(f"finite_fill_mask must be 'additive' or 'bool', got `{mode}`")
         self._finite_fill_mask = mode
 
+    @staticmethod
+    def _parse_bound(name: str, value) -> int | None:
+        # `PassPipeline.set_options` is documented to take strings.
+        if value is None or (isinstance(value, str) and value.strip().lower() in ("", "none")):
+            return None
+        try:
+            bound = int(value)
+            integral = bound == value if not isinstance(value, str) else True
+        except (TypeError, ValueError):
+            integral = False
+        if not integral or bound < 1:
+            raise ValueError(f"{name} must be a positive integer or None, got `{value}`")
+        return bound
+
+    @property
+    def max_head_dim(self) -> int | None:
+        return self._max_head_dim
+
+    @max_head_dim.setter
+    def max_head_dim(self, value):
+        self._max_head_dim = self._parse_bound("max_head_dim", value)
+
+    @property
+    def max_key_len(self) -> int | None:
+        return self._max_key_len
+
+    @max_key_len.setter
+    def max_key_len(self, value):
+        self._max_key_len = self._parse_bound("max_key_len", value)
+
     def apply(self, prog):
+        options = _Options(self._finite_fill_mask, self._max_head_dim, self._max_key_len)
         for f in prog.functions.values():
-            fused = _fuse_attention_to_sdpa(f, self._finite_fill_mask)
+            fused = _fuse_attention_to_sdpa(f, options)
             if fused:
                 logger.debug("fuse_attention_to_sdpa: fused %d attention block(s)", fused)

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -6,10 +6,16 @@ transpose_y=True) -> [reshape] -> [transpose]``, so an attention block looks
 like::
 
     matmul_0(Q, K, transpose_y=True) -> [reshape/transpose]* -> [scale] ->
-      [mask] -> [cast] -> softmax(axis=-1) -> [reshape/transpose]* ->
+      [bias] -> [mask] -> [cast] -> softmax(axis=-1) -> [reshape/transpose]* ->
       matmul_1(W, V, transpose_y=True)
 
 The pass matches that and emits a single ``scaled_dot_product_attention``.
+
+``bias`` is an additive float mask and ``mask`` a ``select`` against a large
+negative fill; either may be absent, and ``jax.nn.dot_product_attention`` (and
+therefore ``flax.nnx.MultiHeadAttention``) emits both when it is given a
+``bias`` as well as a ``mask``. The two collapse into SDPA's single
+``attn_mask``.
 
 Everything happens in "matmul space": the SDPA operands are exactly the matmul
 operands, so nothing is assumed about how the model laid out heads, groups or
@@ -380,20 +386,26 @@ def _match_safe_softmax(softmax_op) -> _SafeSoftmax | None:
 
 
 def _safe_softmax_is_redundant(pattern) -> bool:
-    """True when no score row can be entirely -inf, so the wrapper is an identity."""
-    if pattern.mask_kind is None:
-        return True
-    if pattern.mask_kind == "select":
+    """True when no score row can be entirely -inf, so the wrapper is an identity.
+
+    Every matched score modifier has to be harmless on its own; if any of them
+    can put a -inf into the scores, the wrapper may be doing real work.
+    """
+    if pattern.select_cond is not None and math.isinf(float(pattern.select_fill)):
         # A finite fill (`torch.finfo(dtype).min`) leaves a fully masked row
         # finite, so softmax produces a uniform row rather than NaN.
-        return not math.isinf(float(pattern.mask_fill))
-    mask_value = getattr(pattern.mask_var, "val", None)
-    if mask_value is None:
-        # A mask computed at runtime (Whisper builds one out of -inf and 0.0)
-        # may well have an all -inf row, and then the wrapper is *not* an
-        # identity: SDPA would return NaN where the original graph returns 0.
         return False
-    return not bool(np.isinf(np.asarray(mask_value)).any())
+    if pattern.add_var is not None:
+        mask_value = getattr(pattern.add_var, "val", None)
+        if mask_value is None:
+            # A mask computed at runtime (Whisper builds one out of -inf and
+            # 0.0) may well have an all -inf row, and then the wrapper is *not*
+            # an identity: SDPA would return NaN where the original graph
+            # returns 0.
+            return False
+        if bool(np.isinf(np.asarray(mask_value)).any()):
+            return False
+    return True
 
 
 def _swap_last_two(rank: int) -> list[int]:
@@ -431,14 +443,19 @@ class _Pattern:
         self.matmul_0 = None
         self.matmul_1 = None
         self.weights_var = None
-        self.back_layout_ops = []       # matmul_0 -> softmax, in execution order
-        self.fwd_layout_ops = []        # softmax -> matmul_1, in execution order
-        self.mask_kind = None           # None | "select" | "add"
-        self.mask_var = None            # the compact condition / additive mask
-        self.mask_fill = None           # the `select` fill value
-        self.mask_negated = False       # matched select(cond, fill, scores)
-        self.scale = None               # multiplicative factor applied to the scores
-        self.mask_before_scale = False  # forward order was mask -> scale
+        self.back_layout_ops = []        # matmul_0 -> softmax, in execution order
+        self.fwd_layout_ops = []         # softmax -> matmul_1, in execution order
+        self.add_var = None              # the additive (float) mask / attention bias
+        self.add_before_scale = False    # forward order was bias -> scale
+        self.select_cond = None          # the compact condition of a `select` mask
+        self.select_fill = None          # the `select` fill value
+        self.select_negated = False      # matched select(cond, fill, scores)
+        self.select_before_scale = False  # forward order was mask -> scale
+        self.scale = None                # multiplicative factor applied to the scores
+
+    @property
+    def has_mask(self) -> bool:
+        return self.add_var is not None or self.select_cond is not None
 
 
 class _Space:
@@ -519,19 +536,23 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
         elif op_type in _LAYOUT_OPS:
             back_ops.append(op)
             next_var = op.inputs["x"]
-        elif op_type == "select" and pattern.mask_kind is None:
+        elif op_type == "select" and pattern.select_cond is None:
+            if pattern.add_var is not None:
+                # Walking backwards, the additive mask was seen first, so it is
+                # applied *after* this `select`: the bias then also shifts the
+                # fill value, which a single `attn_mask` cannot express.
+                return False
             cond, a, b = op.inputs["cond"], op.inputs["a"], op.inputs["b"]
             fill_a, fill_b = uniform_scalar_value(a), uniform_scalar_value(b)
             if fill_b is not None and fill_b <= _MASK_FILL_THRESHOLD:
-                pattern.mask_fill, pattern.mask_negated, next_var = fill_b, False, a
+                pattern.select_fill, pattern.select_negated, next_var = fill_b, False, a
             elif fill_a is not None and fill_a <= _MASK_FILL_THRESHOLD:
-                pattern.mask_fill, pattern.mask_negated, next_var = fill_a, True, b
+                pattern.select_fill, pattern.select_negated, next_var = fill_a, True, b
             else:
                 return False
-            pattern.mask_kind = "select"
-            pattern.mask_var = cond
-            order.append("mask")
-        elif op_type == "add" and pattern.mask_kind is None:
+            pattern.select_cond = cond
+            order.append("select")
+        elif op_type == "add" and pattern.add_var is None:
             x, y = op.inputs["x"], op.inputs["y"]
             # A uniform constant shifts every score by the same amount, which
             # softmax cancels out; it carries no masking information, so there
@@ -541,13 +562,12 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
             if uniform_scalar_value(x) is not None or uniform_scalar_value(y) is not None:
                 return False
             if _leads_to_matmul(x):
-                next_var, pattern.mask_var = x, y
+                next_var, pattern.add_var = x, y
             elif _leads_to_matmul(y):
-                next_var, pattern.mask_var = y, x
+                next_var, pattern.add_var = y, x
             else:
                 return False
-            pattern.mask_kind = "add"
-            order.append("mask")
+            order.append("add")
         elif op_type in ("mul", "real_div") and pattern.scale is None:
             if op_type == "real_div":
                 divisor = uniform_scalar_value(op.inputs["y"])
@@ -573,8 +593,13 @@ def _match_backward(softmax_op, pattern, ignored=()) -> bool:
         var = next_var
 
     pattern.back_layout_ops = list(reversed(back_ops))
-    # The op encountered first walking backwards is the one applied last.
-    pattern.mask_before_scale = order[:2] == ["scale", "mask"]
+    # `order` is in reverse execution order, so a modifier that appears *after*
+    # the scale in it is applied *before* the scale, and its contribution to
+    # `attn_mask` has to be scaled along (SDPA applies `attn_mask` last).
+    if "scale" in order:
+        scale_index = order.index("scale")
+        pattern.select_before_scale = "select" in order and order.index("select") > scale_index
+        pattern.add_before_scale = "add" in order and order.index("add") > scale_index
     return True
 
 
@@ -808,36 +833,70 @@ def _mask_to_sdpa_space(mask_var, space, softmax_shape, seq_len, before_op, name
 
 
 def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
-    """Build SDPA's ``attn_mask`` from the matched ``select`` / additive mask."""
-    softmax_op = pattern.softmax_op
-    mask_var = pattern.mask_var
-    # Peel the broadcast tile the converter emits for `select`; the compact
-    # condition is what we want to re-layout. A tile that replicates a dimension
-    # that is not 1 is a real tile, not a broadcast, and must be kept.
-    mask_var = _peel_broadcast_tile(mask_var)
+    """Build SDPA's ``attn_mask`` from the matched additive / ``select`` masks.
 
-    mask = _mask_to_sdpa_space(
-        mask_var, space, softmax_op.x.shape, seq_len, before_op, softmax_op.name + "_mask"
-    )
+    Either may be absent; when both are present the additive one is applied
+    first (the backward walk rejects the other order), so the block computes
+    ``select(cond, scores + bias, fill)`` and the equivalent single mask is
+    ``select(cond, bias, fill)``.
+    """
+    softmax_op = pattern.softmax_op
+
+    def to_sdpa_space(var, name):
+        # Peel the broadcast tile the converter emits; the compact operand is
+        # what we want to re-layout. A tile that replicates a dimension that is
+        # not 1 is a real tile, not a broadcast, and must be kept.
+        return _mask_to_sdpa_space(
+            _peel_broadcast_tile(var), space, softmax_op.x.shape, seq_len, before_op, name
+        )
+
+    bias = None
+    if pattern.add_var is not None:
+        bias = to_sdpa_space(pattern.add_var, softmax_op.name + "_bias")
+        if bias is None:
+            return None
+        if pattern.add_before_scale and pattern.scale is not None:
+            bias = mb.mul(
+                x=bias,
+                y=_np_scalar(float(pattern.scale), bias.dtype),
+                before_op=before_op,
+                name=softmax_op.name + "_bias_scaled",
+            )
+
+    if pattern.select_cond is None:
+        return bias
+
+    mask = to_sdpa_space(pattern.select_cond, softmax_op.name + "_mask")
     if mask is None:
         return None
 
-    if pattern.mask_kind == "add":
-        if pattern.mask_before_scale and pattern.scale is not None:
-            mask = mb.mul(
-                x=mask,
-                y=_np_scalar(float(pattern.scale), query.dtype),
-                before_op=before_op,
-                name=softmax_op.name + "_mask_scaled",
-            )
-        return mask
-
-    if pattern.mask_negated:
+    if pattern.select_negated:
         mask = mb.logical_not(x=mask, before_op=before_op, name=softmax_op.name + "_mask_not")
 
-    fill = float(pattern.mask_fill)
-    if pattern.mask_before_scale and pattern.scale is not None:
+    fill = float(pattern.select_fill)
+    if pattern.select_before_scale and pattern.scale is not None:
         fill *= float(pattern.scale)
+
+    if bias is not None:
+        # A boolean `attn_mask` cannot carry the bias too, so the two collapse
+        # into one float mask. `bool` mode asks for the -inf semantics.
+        if not math.isinf(fill) and finite_fill_mask == "bool":
+            fill = -math.inf
+        combined = mb.select(
+            cond=mask,
+            a=bias,
+            b=_np_scalar(fill, bias.dtype),
+            before_op=before_op,
+            name=softmax_op.name + "_mask_bias",
+        )
+        if combined.dtype != query.dtype:
+            combined = mb.cast(
+                x=combined,
+                dtype=types.builtin_to_string(query.dtype),
+                before_op=before_op,
+                name=softmax_op.name + "_mask_bias_cast",
+            )
+        return combined
 
     if math.isinf(fill) or finite_fill_mask == "bool":
         # A -inf fill and SDPA's boolean mask have identical semantics.
@@ -948,7 +1007,7 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
     seq_len = key.shape[-2]
 
     attn_mask = None
-    if pattern.mask_kind is not None:
+    if pattern.has_mask:
         attn_mask = _build_mask(pattern, space, matmul_1, seq_len, query, finite_fill_mask)
         if attn_mask is None:
             return False
@@ -1037,7 +1096,7 @@ def _fuse_attention_to_sdpa(block, finite_fill_mask: str) -> int:
 @register_pass(namespace="common")
 class fuse_attention_to_sdpa(AbstractGraphPass):
     """
-    Fuse ``matmul -> [scale] -> [mask] -> softmax -> matmul`` into
+    Fuse ``matmul -> [scale] -> [bias] -> [mask] -> softmax -> matmul`` into
     ``scaled_dot_product_attention``.
 
     Support options:

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -774,6 +774,77 @@ class TestAdditiveBiasAndSelectMask:
         assert _sdpa_ops(prog) == 0
 
 
+class TestShapeBounds:
+    """``max_head_dim`` / ``max_key_len`` opt a block out of the fusion by size.
+
+    A fused SDPA over global attention (large ``E``, long ``S``) is known to
+    break the ANE partitioner and the BNNS fp16 kernel; consumers targeting
+    those backends leave such sites decomposed.
+    """
+
+    @staticmethod
+    def _prog(key_len=S):
+        @mb.program(opset_version=ct.target.iOS18, input_specs=[
+            mb.TensorSpec(shape=(B, H, L, E)),
+            mb.TensorSpec(shape=(B, H, key_len, E)),
+            mb.TensorSpec(shape=(B, H, key_len, E)),
+        ])
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            weights = mb.softmax(x=scores, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        return prog
+
+    @pytest.mark.parametrize("option, fused_at, unfused_at", [
+        ("max_head_dim", E, E - 1),
+        ("max_key_len", S, S - 1),
+    ])
+    def test_bound_is_inclusive(self, option, fused_at, unfused_at):
+        prog = self._prog()
+        _apply(prog, **{option: fused_at})
+        assert _sdpa_ops(prog) == 1
+
+        prog = self._prog()
+        _apply(prog, **{option: unfused_at})
+        assert _sdpa_ops(prog) == 0
+        assert "softmax" in get_op_types_in_program(prog)
+
+    def test_bounds_accept_the_string_form_set_options_documents(self):
+        prog = self._prog()
+        _apply(prog, max_head_dim=str(E - 1))
+        assert _sdpa_ops(prog) == 0
+
+        prog = self._prog()
+        _apply(prog, max_head_dim="none", max_key_len="")
+        assert _sdpa_ops(prog) == 1
+
+    def test_symbolic_key_length_counts_as_too_long(self):
+        prog = self._prog(key_len=get_new_symbol())
+        _apply(prog, max_key_len=4096)
+        assert _sdpa_ops(prog) == 0
+
+        # ...but only when a bound is set; unbounded fuses as before.
+        prog = self._prog(key_len=get_new_symbol())
+        _apply(prog)
+        assert _sdpa_ops(prog) == 1
+
+    @pytest.mark.parametrize("value", [0, -1, "abc", 1.5])
+    def test_invalid_bound_is_rejected(self, value):
+        with pytest.raises(ValueError, match="max_key_len"):
+            _apply(self._prog(), max_key_len=value)
+
+    def test_options_do_not_leak_between_runs(self):
+        """The pass instance is a registry singleton; a bound set once must not stick."""
+        prog = self._prog()
+        _apply(prog, max_key_len=S - 1)
+        assert _sdpa_ops(prog) == 0
+
+        prog = self._prog()
+        _apply(prog)
+        assert _sdpa_ops(prog) == 1
+
+
 class TestUnitQueryLength:
     """The autoregressive decode step: a single query row.
 

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -85,9 +85,11 @@ def _predict(prog, **inputs):
     return np.array(next(iter(result.values())))
 
 
-def _reference_attention(q, k, v, mask=None, fill=-1e9):
-    """``softmax(q @ k^T [+ mask]) @ v`` in numpy, over the last two axes."""
+def _reference_attention(q, k, v, mask=None, fill=-1e9, bias=None):
+    """``softmax(where(mask, q @ k^T [+ bias], fill)) @ v``, over the last two axes."""
     scores = np.matmul(q, np.swapaxes(k, -2, -1))
+    if bias is not None:
+        scores = scores + bias
     if mask is not None:
         scores = np.where(mask, scores, np.float32(fill))
     scores = scores - scores.max(axis=-1, keepdims=True)
@@ -579,6 +581,197 @@ class TestFuseAttentionToSdpa:
         ops_after_first = get_op_types_in_program(prog)
         _apply(prog)
         assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestAdditiveBiasAndSelectMask:
+    """``select(cond, scores + bias, fill)``: both masks at once.
+
+    ``jax.nn.dot_product_attention`` -- and therefore ``flax.nnx``, which calls
+    it -- adds the ``bias`` to the logits and *then* applies ``mask`` as a
+    ``where`` against a large negative fill. SDPA has a single ``attn_mask``, so
+    the two have to collapse into ``select(cond, bias, fill)``.
+    """
+
+    @staticmethod
+    def _prog(fill=NEG_INF, mask_shape=(B, 1, 1, S)):
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[
+                *_qkv_specs(),
+                mb.TensorSpec(shape=(B, 1, L, S)),
+                mb.TensorSpec(shape=mask_shape, dtype=types.bool),
+            ],
+        )
+        def prog(q, k, v, bias, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            biased = mb.add(x=scaled, y=bias)
+            masked = mb.select(cond=mask, a=biased, b=fill)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        return prog
+
+    def test_bias_and_neg_inf_mask_collapse_into_one_float_mask(self):
+        prog = self._prog()
+        _apply(prog)
+
+        assert get_op_types_in_program(prog) == ["select", "scaled_dot_product_attention"]
+        select = next(op for op in _ops(prog) if op.op_type == "select")
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert select.cond is prog.functions["main"].inputs["mask"]
+        assert select.a is prog.functions["main"].inputs["bias"]
+        assert math.isinf(float(select.b.val)) and float(select.b.val) < 0
+        assert sdpa.attn_mask is select.outputs[0]
+        assert sdpa.attn_mask.dtype == types.fp32
+        assert_model_is_valid(
+            prog,
+            {"q": (B, H, L, E), "k": (B, H, S, E), "v": (B, H, S, E),
+             "bias": (B, 1, L, S), "mask": (B, 1, 1, S)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_bias_and_finite_fill_keep_the_finite_fill(self):
+        """A finite fill leaves a fully masked row finite; do not turn it to -inf."""
+        prog = self._prog(fill=TORCH_MIN_FILL)
+        _apply(prog)
+
+        assert get_op_types_in_program(prog) == ["select", "scaled_dot_product_attention"]
+        select = next(op for op in _ops(prog) if op.op_type == "select")
+        np.testing.assert_allclose(select.b.val, TORCH_MIN_FILL, rtol=1e-6)
+
+    def test_bias_and_finite_fill_with_the_bool_option_masks_with_neg_inf(self):
+        """``finite_fill_mask='bool'`` asks for -inf semantics, float mask or not."""
+        prog = self._prog(fill=TORCH_MIN_FILL)
+        _apply(prog, finite_fill_mask="bool")
+
+        assert get_op_types_in_program(prog) == ["select", "scaled_dot_product_attention"]
+        select = next(op for op in _ops(prog) if op.op_type == "select")
+        assert math.isinf(float(select.b.val))
+
+    def test_negated_mask_with_a_bias(self):
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[
+                *_qkv_specs(),
+                mb.TensorSpec(shape=(B, 1, L, S)),
+                mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool),
+            ],
+        )
+        def prog(q, k, v, bias, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float32(1.0 / math.sqrt(E)))
+            biased = mb.add(x=scaled, y=bias)
+            masked = mb.select(cond=mask, a=NEG_INF, b=biased)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog)
+        assert ops == ["logical_not", "select", "scaled_dot_product_attention"]
+
+    def test_a_scale_between_the_bias_and_the_mask_scales_only_the_bias(self):
+        """``(scores + bias) * c`` then mask: SDPA applies attn_mask after the scale."""
+        scale = np.float32(0.25)
+
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[
+                *_qkv_specs(),
+                mb.TensorSpec(shape=(B, 1, L, S)),
+                mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool),
+            ],
+        )
+        def prog(q, k, v, bias, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=scores, y=bias)
+            scaled = mb.mul(x=biased, y=scale)
+            masked = mb.select(cond=mask, a=scaled, b=FINITE_FILL)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        ops = _ops(prog)
+        assert get_op_types_in_program(prog).count("scaled_dot_product_attention") == 1
+        bias_scale = next(op for op in ops if op.op_type == "mul" and op.x.op is None)
+        np.testing.assert_allclose(bias_scale.y.val, scale, rtol=1e-6)
+        # The mask runs after the scale, so its fill stays as it is.
+        select = next(op for op in ops if op.op_type == "select")
+        np.testing.assert_allclose(select.b.val, FINITE_FILL, rtol=1e-6)
+
+    def test_keeps_the_original_numerics(self):
+        prog = self._prog(fill=NEG_INF, mask_shape=(B, 1, L, S))
+        _apply(prog)
+        assert get_op_types_in_program(prog).count("scaled_dot_product_attention") == 1
+
+        rng = np.random.RandomState(0)
+        q = rng.randn(B, H, L, E).astype(np.float32)
+        k = rng.randn(B, H, S, E).astype(np.float32)
+        v = rng.randn(B, H, S, E).astype(np.float32)
+        bias = rng.randn(B, 1, L, S).astype(np.float32)
+        # Every row keeps at least one key, so -inf never produces a NaN row.
+        mask = (np.arange(S) < S - 2).reshape(1, 1, 1, S) & np.ones((B, 1, L, S), dtype=bool)
+
+        # The program scales the scores before adding the bias.
+        expected = _reference_attention(
+            q / math.sqrt(E), k, v, mask=mask, fill=-np.inf, bias=bias
+        )
+        # Core ML has no boolean model input; it exposes the mask as fp32.
+        got = _predict(prog, q=q, k=k, v=v, bias=bias, mask=mask.astype(np.float32))
+        np.testing.assert_allclose(got, expected, atol=1e-4, rtol=1e-4)
+
+    def test_a_bias_applied_after_the_mask_is_not_fused(self):
+        """``where(cond, scores, fill) + bias`` also shifts the fill; stay away."""
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[
+                *_qkv_specs(),
+                mb.TensorSpec(shape=(B, 1, L, S)),
+                mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool),
+            ],
+        )
+        def prog(q, k, v, bias, mask):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            masked = mb.select(cond=mask, a=scores, b=FINITE_FILL)
+            biased = mb.add(x=masked, y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_two_additive_masks_are_not_fused(self):
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, L, S)),
+                         mb.TensorSpec(shape=(B, 1, L, S))],
+        )
+        def prog(q, k, v, bias_0, bias_1):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            biased = mb.add(x=mb.add(x=scores, y=bias_0), y=bias_1)
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
+
+    def test_two_select_masks_are_not_fused(self):
+        @mb.program(
+            opset_version=ct.target.iOS18,
+            input_specs=[*_qkv_specs(),
+                         mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool),
+                         mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],
+        )
+        def prog(q, k, v, mask_0, mask_1):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            masked = mb.select(cond=mask_0, a=scores, b=NEG_INF)
+            masked = mb.select(cond=mask_1, a=masked, b=NEG_INF)
+            weights = mb.softmax(x=masked, axis=-1)
+            return mb.matmul(x=weights, y=v, transpose_y=False)
+
+        _apply(prog)
+        assert _sdpa_ops(prog) == 0
 
 
 class TestUnitQueryLength:
@@ -1111,23 +1304,266 @@ class TestFuseAttentionToSdpaEndToEnd:
         cml_model = run_and_compare_specific_input(attention, [q, k, v, mask])
         self._assert_fused(cml_model)
 
+
+def _f32(*shape):
+    return jax.ShapeDtypeStruct(shape, jnp.float32)
+
+
+def _bool(*shape):
+    return jax.ShapeDtypeStruct(shape, jnp.bool_)
+
+
+class TestLibraryAttentionEndToEnd:
+    """The attention the real libraries write, not just the spelling we picked.
+
+    Every case goes through the converter and the full pass pipeline and has to
+    come out as a single ``scaled_dot_product_attention``; ``run_and_compare``
+    checks the numerics against JAX along the way.
+    """
+
+    @staticmethod
+    def _assert_fused(cml_model, expected: int = 1):
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_dot_product_attention") == expected
+        assert "softmax" not in ops
+        return ops
+
+    # -- jax.nn.dot_product_attention ---------------------------------------
+
+    def test_jax_dot_product_attention(self):
+        def attention(q, k, v):
+            return jax.nn.dot_product_attention(q, k, v, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4),
+        ]))
+
+    def test_jax_dot_product_attention_with_mask(self):
+        def attention(q, k, v, mask):
+            return jax.nn.dot_product_attention(q, k, v, mask=mask, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4), _bool(2, 1, 5, 7),
+        ]))
+
+    def test_jax_dot_product_attention_is_causal(self):
+        def attention(q, k, v):
+            return jax.nn.dot_product_attention(q, k, v, is_causal=True, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 5, 3, 4), _f32(2, 5, 3, 4),
+        ]))
+
+    def test_jax_dot_product_attention_grouped_query(self):
+        """Six query heads over three key/value heads.
+
+        ``_dot_product_attention_xla`` vmaps its core over the group axis, so the
+        scores gain an extra axis that the layout tracking has to see through.
+        """
+        def attention(q, k, v):
+            return jax.nn.dot_product_attention(q, k, v, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 6, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4),
+        ]))
+
+    def test_jax_dot_product_attention_decode_step(self):
+        def attention(q, k, v):
+            return jax.nn.dot_product_attention(q, k, v, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(1, 1, 3, 4), _f32(1, 7, 3, 4), _f32(1, 7, 3, 4),
+        ]))
+
+    def test_jax_dot_product_attention_with_bias(self):
+        def attention(q, k, v, bias):
+            return jax.nn.dot_product_attention(q, k, v, bias=bias, implementation="xla")
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4), _f32(2, 3, 5, 7),
+        ]))
+
+    def test_jax_dot_product_attention_with_bias_and_mask(self):
+        """``logits + bias`` and then ``where(mask, logits, big_neg)``: two masks."""
+        def attention(q, k, v, bias, mask):
+            return jax.nn.dot_product_attention(
+                q, k, v, bias=bias, mask=mask, implementation="xla"
+            )
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4),
+            _f32(2, 3, 5, 7), _bool(2, 1, 5, 7),
+        ]))
+
+    def test_jax_dot_product_attention_with_bias_and_causal_mask(self):
+        def attention(q, k, v, bias):
+            return jax.nn.dot_product_attention(
+                q, k, v, bias=bias, is_causal=True, implementation="xla"
+            )
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 5, 3, 4), _f32(2, 5, 3, 4), _f32(2, 3, 5, 5),
+        ]))
+
+    def test_jax_dot_product_attention_grouped_query_with_bias_and_mask(self):
+        def attention(q, k, v, bias, mask):
+            return jax.nn.dot_product_attention(
+                q, k, v, bias=bias, mask=mask, implementation="xla"
+            )
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 6, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4),
+            _f32(2, 6, 5, 7), _bool(2, 1, 5, 7),
+        ]))
+
+    # -- flax.nnx ------------------------------------------------------------
+
+    @staticmethod
+    def _flax_fn(layer, call):
+        """A plain JAX function around ``layer``, with its state at trace level."""
+        from flax import nnx  # noqa: PLC0415
+
+        graphdef, state = nnx.split(layer)
+
+        def fn(*args):
+            merged = nnx.merge(graphdef, jax.tree.map(lambda leaf: leaf, state))
+            return call(merged, *args)
+
+        return fn
+
     def test_flax_multi_head_attention(self):
         from flax import nnx  # noqa: PLC0415
 
-        class Attention(nnx.Module):
-            def __init__(self, rngs):
-                self.layer = nnx.MultiHeadAttention(
-                    num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=rngs
-                )
-
-            def __call__(self, q, k, v):
-                return self.layer(q, k, v)
-
-        shape = (4, 3, 2, 5)
-        cml_model = run_and_compare(
-            nnx.jit(Attention(nnx.Rngs(0))),
-            (jnp.zeros(shape), jnp.zeros(shape), jnp.zeros(shape)),
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=nnx.Rngs(0)
         )
-        ops = get_model_instruction_types(cml_model)
-        assert ops.count("scaled_dot_product_attention") == 1
-        assert "softmax" not in ops
+        fn = self._flax_fn(layer, lambda m, q, k, v: m(q, k, v))
+        self._assert_fused(run_and_compare(fn, [
+            _f32(4, 3, 2, 5), _f32(4, 3, 2, 5), _f32(4, 3, 2, 5),
+        ]))
+
+    def test_flax_multi_head_attention_with_mask(self):
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=nnx.Rngs(0)
+        )
+        fn = self._flax_fn(layer, lambda m, q, k, v, mask: m(q, k, v, mask=mask))
+        self._assert_fused(run_and_compare(fn, [
+            _f32(2, 6, 5), _f32(2, 7, 5), _f32(2, 7, 5), _bool(2, 1, 6, 7),
+        ]))
+
+    def test_flax_multi_head_attention_is_causal(self):
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=nnx.Rngs(0)
+        )
+        fn = self._flax_fn(layer, lambda m, x: m(x, x, x, is_causal=True))
+        self._assert_fused(run_and_compare(fn, [_f32(2, 6, 5)]))
+
+    def test_flax_multi_head_attention_grouped_query(self):
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, num_kv_heads=2, in_features=8, qkv_features=16,
+            decode=False, rngs=nnx.Rngs(0),
+        )
+        fn = self._flax_fn(layer, lambda m, q, k, v: m(q, k, v))
+        self._assert_fused(run_and_compare(fn, [
+            _f32(2, 6, 8), _f32(2, 7, 8), _f32(2, 7, 8),
+        ]))
+
+    def test_flax_multi_head_attention_single_query(self):
+        """A ``(1, 1, D)`` query: the autoregressive decode shape."""
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=False, rngs=nnx.Rngs(0)
+        )
+        fn = self._flax_fn(layer, lambda m, q, k, v, mask: m(q, k, v, mask=mask))
+        self._assert_fused(run_and_compare(fn, [
+            _f32(1, 1, 5), _f32(1, 7, 5), _f32(1, 7, 5), _bool(1, 1, 1, 7),
+        ]))
+
+    def test_flax_multi_head_attention_decode_step(self):
+        """``decode=True``: one token against the KV cache, masked by the cache index."""
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=True, rngs=nnx.Rngs(0)
+        )
+        layer.init_cache((1, 1, 5))
+        fn = self._flax_fn(layer, lambda m, x: m(x, x, x))
+        self._assert_fused(run_and_compare(fn, [_f32(1, 1, 5)]))
+
+    def test_flax_multi_head_attention_with_dropout_configured(self):
+        """A non-zero ``dropout_rate`` takes flax's own attention implementation
+        instead of ``jax.nn.dot_product_attention``: it folds the ``1/sqrt(E)``
+        into the query and contracts with a different einsum."""
+        from flax import nnx  # noqa: PLC0415
+
+        layer = nnx.MultiHeadAttention(
+            num_heads=4, in_features=5, qkv_features=16, decode=False,
+            dropout_rate=0.1, deterministic=True, rngs=nnx.Rngs(0),
+        )
+        fn = self._flax_fn(layer, lambda m, q, k, v, mask: m(q, k, v, mask=mask))
+        self._assert_fused(run_and_compare(fn, [
+            _f32(2, 6, 5), _f32(2, 7, 5), _f32(2, 7, 5), _bool(2, 1, 6, 7),
+        ]))
+
+    def test_flax_dot_product_attention_with_bias_and_mask(self):
+        from flax import nnx  # noqa: PLC0415
+
+        def attention(q, k, v, bias, mask):
+            return nnx.dot_product_attention(q, k, v, bias=bias, mask=mask)
+
+        self._assert_fused(run_and_compare(attention, [
+            _f32(2, 5, 3, 4), _f32(2, 7, 3, 4), _f32(2, 7, 3, 4),
+            _f32(2, 3, 5, 7), _bool(2, 1, 5, 7),
+        ]))
+
+    # -- equinox -------------------------------------------------------------
+
+    @staticmethod
+    def _equinox_fn(model):
+        import equinox as eqx  # noqa: PLC0415
+        import equinox.internal as eqxi  # noqa: PLC0415
+
+        return eqxi.finalise_fn(eqx.nn.inference_mode(model))
+
+    def test_equinox_multihead_attention(self):
+        import equinox as eqx  # noqa: PLC0415
+
+        layer = eqx.nn.MultiheadAttention(
+            num_heads=4, query_size=24, key=jax.random.PRNGKey(0)
+        )
+        model = self._equinox_fn(jax.vmap(lambda q, k, v: layer(q, k, v)))
+        self._assert_fused(run_and_compare(model, [
+            _f32(2, 6, 24), _f32(2, 7, 24), _f32(2, 7, 24),
+        ]))
+
+    def test_equinox_multihead_attention_with_mask(self):
+        """Equinox masks with ``finfo(dtype).min``: a large but finite fill."""
+        import equinox as eqx  # noqa: PLC0415
+
+        layer = eqx.nn.MultiheadAttention(
+            num_heads=4, query_size=24, key=jax.random.PRNGKey(0)
+        )
+        model = self._equinox_fn(
+            jax.vmap(lambda q, k, v, mask: layer(q, k, v, mask=mask))
+        )
+        self._assert_fused(run_and_compare(model, [
+            _f32(2, 6, 24), _f32(2, 7, 24), _f32(2, 7, 24), _bool(2, 4, 6, 7),
+        ]))
+
+    def test_equinox_multihead_attention_single_query(self):
+        import equinox as eqx  # noqa: PLC0415
+
+        layer = eqx.nn.MultiheadAttention(
+            num_heads=4, query_size=24, key=jax.random.PRNGKey(0)
+        )
+        model = self._equinox_fn(jax.vmap(lambda q, k, v: layer(q, k, v)))
+        self._assert_fused(run_and_compare(model, [
+            _f32(1, 1, 24), _f32(1, 7, 24), _f32(1, 7, 24),
+        ]))


### PR DESCRIPTION
## Problem

I audited `fuse_attention_to_sdpa` against the attention the real libraries write, rather than the hand-written idiom the tests spell. Almost everything fuses already — `jax.nn.dot_product_attention` (plain, mask, `is_causal`, grouped-query, decode step, sliding window, `query_seq_lengths`, custom `scale`), `flax.nnx.MultiHeadAttention` (plain, mask, causal, GQA, `(1, 1, D)` single query, `decode=True` against the KV cache, extra batch axes, and the separate implementation a non-zero `dropout_rate` selects), and `equinox.nn.MultiheadAttention` (batched, unbatched, masked, per-head mask, single query, differing key/value/output sizes) all come out as one `scaled_dot_product_attention`.

One combination did not: **an additive bias next to a mask**. `jax.nn.dot_product_attention(q, k, v, bias=..., mask=...)` — and `flax.nnx.dot_product_attention`, which forwards both arguments straight to it — was never fused. Same for `bias=...` together with `is_causal=True`.

## Root cause

`_match_backward` allowed exactly one score modifier between `matmul_0` and the softmax: both the `select` arm and the `add` arm were guarded on `pattern.mask_kind is None`, so whichever the backward walk met first claimed the single slot and the second one fell through to the `else: return False`.

`_dot_product_attention_core` computes `logits + bias` and then `_apply_masks` does `where(combined_mask, logits, big_neg)`, i.e. exactly two modifiers. `jax.nn.dot_product_attention(q, k, v, bias, mask)` on `[2, 5, 3, 4] × [2, 7, 3, 4]` converts to (main):

```
%matmul_0: (2, 3, 5, 7, fp32) = matmul(x=%reshape_8, y=%transpose_1, transpose_y=True)
%reshape_9: (2, 3, 5, 1, 7, fp32) = reshape(x=%matmul_0, shape=[2, 3, 5, 1, 7])
%mul_0:     (2, 3, 5, 1, 7, fp32) = mul(x=%reshape_9, y=[[[[[0.5]]]]])
%add_0:     (1, 2, 3, 5, 7, fp32) = add(x=%transpose_14, y=%transpose_15)         <- bias
%logical_and_0: (1, 2, 3, 5, 7, bool) = logical_and(x=%reshape_12, y=%transpose_4)
%select_0:  (1, 2, 3, 5, 7, fp32) = select(cond=%logical_and_0, a=%add_0, b=%reshape_14)   <- mask
%real_div_0_softmax: (1, 2, 3, 5, 7, fp32) = softmax(x=%select_0, axis=4)
%matmul_1:  (2, 3, 4, 5, fp32) = matmul(x=%transpose_5, y=%reshape_18, transpose_y=True)
```

The walk matches `select_0`, sets `mask_kind = "select"`, then reaches `add_0`, finds `mask_kind` already set and gives up — leaving the softmax and both matmuls in the program.

## Fix

Track the two modifiers separately (`add_var` / `select_cond`), each with its own `before_scale` flag, because a scale may sit anywhere between them and SDPA applies `attn_mask` *after* its own scaling. When both are present they collapse into SDPA's single `attn_mask`: `select(cond, scores + bias, fill)` is `softmax(scores + select(cond, bias, fill))`. That is exact for a `-inf` fill, and for a finite fill it is the same approximation the pass already makes for a lone finite-fill `select` (the huge fill swallows the score). `finite_fill_mask="bool"` keeps its meaning by masking with `-inf`, which is what a boolean `attn_mask` means.

The matcher stays conservative and still refuses anything it cannot reproduce exactly enough:

- a bias applied *after* the mask (`where(cond, scores, fill) + bias`) shifts the fill as well — rejected;
- two additive masks, and two `select` masks — rejected (no library under test emits either; `jax` and `flax` combine boolean masks with `logical_and` first, so they arrive as a single `select`);
- `_safe_softmax_is_redundant` now requires *every* matched modifier to be provably free of `-inf`, instead of inspecting a single one.

The single-mask paths are byte-for-byte unchanged; the `before_scale` bookkeeping reduces to the old `order[:2] == ["scale", "mask"]` test when there is only one modifier.

## Opting sites out (follow-up to the downstream comment below)

Since this makes the pass fire on strictly more patterns, and a fused SDPA over global attention (large head dim, long key length) has been reported to break the ANE partitioner and the BNNS fp16 kernel on macOS 26.x / coremltools 9.0, the pass now takes two bounds so a consumer can keep the sliding-window sites fused and leave the global ones decomposed:

```python
pipeline = build_pass_pipeline()
pipeline.set_options("common::fuse_attention_to_sdpa", {"max_head_dim": 128, "max_key_len": 4096})
```

`None` (the default) fuses everything; a symbolic dimension counts as exceeding a set bound. Documented in the pass docstring; `TestShapeBounds` covers the inclusive bound, the string form, symbolic shapes, invalid values and that options do not stick on the registry singleton.

## Tests

`TestAdditiveBiasAndSelectMask` (hand-built MIL, house style): the emitted `select` mask for a `-inf` fill (plus `assert_model_is_valid`), a finite fill kept finite, the `bool` option masking with `-inf`, a negated condition, a scale sitting between the bias and the mask scaling only the bias, a `_predict` numerics check against the unfused numpy reference, and the three rejected orders.

`TestLibraryAttentionEndToEnd` converts real library code through the converter and the full pass pipeline (`run_and_compare` checks numerics against JAX) and asserts one `scaled_dot_product_attention` with no leftover softmax:

- `jax.nn.dot_product_attention`: plain, mask, `is_causal`, grouped-query, decode step, bias, **bias + mask**, **bias + causal**, **GQA + bias + mask**
- `flax.nnx.MultiHeadAttention`: plain, mask, `is_causal`, grouped-query, `(1, 1, D)` query, `decode=True` against the KV cache, non-zero `dropout_rate` (flax's own implementation, which folds `1/sqrt(E)` into the query and uses a different einsum)
- `flax.nnx.dot_product_attention` with **bias and mask**
- `equinox.nn.MultiheadAttention`: plain, masked (`finfo(dtype).min` fill), single query

Ten of those fail on `main`:

```
FAILED TestLibraryAttentionEndToEnd::test_jax_dot_product_attention_with_bias_and_mask
FAILED TestLibraryAttentionEndToEnd::test_jax_dot_product_attention_with_bias_and_causal_mask
FAILED TestLibraryAttentionEndToEnd::test_jax_dot_product_attention_grouped_query_with_bias_and_mask
FAILED TestLibraryAttentionEndToEnd::test_flax_dot_product_attention_with_bias_and_mask
FAILED TestAdditiveBiasAndSelectMask::test_bias_and_neg_inf_mask_collapse_into_one_float_mask
FAILED TestAdditiveBiasAndSelectMask::test_bias_and_finite_fill_keep_the_finite_fill
FAILED TestAdditiveBiasAndSelectMask::test_bias_and_finite_fill_with_the_bool_option_masks_with_neg_inf
FAILED TestAdditiveBiasAndSelectMask::test_negated_mask_with_a_bias
FAILED TestAdditiveBiasAndSelectMask::test_a_scale_between_the_bias_and_the_mask_scales_only_the_bias
FAILED TestAdditiveBiasAndSelectMask::test_keeps_the_original_numerics
```

The rest were verified to fuse before this change and are added so the suite demonstrates library coverage rather than a single spelling.

## Verification

`pytest tests/` — 462 passed, 1 skipped (`tests/pytorch`, which needs `torch`/`torchax`/`transformers`, is skipped in this environment). `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E