### PR TITLE
Fuse the tanh-approximated GELU that jax.nn.gelu emits by default

### DIFF
--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -25,7 +25,12 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import sole_consumer, uniform_const_operand, uniform_scalar_value
+from .pattern_utils import (
+    peel_to_scaled_input,
+    sole_consumer,
+    uniform_const_operand,
+    uniform_scalar_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,11 +42,6 @@ _FACTOR = -1.0 / math.sqrt(2.0)
 # Wide enough for fp16 rounding, but not for merely GELU-like formulae.
 _FACTOR_TOLERANCE = 1e-4
 
-# Upper bound on the number of scaling/negation ops peeled off the erf argument.
-# The converter emits at most two (a negate and a multiply); the bound just keeps
-# the search finite for hand-written graphs.
-_MAX_PEEL_DEPTH = 8
-
 
 def _other_operand(op, var):
     """The operand of the binary ``op`` that is not ``var`` (``None`` if ``var`` is not one)."""
@@ -50,62 +50,6 @@ def _other_operand(op, var):
     if op.y is var:
         return op.x
     return None
-
-
-def _const_scaled_operand(op):
-    """Split a ``mul``/``real_div``/``sub`` op into ``(input_var, factor)``.
-
-    Recognises the ops that scale or negate a value by a compile-time constant:
-    ``mul(v, c)``/``mul(c, v)`` -> ``(v, c)``, ``real_div(v, c)`` -> ``(v, 1/c)``
-    and the negation ``sub(0, v)`` -> ``(v, -1)``. Returns ``None`` otherwise.
-    """
-    if op.op_type == "mul":
-        scaled = uniform_const_operand(op)
-        if scaled is None:
-            return None
-        factor, operand = scaled
-        return operand, factor
-
-    if op.op_type == "real_div":
-        divisor = uniform_scalar_value(op.y)
-        if divisor is not None and divisor != 0.0:
-            return op.x, 1.0 / divisor
-        return None
-
-    if op.op_type == "sub":
-        lhs = uniform_scalar_value(op.x)
-        if lhs is not None and abs(lhs) < 1e-12:
-            return op.y, -1.0
-        return None
-
-    return None
-
-
-def _peel_to_scaled_input(var, block):
-    """Walk back over constant scalings/negations, returning ``[(var, factor), ...]``.
-
-    The first entry is ``(var, 1.0)`` itself, then every prefix of the chain with
-    the accumulated factor: ``arg == entry_var * factor``.
-    """
-    chain = [(var, 1.0)]
-    factor = 1.0
-    current = var
-    for _ in range(_MAX_PEEL_DEPTH):
-        op = current.op
-        if op is None or op.enclosing_block is not block:
-            break
-        if sole_consumer(current) is None:
-            # The intermediate value is used elsewhere; peeling further would
-            # leave the op in the graph anyway, and the rewrite must not change
-            # what that other consumer sees.
-            break
-        split = _const_scaled_operand(op)
-        if split is None:
-            break
-        current, step = split
-        factor *= step
-        chain.append((current, factor))
-    return chain
 
 
 def _match_half_x(var, x, block) -> bool:
@@ -151,7 +95,7 @@ def _match(mul_op, block):
         if sole_consumer(half_var) is not mul_op:
             continue
 
-        for candidate, factor in _peel_to_scaled_input(erf_op.x, block):
+        for candidate, factor in peel_to_scaled_input(erf_op.x, block):
             if abs(factor - _FACTOR) > _FACTOR_TOLERANCE:
                 continue
             if not _match_half_x(half_var, candidate, block):

--- a/stablehlo_coreml/passes/fuse_gelu_tanh.py
+++ b/stablehlo_coreml/passes/fuse_gelu_tanh.py
@@ -1,0 +1,235 @@
+"""MIL pass: fuse JAX's ``tanh``-approximated GELU into ``gelu(mode="TANH_APPROXIMATION")``.
+
+``jax.nn.gelu(x)`` -- ``approximate=True`` is the *default*, so this is what
+``flax.nnx.gelu`` and every ``equinox`` MLP with a GELU activation trace to --
+is written as ``x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x**3)))``,
+which the converter lowers to::
+
+    %1 = mul(x=%x, y=%x)
+    %2 = mul(x=%1, y=%x)              # x**3, spelled as two multiplications
+    %3 = mul(x=0.044715, y=%2)
+    %4 = add(x=%x, y=%3)
+    %5 = mul(x=0.7978845834732056, y=%4)
+    %6 = tanh(x=%5)
+    %7 = add(x=1.0, y=%6)
+    %8 = mul(x=0.5, y=%7)
+    %9 = mul(x=%x, y=%8)
+
+coremltools has a pass for this shape, ``fuse_gelu_tanh_approximation``, but it
+insists on a literal ``pow(x, 3)`` while JAX emits the ``x * x * x`` chain
+above, so nine elementwise ops over the activation tensor survived into every
+converted model. This pass recognises both spellings of the cube.
+
+The coefficients are recovered by peeling constant scalings, so the
+associativity does not matter: ``x * (0.5 * (1 + tanh(t)))`` and
+``(0.5 * x) * (1 + tanh(t))`` are both matched, as is a ``tanh`` argument
+written in distributed form (``k*x + k*a*x**3``) rather than factored.
+"""
+
+import logging
+import math
+
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+
+from .pattern_utils import (
+    dtype_epsilon,
+    peel_to_scaled_input,
+    sole_consumer,
+    uniform_const_operand,
+    uniform_scalar_value,
+)
+
+logger = logging.getLogger(__name__)
+
+# The coefficients of the tanh approximation, as the paper writes them.
+_SQRT_2_OVER_PI = math.sqrt(2.0 / math.pi)
+_CUBE_COEFFICIENT = 0.044715
+# Coefficient of `x**3` inside the tanh once the outer factor is distributed.
+_CUBIC_TERM = _SQRT_2_OVER_PI * _CUBE_COEFFICIENT
+
+# Relative tolerance on every coefficient of the pattern. Tight enough to reject
+# a merely GELU-shaped formula, loose enough for a constant that was rounded to
+# fp32 -- `_tolerance` widens it further for narrower element types.
+_RELATIVE_TOLERANCE = 1e-4
+# How many ulps of the operand type a coefficient may be off. The literals reach
+# MIL already rounded to that type, and the matcher multiplies two of them
+# together, so the error compounds.
+_TOLERANCE_ULPS = 8.0
+
+
+def _tolerance(var) -> float:
+    """Relative tolerance on the coefficients, for a pattern computed in ``var``'s type."""
+    return max(_RELATIVE_TOLERANCE, _TOLERANCE_ULPS * dtype_epsilon(var))
+
+
+def _close(value: float, expected: float, tolerance: float) -> bool:
+    return abs(value - expected) <= tolerance * abs(expected)
+
+
+def _square_input(var, block):
+    """Return ``v`` if ``var`` is ``mul(v, v)``, else ``None``."""
+    op = getattr(var, "op", None)
+    if op is None or op.op_type != "mul" or op.enclosing_block is not block:
+        return None
+    return op.x if op.x is op.y else None
+
+
+def _cube_input(var, block):
+    """Return ``v`` if ``var`` is ``v ** 3``, else ``None``.
+
+    Both ``pow(v, 3)`` and the ``mul(mul(v, v), v)`` chain JAX emits are
+    recognised; in the latter case the square must not be observed elsewhere.
+    """
+    op = getattr(var, "op", None)
+    if op is None or op.enclosing_block is not block:
+        return None
+
+    if op.op_type == "pow":
+        exponent = uniform_scalar_value(op.y)
+        if exponent is not None and exponent == 3.0:
+            return op.x
+        return None
+
+    if op.op_type != "mul":
+        return None
+    for square, base in ((op.x, op.y), (op.y, op.x)):
+        if _square_input(square, block) is base and sole_consumer(square) is op:
+            return base
+    return None
+
+
+def _match_tanh_argument(arg, block, tolerance):
+    """Return ``x`` if ``arg`` is ``sqrt(2/pi) * (x + 0.044715 * x**3)``, else ``None``."""
+    for inner, outer_factor in peel_to_scaled_input(arg, block):
+        add_op = getattr(inner, "op", None)
+        if add_op is None or add_op.op_type != "add" or add_op.enclosing_block is not block:
+            continue
+
+        for linear_var, cubic_var in ((add_op.x, add_op.y), (add_op.y, add_op.x)):
+            if linear_var is cubic_var:
+                continue
+            if sole_consumer(cubic_var) is not add_op:
+                continue
+
+            for cube_var, cube_factor in peel_to_scaled_input(cubic_var, block):
+                x = _cube_input(cube_var, block)
+                if x is None:
+                    continue
+                if not _close(outer_factor * cube_factor, _CUBIC_TERM, tolerance):
+                    continue
+                for linear_base, linear_factor in peel_to_scaled_input(linear_var, block):
+                    if linear_base is not x:
+                        continue
+                    if _close(outer_factor * linear_factor, _SQRT_2_OVER_PI, tolerance):
+                        return x
+    return None
+
+
+def _match(mul_op, block):
+    """Return ``x`` if ``mul_op`` computes the tanh-approximated GELU of ``x``."""
+    if mul_op.op_type != "mul":
+        return None
+    tolerance = _tolerance(mul_op.outputs[0])
+
+    for cdf_var, scale_var in ((mul_op.x, mul_op.y), (mul_op.y, mul_op.x)):
+        if cdf_var is scale_var:
+            continue
+        if sole_consumer(cdf_var) is not mul_op:
+            continue
+
+        for sum_var, cdf_factor in peel_to_scaled_input(cdf_var, block):
+            add_op = getattr(sum_var, "op", None)
+            if add_op is None or add_op.op_type != "add" or add_op.enclosing_block is not block:
+                continue
+            operand = uniform_const_operand(add_op)
+            if operand is None:
+                continue
+            one, tanh_var = operand
+            if not _close(one, 1.0, tolerance):
+                continue
+
+            tanh_op = getattr(tanh_var, "op", None)
+            if tanh_op is None or tanh_op.op_type != "tanh":
+                continue
+            if tanh_op.enclosing_block is not block:
+                continue
+            if sole_consumer(tanh_var) is not add_op:
+                continue
+
+            x = _match_tanh_argument(tanh_op.x, block, tolerance)
+            if x is None:
+                continue
+
+            # What is left of the product must be `0.5 * x`.
+            for base, factor in peel_to_scaled_input(scale_var, block):
+                if base is x and _close(factor * cdf_factor, 0.5, tolerance):
+                    return x
+
+    return None
+
+
+@block_context_manager
+def _fuse_gelu_tanh(block) -> int:
+    fused = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            fused += _fuse_gelu_tanh(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        x = _match(op, block)
+        if x is None:
+            continue
+
+        gelu = mb.gelu(x=x, mode="TANH_APPROXIMATION", before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
+        fused += 1
+
+    return fused
+
+
+@register_pass(namespace="common")
+class fuse_gelu_tanh(AbstractGraphPass):
+    """
+    Fuse ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x**3)))`` into
+    ``gelu(x, mode="TANH_APPROXIMATION")``.
+
+    This is the default spelling of ``jax.nn.gelu`` (and therefore of
+    ``flax.nnx.gelu``). coremltools' ``fuse_gelu_tanh_approximation`` covers the
+    same formula but requires the cube to be a literal ``pow(x, 3)``, which is
+    not what JAX emits.
+
+    Given:
+        %1 = mul(x=%0, y=%0)
+        %2 = mul(x=%1, y=%0)
+        %3 = mul(x=0.044715, y=%2)
+        %4 = add(x=%0, y=%3)
+        %5 = mul(x=0.7978845834732056, y=%4)
+        %6 = tanh(x=%5)
+        %7 = add(x=1.0, y=%6)
+        %8 = mul(x=0.5, y=%7)
+        %9 = mul(x=%0, y=%8)
+
+    Result:
+        %9 = gelu(x=%0, mode="TANH_APPROXIMATION")
+
+    The coefficients are recovered by peeling constant scalings off each side,
+    so the two associativities of the ``0.5 *`` factor and both the factored and
+    the distributed spelling of the ``tanh`` argument are matched. They are
+    compared with a relative tolerance that widens with the operand type, since
+    fp16 cannot hold ``0.044715`` or ``sqrt(2/pi)`` to fp32 accuracy. Every
+    intermediate value of the pattern must have exactly one consumer, apart from
+    ``x`` itself, which the pattern reads three times.
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            fused = _fuse_gelu_tanh(f)
+            if fused:
+                logger.debug("fuse_gelu_tanh: fused %d approximated GELU(s)", fused)

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -14,19 +14,28 @@ proven (typically because a dimension is symbolic) the helpers report the
 """
 
 import numpy as np
+from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
 __all__ = [
     "broadcast_shapes",
     "const_int_list",
+    "const_scaled_operand",
     "dims_equal",
+    "dtype_epsilon",
     "is_broadcast_tile",
     "normalize_axis",
+    "peel_to_scaled_input",
     "shapes_equal",
     "sole_consumer",
     "uniform_const_operand",
     "uniform_scalar_value",
 ]
+
+# Upper bound on the number of scaling/negation ops `peel_to_scaled_input` walks
+# back over. The converter emits at most two or three; the bound just keeps the
+# search finite for hand-written graphs.
+MAX_PEEL_DEPTH = 8
 
 
 def uniform_scalar_value(var) -> float | None:
@@ -208,3 +217,75 @@ def is_broadcast_tile(op) -> bool:
         return False
     # `dim` may be symbolic; only a literal 1 is safe to broadcast.
     return all(rep == 1 or dims_equal(dim, 1) for dim, rep in zip(x_shape, reps))
+
+
+def const_scaled_operand(op):
+    """Split a ``mul``/``real_div``/``sub`` op into ``(input_var, factor)``.
+
+    Recognises the ops that scale or negate a value by a compile-time constant:
+    ``mul(v, c)``/``mul(c, v)`` -> ``(v, c)``, ``real_div(v, c)`` -> ``(v, 1/c)``
+    and the negation ``sub(0, v)`` -> ``(v, -1)``. Returns ``None`` otherwise.
+    """
+    if op.op_type == "mul":
+        scaled = uniform_const_operand(op)
+        if scaled is None:
+            return None
+        factor, operand = scaled
+        return operand, factor
+
+    if op.op_type == "real_div":
+        divisor = uniform_scalar_value(op.y)
+        if divisor is not None and divisor != 0.0:
+            return op.x, 1.0 / divisor
+        return None
+
+    if op.op_type == "sub":
+        lhs = uniform_scalar_value(op.x)
+        if lhs is not None and abs(lhs) < 1e-12:
+            return op.y, -1.0
+        return None
+
+    return None
+
+
+def peel_to_scaled_input(var, block):
+    """Walk back over constant scalings/negations, returning ``[(var, factor), ...]``.
+
+    The first entry is ``(var, 1.0)`` itself, then every prefix of the chain with
+    the accumulated factor: ``var == entry_var * factor``.
+
+    Peeling stops at a value that has more than one consumer: rewriting past it
+    would leave the op in the graph anyway, and must not change what the other
+    consumer sees.
+    """
+    chain = [(var, 1.0)]
+    factor = 1.0
+    current = var
+    for _ in range(MAX_PEEL_DEPTH):
+        op = current.op
+        if op is None or op.enclosing_block is not block:
+            break
+        if sole_consumer(current) is None:
+            break
+        split = const_scaled_operand(op)
+        if split is None:
+            break
+        current, step = split
+        factor *= step
+        chain.append((current, factor))
+    return chain
+
+
+def dtype_epsilon(var) -> float:
+    """Machine epsilon of ``var``'s element type (``0.0`` if it is not a float).
+
+    Pattern constants reach MIL already rounded to the operand type, so a
+    matcher comparing them against exact mathematical values has to allow at
+    least this much slack.
+    """
+    if var is None:
+        return 0.0
+    dtype = getattr(var, "dtype", None)
+    if dtype is None or not types.is_float(dtype):
+        return 0.0
+    return float(np.finfo(types.nptype_from_builtin(dtype)).eps)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -13,6 +13,7 @@ import coremltools as ct
 # Importing the pass modules registers them in coremltools' PASS_REGISTRY.
 from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
 from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
+from . import fuse_gelu_tanh as _fuse_gelu_tanh  # noqa: F401
 from . import fuse_logit_softcap as _fuse_logit_softcap  # noqa: F401
 from . import fuse_reduce_keep_dims as _fuse_reduce_keep_dims  # noqa: F401
 from . import remove_broadcast_tiles as _remove_broadcast_tiles  # noqa: F401
@@ -51,6 +52,8 @@ FUSION_PASSES: list[str] = [
     "common::fuse_logit_softcap",
     _DCE,
     "common::fuse_gelu_erfc",
+    _DCE,
+    "common::fuse_gelu_tanh",
     _DCE,
 ]
 

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -138,6 +138,18 @@ class TestFuseGeluErfc:
         _apply(prog)
         assert "gelu" not in get_op_types_in_program(prog)
 
+    def test_not_fused_for_the_tanh_approximation(self):
+        """This pass covers the `erfc` form only; `fuse_gelu_tanh` covers the other."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            cubed = mb.mul(x=mb.mul(x=x, y=x), y=x)
+            inner = mb.add(x=x, y=mb.mul(x=0.044715, y=cubed))
+            cdf = mb.add(x=1.0, y=mb.tanh(x=mb.mul(x=math.sqrt(2.0 / math.pi), y=inner)))
+            return mb.mul(x=x, y=mb.mul(x=0.5, y=cdf))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
     def test_not_fused_when_erf_is_shared(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
         def prog(x):
@@ -210,16 +222,22 @@ class TestFuseGeluErfcEndToEnd:
         )
         assert "gelu" not in get_model_instruction_types(cml_model)
 
-    def test_tanh_approximated_gelu_still_converts(self):
-        """The tanh approximation converts correctly, but is not fused.
+    def test_tanh_approximated_gelu_is_fused_by_its_own_pass(self):
+        """`jax.nn.gelu(approximate=True)` is a different formula entirely.
 
-        coremltools' `fuse_gelu_tanh_approximation` insists on a literal
-        `pow(x, 3)`, while JAX emits `x * x * x`. This pass deliberately only
-        covers the `erfc` form, so the approximation stays decomposed.
+        It is matched by `fuse_gelu_tanh` (see its test module), not by this
+        pass -- what is checked here is only that the two do not disagree about
+        which `gelu` mode the result is.
         """
         cml_model = run_and_compare(
             lambda x: jax.nn.gelu(x, approximate=True),
             [jax.ShapeDtypeStruct((4, 16), jnp.float32)],
         )
-        ops = get_model_instruction_types(cml_model)
-        assert ops.count("tanh") == 1
+        gelu_ops = [
+            op
+            for func in cml_model._mil_program.functions.values()
+            for op in func.operations
+            if op.op_type == "gelu"
+        ]
+        assert len(gelu_ops) == 1
+        assert gelu_ops[0].mode.val == "TANH_APPROXIMATION"

--- a/tests/passes/test_fuse_gelu_tanh.py
+++ b/tests/passes/test_fuse_gelu_tanh.py
@@ -1,0 +1,329 @@
+import math
+
+import coremltools as ct
+import equinox as eqx
+import equinox.internal as eqxi
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+from flax import nnx
+
+from tests.utils import (
+    get_model_instruction_types,
+    run_and_compare,
+    run_and_compare_jit_lowering,
+    run_and_compare_specific_input,
+)
+
+PASS_NAME = "common::fuse_gelu_tanh"
+DCE_PASS_NAME = "common::dead_code_elimination"
+
+SQRT_2_OVER_PI = math.sqrt(2.0 / math.pi)
+CUBE_COEFFICIENT = 0.044715
+
+
+def _apply(prog):
+    apply_pass_and_basic_check(prog, PASS_NAME)
+    # The pass leaves the matched ops behind; DCE is what removes them.
+    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
+
+
+def _tanh_gelu(
+    x,
+    *,
+    outer=SQRT_2_OVER_PI,
+    cube=CUBE_COEFFICIENT,
+    half=0.5,
+    one=1.0,
+    pow_cube=False,
+    half_on_x=False,
+):
+    """Build `half * x * (one + tanh(outer * (x + cube * x**3)))`."""
+    if pow_cube:
+        cubed = mb.pow(x=x, y=3.0)
+    else:
+        cubed = mb.mul(x=mb.mul(x=x, y=x), y=x)
+    inner = mb.add(x=x, y=mb.mul(x=cube, y=cubed))
+    cdf = mb.add(x=one, y=mb.tanh(x=mb.mul(x=outer, y=inner)))
+    if half_on_x:
+        return mb.mul(x=mb.mul(x=x, y=half), y=cdf)
+    return mb.mul(x=x, y=mb.mul(x=half, y=cdf))
+
+
+def _gelu_ops(prog):
+    return [op for op in prog.functions["main"].operations if op.op_type == "gelu"]
+
+
+class TestFuseGeluTanh:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_replaces_the_jax_chain(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x)
+
+        assert get_op_types_in_program(prog) == [
+            "mul", "mul", "mul", "add", "mul", "tanh", "add", "mul", "mul",
+        ]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+        assert _gelu_ops(prog)[0].mode.val == "TANH_APPROXIMATION"
+        assert_model_is_valid(
+            prog, {"x": (4, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_replaces_the_pow_spelling(self):
+        """coremltools' own pass only covers this one; ours has to cover both."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, pow_cube=True)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_replaces_the_half_folded_into_x(self):
+        """`(0.5 * x) * (1 + tanh(...))` is the same product, associated differently."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, half_on_x=True)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_replaces_a_distributed_tanh_argument(self):
+        """`k*x + k*a*x**3` instead of the factored `k*(x + a*x**3)`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            cubed = mb.mul(x=mb.mul(x=x, y=x), y=x)
+            inner = mb.add(
+                x=mb.mul(x=x, y=SQRT_2_OVER_PI),
+                y=mb.mul(x=cubed, y=SQRT_2_OVER_PI * CUBE_COEFFICIENT),
+            )
+            cdf = mb.add(x=mb.tanh(x=inner), y=1.0)
+            return mb.mul(x=mb.mul(x=cdf, y=0.5), y=x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_replaces_the_x_squared_times_x_spelling(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            cubed = mb.mul(x=x, y=mb.mul(x=x, y=x))
+            inner = mb.add(x=mb.mul(x=CUBE_COEFFICIENT, y=cubed), y=x)
+            cdf = mb.add(x=1.0, y=mb.tanh(x=mb.mul(x=SQRT_2_OVER_PI, y=inner)))
+            return mb.mul(x=mb.mul(x=0.5, y=cdf), y=x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_uniform_tensor_constants(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(
+                x,
+                outer=np.full((1,), SQRT_2_OVER_PI, dtype=np.float32),
+                cube=np.full((1,), CUBE_COEFFICIENT, dtype=np.float32),
+                half=np.full((1,), 0.5, dtype=np.float32),
+                one=np.full((1,), 1.0, dtype=np.float32),
+            )
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_fp16_rounded_coefficients_are_still_fused(self):
+        """`0.044715` and `sqrt(2/pi)` do not survive the trip through fp16.
+
+        The matcher multiplies the two together, so the error compounds to about
+        two fp16 ulps -- well outside an fp32-calibrated tolerance.
+        """
+        cube = np.float16(CUBE_COEFFICIENT)
+        outer = np.float16(SQRT_2_OVER_PI)
+        cubic_term = float(outer) * float(cube)
+        assert abs(cubic_term / (SQRT_2_OVER_PI * CUBE_COEFFICIENT) - 1.0) > 1e-4
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8), dtype=types.fp16)])
+        def prog(x):
+            return _tanh_gelu(x, outer=outer, cube=cube, half=np.float16(0.5), one=np.float16(1.0))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["gelu"]
+
+    def test_not_fused_for_the_wrong_cube_coefficient(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, cube=0.05)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_the_wrong_outer_coefficient(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, outer=0.8)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_the_wrong_half(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, half=0.25)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_the_wrong_offset(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x, one=2.0)
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_a_square_instead_of_a_cube(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            squared = mb.mul(x=x, y=x)
+            inner = mb.add(x=x, y=mb.mul(x=CUBE_COEFFICIENT, y=squared))
+            cdf = mb.add(x=1.0, y=mb.tanh(x=mb.mul(x=SQRT_2_OVER_PI, y=inner)))
+            return mb.mul(x=x, y=mb.mul(x=0.5, y=cdf))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_for_a_different_input(self):
+        """The cube, the linear term and the outer factor must share one var."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(4, 8))])
+        def prog(x, y):
+            cubed = mb.mul(x=mb.mul(x=y, y=y), y=y)
+            inner = mb.add(x=x, y=mb.mul(x=CUBE_COEFFICIENT, y=cubed))
+            cdf = mb.add(x=1.0, y=mb.tanh(x=mb.mul(x=SQRT_2_OVER_PI, y=inner)))
+            return mb.mul(x=x, y=mb.mul(x=0.5, y=cdf))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_when_the_tanh_is_shared(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            cubed = mb.mul(x=mb.mul(x=x, y=x), y=x)
+            inner = mb.add(x=x, y=mb.mul(x=CUBE_COEFFICIENT, y=cubed))
+            tanh = mb.tanh(x=mb.mul(x=SQRT_2_OVER_PI, y=inner))
+            cdf = mb.add(x=1.0, y=tanh)
+            return mb.mul(x=x, y=mb.mul(x=0.5, y=cdf)), tanh
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_not_fused_when_the_square_is_shared(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            squared = mb.mul(x=x, y=x)
+            cubed = mb.mul(x=squared, y=x)
+            inner = mb.add(x=x, y=mb.mul(x=CUBE_COEFFICIENT, y=cubed))
+            cdf = mb.add(x=1.0, y=mb.tanh(x=mb.mul(x=SQRT_2_OVER_PI, y=inner)))
+            return mb.mul(x=x, y=mb.mul(x=0.5, y=cdf)), squared
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+
+    def test_fused_inside_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                return _tanh_gelu(x)
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        ops = get_op_types_in_program(prog, recurse=True)
+        assert "gelu" in ops
+        assert "tanh" not in ops
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
+        def prog(x):
+            return _tanh_gelu(x)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+
+class TestFuseGeluTanhEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_jax_gelu_default_is_the_tanh_approximation(self):
+        """`approximate=True` is the default, so this is the common spelling."""
+        cml_model = run_and_compare(
+            jax.nn.gelu, [jax.ShapeDtypeStruct((4, 16), jnp.float32)]
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("gelu") == 1
+        assert "tanh" not in ops
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
+    def test_tanh_gelu_via_jit_lowering(self, dtype):
+        inputs = (jax.random.normal(jax.random.PRNGKey(0), (4, 16), dtype=dtype),)
+        precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
+        cml_model = run_and_compare_jit_lowering(
+            lambda x: jax.nn.gelu(x, approximate=True),
+            inputs,
+            atol=1e-04 * precision_loss,
+            rtol=1e-05 * precision_loss,
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("gelu") == 1
+        assert "tanh" not in ops
+
+    def test_tanh_gelu_saturates_the_same_way(self):
+        """The fused op has to agree where the approximation flattens out."""
+        big = jnp.linspace(-30.0, 30.0, 64, dtype=jnp.float32).reshape(4, 16)
+        cml_model = run_and_compare_specific_input(jax.nn.gelu, (big,))
+        assert get_model_instruction_types(cml_model).count("gelu") == 1
+
+    def test_flax_gelu(self):
+        cml_model = run_and_compare(nnx.gelu, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("gelu") == 1
+        assert "tanh" not in ops
+
+    def test_equinox_mlp_with_a_gelu_activation(self):
+        model = eqx.nn.MLP(
+            in_size=8, out_size=4, width_size=16, depth=2,
+            activation=jax.nn.gelu, key=jax.random.PRNGKey(0),
+        )
+        cml_model = run_and_compare(
+            eqxi.finalise_fn(eqx.nn.inference_mode(model)),
+            [jax.ShapeDtypeStruct((8,), jnp.float32)],
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("gelu") == 2
+        assert "tanh" not in ops
+
+    def test_the_exact_gelu_still_fuses_to_the_exact_mode(self):
+        """The two GELU passes must not steal each other's pattern."""
+        inputs = (jax.random.normal(jax.random.PRNGKey(0), (4, 16), jnp.float32),)
+        cml_model = run_and_compare_jit_lowering(
+            lambda x: jax.nn.gelu(x, approximate=False), inputs
+        )
+        gelu_ops = [
+            op
+            for func in cml_model._mil_program.functions.values()
+            for op in func.operations
+            if op.op_type == "gelu"
+        ]
+        assert len(gelu_ops) == 1
+        assert gelu_ops[0].mode.val == "EXACT"

--- a/tests/passes/test_pattern_utils.py
+++ b/tests/passes/test_pattern_utils.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pytest
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil import get_new_symbol
+from coremltools.converters.mil.mil import get_new_symbol, types
 
 from stablehlo_coreml.passes.pattern_utils import (
     broadcast_shapes,
     dims_equal,
+    dtype_epsilon,
+    peel_to_scaled_input,
     shapes_equal,
     sole_consumer,
     uniform_scalar_value,
@@ -148,3 +150,82 @@ class TestSoleConsumer:
 
     def test_none(self):
         assert sole_consumer(None) is None
+
+
+class TestPeelToScaledInput:
+
+    def test_peels_a_chain_of_constant_scalings(self):
+        def build(x, captured):
+            scaled = mb.mul(x=x, y=np.float32(3.0))
+            negated = mb.sub(x=np.float32(0.0), y=scaled)
+            captured["out"] = mb.real_div(x=negated, y=np.float32(2.0))
+            # `sole_consumer` refuses a block output, so keep `out` internal.
+            return mb.identity(x=captured["out"])
+
+        prog, captured = _build(build)
+        block = prog.functions["main"]
+        chain = peel_to_scaled_input(captured["out"], block)
+
+        assert [var for var, _ in chain][-1] is captured["x"]
+        assert [factor for _, factor in chain] == pytest.approx([1.0, 0.5, -0.5, -1.5])
+
+    def test_stops_at_a_value_with_two_consumers(self):
+        def build(x, captured):
+            scaled = mb.mul(x=x, y=np.float32(3.0))
+            captured["out"] = mb.mul(x=scaled, y=np.float32(2.0))
+            return mb.add(x=captured["out"], y=scaled)
+
+        prog, captured = _build(build)
+        chain = peel_to_scaled_input(captured["out"], prog.functions["main"])
+
+        # `scaled` escapes to the `add`, so peeling past it is not allowed.
+        assert len(chain) == 2
+        assert chain[-1][0] is not captured["x"]
+
+    def test_stops_at_a_non_scaling_op(self):
+        def build(x, captured):
+            captured["out"] = mb.mul(x=mb.tanh(x=x), y=np.float32(3.0))
+            return mb.identity(x=captured["out"])
+
+        prog, captured = _build(build)
+        chain = peel_to_scaled_input(captured["out"], prog.functions["main"])
+        assert len(chain) == 2
+        assert chain[-1][0].op.op_type == "tanh"
+
+    def test_a_non_constant_multiplication_is_not_a_scaling(self):
+        def build(x, captured):
+            captured["out"] = mb.mul(x=x, y=x)
+            return mb.identity(x=captured["out"])
+
+        prog, captured = _build(build)
+        assert peel_to_scaled_input(captured["out"], prog.functions["main"]) == [
+            (captured["out"], 1.0)
+        ]
+
+
+class TestDtypeEpsilon:
+
+    def test_matches_numpy(self):
+        _, captured = _build(lambda x, c: c.setdefault("v", mb.tanh(x=x)))
+        assert dtype_epsilon(captured["v"]) == pytest.approx(np.finfo(np.float32).eps)
+
+    def test_fp16(self):
+        captured = {}
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4,), dtype=types.fp16)])
+        def prog(x):
+            captured["v"] = mb.tanh(x=x)
+            return captured["v"]
+
+        assert dtype_epsilon(captured["v"]) == pytest.approx(np.finfo(np.float16).eps)
+
+    def test_non_float_and_none(self):
+        captured = {}
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4,), dtype=types.int32)])
+        def prog(x):
+            captured["v"] = mb.add(x=x, y=np.int32(1))
+            return captured["v"]
+
+        assert dtype_epsilon(captured["v"]) == 0.0
+        assert dtype_epsilon(None) == 0.0


### PR DESCRIPTION
## Problem

`fuse_gelu_erfc` handles `jax.nn.gelu(x, approximate=False)`. Auditing it against the spellings the real libraries use turned up the other branch: **`approximate=True` is the default**, so plain `jax.nn.gelu`, `flax.nnx.gelu`, and every `equinox` MLP with a GELU activation trace to the tanh approximation — and none of it was ever fused.

Converting each through the real converter + `DEFAULT_HLO_PIPELINE` and reading the MIL, before this change:

| spelling | fp32 | fp16 |
| --- | --- | --- |
| `jax.nn.gelu(x, approximate=False)` (jit-lower path) | fused, `EXACT` | fused, `EXACT` |
| `flax.nnx.gelu(x, approximate=False)` | fused, `EXACT` | fused, `EXACT` |
| `eqx.nn.MLP(activation=partial(gelu, approximate=False))` | fused, `EXACT` | — |
| **`jax.nn.gelu(x)` (the default)** | **not fused** | **not fused** |
| **`flax.nnx.gelu(x)` (the default)** | **not fused** | **not fused** |
| **`eqx.nn.MLP(activation=jax.nn.gelu)`** | **not fused** | — |

Nine elementwise ops over the activation tensor — the widest tensor in an FFN block — survived into every converted model.

## Root cause

coremltools does ship a pass for this formula, `fuse_gelu_tanh_approximation`, but its pattern requires the cube to be a literal `pow(x, 3)`. JAX writes `x ** 3` as `x * x * x`:

```
main[CoreML8](%x: (4, 16, fp32)(Tensor)) {
  block0() {
    %mul_0: (4, 16, fp32)(Tensor) = mul(x=%x, y=%x, name="mul_0")
    %mul_1: (4, 16, fp32)(Tensor) = mul(x=%mul_0, y=%x, name="mul_1")
    %mul_2: (4, 16, fp32)(Tensor) = mul(x=[[0.044714998453855515]], y=%mul_1, name="mul_2")
    %add_0: (4, 16, fp32)(Tensor) = add(x=%x, y=%mul_2, name="add_0")
    %mul_3: (4, 16, fp32)(Tensor) = mul(x=[[0.7978845834732056]], y=%add_0, name="mul_3")
    %tanh_0: (4, 16, fp32)(Tensor) = tanh(x=%mul_3, name="tanh_0")
    %add_1: (4, 16, fp32)(Tensor) = add(x=[[1.0]], y=%tanh_0, name="add_1")
    %mul_4: (4, 16, fp32)(Tensor) = mul(x=[[0.5]], y=%add_1, name="mul_4")
    %mul_5: (4, 16, fp32)(Tensor) = mul(x=%x, y=%mul_4, name="mul_5")
  } -> (%mul_5)
}
```

`fuse_gelu_tanh_approximation`'s matcher never gets past `%mul_1`. torch, by contrast, *does* emit `pow`, which is why the gpt2 case in the PyTorch suite already counted fused GELUs and the gap stayed invisible from that side.

## Fix

A new pass, `fuse_gelu_tanh`, recognising both spellings of the cube and rewriting the block to `gelu(x, mode="TANH_APPROXIMATION")` — the same relationship `fuse_gelu_erfc` has to coremltools' `fuse_gelu_exact`.

Rather than pinning down one op arrangement it recovers the coefficients by peeling constant scalings, reusing the `peel_to_scaled_input` helper `fuse_gelu_erfc` already had — now promoted to `pattern_utils` along with `const_scaled_operand`. That makes the associativity of the `0.5 *` factor irrelevant (`x * (0.5 * cdf)` and `(0.5 * x) * cdf` both match) and covers a `tanh` argument written distributed (`k*x + k*a*x**3`) as well as factored.

Coefficients are compared with a **relative** tolerance that widens with the element type, for the same reason the softcap pass needs one: fp16 holds neither `0.044715` nor `sqrt(2/pi)`, and the matcher multiplies the two rounded literals together, so the cubic term drifts by roughly two fp16 ulps — far outside an fp32-calibrated tolerance. Every intermediate of the pattern must have exactly one consumer, apart from `x` itself, which the formula reads three times.

## Tests

New `tests/passes/test_fuse_gelu_tanh.py`. Hand-built MIL: the JAX chain, the `pow` spelling, `x * (x * x)`, the half folded into `x`, the distributed tanh argument, uniform tensor constants, fp16-rounded coefficients. Negatives: each wrong coefficient, a square instead of a cube, a foreign input, a shared `tanh`, a shared square. Plus nesting and idempotence.

End to end: `jax.nn.gelu` through both the export and the `jax.jit(...).lower()` path in fp32 and fp16, a saturating `linspace(-30, 30)` input range, `flax.nnx.gelu`, an `equinox.nn.MLP` with a GELU activation, and an assertion that the exact GELU still comes out as `mode="EXACT"` so the two passes do not steal each other's pattern.

`test_fuse_gelu_erfc.py`'s `test_tanh_approximated_gelu_still_converts` was the test documenting this gap; it is replaced by a unit-level test that `fuse_gelu_erfc` alone still declines the tanh form. The two helpers promoted to `pattern_utils` get direct tests.

## Verification

Full JAX suite: 452 passed. `tests/passes`: 234 passed. PyTorch suite: 15 passed — torch's `pow`-based gpt2 GELUs were already fused (by coremltools; now by this pass first, into the same op), so its expected op counts are unchanged. `ruff check .` clean. All 12 GELU spellings I audited now fuse, except `jax.nn.gelu(approximate=False)` on the `jax.export` path, where CHLO is legalized into an `abs`/`less`/`select` polynomial before the converter ever sees an `erf` — a pre-existing, separately documented limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E
