### PR TITLE
Decide remove_broadcast_tiles per axis so dynamic shapes keep working

### DIFF
--- a/stablehlo_coreml/passes/broadcast_select_operands.py
+++ b/stablehlo_coreml/passes/broadcast_select_operands.py
@@ -1,0 +1,214 @@
+"""MIL pass: give ``select`` operands the full output shape when a dim is symbolic.
+
+E5RT (Apple's Core ML runtime) cannot propagate shapes through a ``select``
+whose operand broadcasts from 1 into a *symbolic* dimension. Loading such a
+model fails with
+
+    Failed to PropagateInputTensorShapes: Validation error during type
+    inference for select: Incompatible Dimension.
+
+``remove_broadcast_tiles`` already knows about this failure and deliberately
+keeps the ``tile``s that feed a ``select``. That is only half the story: it can
+only preserve tiles that exist, and JAX never emits one for the value operand of
+a whole-tensor cache write such as ``jnp.where(mask, value, cache)`` with
+``cache: (1, L, nkv, hd)`` (symbolic ``L``) and ``value: (1, 1, nkv, hd)``.
+``jnp.where`` broadcasts implicitly, and an explicit ``jnp.broadcast_to`` in the
+traced source is folded away before it reaches MIL, so the missing broadcast has
+to be introduced here, on the MIL side.
+
+A ``tile`` is not an option -- its ``reps`` would themselves have to be
+symbolic. Each under-shaped operand is instead widened with ``fill_like`` plus
+an identity operation: ``fill_like`` takes its shape from a reference operand
+that already carries the output shape, so no symbolic arithmetic is needed.
+Adding zero is exact in fp16 (and a bool ``cond`` is widened by ``logical_or``
+against ``False`` instead), so the rewrite does not change numerics.
+
+Static-shape ``select``s are left alone -- there the runtime knows every size
+and propagates shapes fine, and the existing tiles are what keeps that path
+working.
+"""
+
+import logging
+
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .pattern_utils import aligned_dim, dims_equal
+
+logger = logging.getLogger(__name__)
+
+# `select`'s operands.
+_OPERANDS = ("cond", "a", "b")
+
+# The order in which operands are considered as the `fill_like` reference.
+# `fill_like` only takes its *shape* from the reference -- its output dtype
+# follows its `value` -- so any of the three works and no `cast` is ever needed.
+# Preferring `a`/`b` keeps the emitted zero tensor in the dtype it is added to,
+# which makes the graph easier to read.
+_REFERENCE_ORDER = ("a", "b", "cond")
+
+
+def _needs_widening(operand, out_shape) -> bool:
+    """True if ``operand`` broadcasts from a static 1 into a symbolic output dim.
+
+    A rank below the output's is not in itself a reason to widen: an operand
+    only has to be widened on the axes where broadcasting stretches it *and* the
+    output dimension is symbolic. On a static axis both sizes are known at load
+    time and E5RT propagates the shape fine. Operands are right-aligned
+    NumPy-style, so an axis that broadcasting prepends to a lower-rank operand
+    reads as a static 1 and does trigger widening when the output is symbolic
+    there.
+
+    A symbolic operand dimension never triggers widening, even when it is a
+    different symbol than the output's: MIL mints a fresh symbol at nearly every
+    op, so one runtime dimension routinely reaches a ``select`` under several
+    names, and only a literal 1 is provably a broadcast.
+    """
+    if operand is None or operand.shape is None:
+        return False
+    out_rank = len(out_shape)
+    if len(operand.shape) > out_rank:
+        return False
+    for axis, out_dim in enumerate(out_shape):
+        if not is_symbolic(out_dim):
+            continue
+        dim = aligned_dim(operand, axis, out_rank)
+        if dim is not None and not is_symbolic(dim) and int(dim) == 1:
+            return True
+    return False
+
+
+def _has_output_shape(operand, out_shape) -> bool:
+    """True if ``operand`` already carries the output shape, so it can size ``fill_like``.
+
+    Static dimensions have to match exactly. A symbolic output dimension only
+    requires the operand to be symbolic there too (see ``_needs_widening`` on
+    why symbols cannot be compared): the output dimension is the broadcast of
+    the operands, so an operand that is symbolic on that axis carries the full
+    size whatever the symbol is called.
+    """
+    if operand is None or operand.shape is None:
+        return False
+    if len(operand.shape) != len(out_shape):
+        return False
+    for dim, out_dim in zip(operand.shape, out_shape):
+        if is_symbolic(out_dim):
+            if not is_symbolic(dim):
+                return False
+        elif not dims_equal(dim, out_dim):
+            return False
+    return True
+
+
+def _fill_reference(op, out_shape):
+    """The operand ``fill_like`` should take its shape from, or ``None``."""
+    for name in _REFERENCE_ORDER:
+        operand = op.inputs.get(name)
+        if _has_output_shape(operand, out_shape):
+            return operand
+    return None
+
+
+def _widen(operand, reference, op, name: str):
+    """``operand`` broadcast up to ``reference``'s shape, without changing its value.
+
+    ``select``'s operands are fp16/fp32/int32/bool, all of which ``fill_like``
+    can produce, so the identity tensor always comes out in ``operand``'s own
+    dtype and no ``cast`` is needed.
+    """
+    is_bool = operand.dtype == types.bool
+    identity = types.nptype_from_builtin(operand.dtype)(0)
+    zeros = mb.fill_like(
+        ref_tensor=reference,
+        value=identity,
+        before_op=op,
+        name=f"{op.name}_{name}_broadcast_identity",
+    )
+    combine = mb.logical_or if is_bool else mb.add
+    return combine(x=operand, y=zeros, before_op=op, name=f"{op.name}_{name}_broadcast")
+
+
+@block_context_manager
+def _broadcast_select_operands(block) -> int:
+    widened = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            widened += _broadcast_select_operands(nested_block)
+        if len(op.blocks) > 0:
+            continue
+
+        if op.op_type != "select":
+            continue
+
+        out_shape = op.outputs[0].shape
+        if out_shape is None or not any(is_symbolic(dim) for dim in out_shape):
+            continue
+
+        under_shaped = [name for name in _OPERANDS if _needs_widening(op.inputs.get(name), out_shape)]
+        if not under_shaped:
+            continue
+
+        reference = _fill_reference(op, out_shape)
+        if reference is None:
+            logger.debug(
+                "broadcast_select_operands: no operand of '%s' carries the full output shape %s",
+                op.name,
+                out_shape,
+            )
+            continue
+
+        operands = {name: op.inputs[name] for name in _OPERANDS}
+        for name in under_shaped:
+            operands[name] = _widen(operands[name], reference, op, name)
+
+        # The operands changed shape, so type inference on the new `select` must
+        # not be re-run against the old output type (`no_check_var_types`). The
+        # output itself is unaffected: widening only replaces implicit
+        # broadcasting with explicit, so the broadcast result is the same shape.
+        widened_select = mb.select(**operands, before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=widened_select,
+            no_check_var_types=True,
+        )
+        block.remove_ops([op])
+        widened += 1
+
+    return widened
+
+
+@register_pass(namespace="common")
+class broadcast_select_operands(AbstractGraphPass):
+    """
+    Widen the operands of a ``select`` that broadcast into a symbolic dimension.
+
+    A ``select`` is rewritten when all of the following hold:
+
+    1. Its output shape has at least one symbolic dimension.
+    2. Some operand (``cond``, ``a`` or ``b``) has a static 1 -- or no axis at
+       all -- where the output dimension is symbolic.
+    3. Some operand already carries the full output shape, to size ``fill_like``
+       from.
+
+    Given (``L`` symbolic):
+        %3 = select(cond=%c, a=%v, b=%cache)   # %c, %cache: (1, L, 2, 8), %v: (1, 1, 2, 8)
+
+    Result:
+        %1 = fill_like(ref_tensor=%cache, value=0.0)         # (1, L, 2, 8)
+        %2 = add(x=%v, y=%1)                                # (1, L, 2, 8)
+        %3 = select(cond=%c, a=%2, b=%cache)
+    """
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            widened = _broadcast_select_operands(f)
+            if widened:
+                logger.debug("broadcast_select_operands: widened %d select op(s)", widened)

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -17,6 +17,7 @@ import numpy as np
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
 __all__ = [
+    "aligned_dim",
     "broadcast_shapes",
     "const_int_list",
     "dims_equal",
@@ -97,6 +98,21 @@ def shapes_equal(a, b) -> bool:
     if len(a) != len(b):
         return False
     return all(dims_equal(x, y) for x, y in zip(a, b))
+
+
+def aligned_dim(operand, out_axis: int, out_rank: int):
+    """``operand``'s dimension at output axis ``out_axis``, NumPy-aligned to the right.
+
+    Axes that broadcasting prepends to a lower-rank operand read as 1.
+    ``None`` when the operand's shape is unknown.
+    """
+    shape = operand.shape
+    if shape is None:
+        return None
+    axis = out_axis - (out_rank - len(shape))
+    if axis < 0:
+        return 1
+    return shape[axis]
 
 
 def _broadcast_dims(a, b):

--- a/stablehlo_coreml/passes/remove_broadcast_tiles.py
+++ b/stablehlo_coreml/passes/remove_broadcast_tiles.py
@@ -15,7 +15,7 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import const_int_list, dims_equal, is_broadcast_tile
+from .pattern_utils import aligned_dim, const_int_list, dims_equal, is_broadcast_tile
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 # is loaded as a multifunction .mlpackage. It fails with
 #   "Failed to PropagateInputTensorShapes: Validation error during type
 #    inference for select: Incompatible Dimension"
-# so tiles feeding a `select` must be preserved.
+# so tiles feeding a `select` must be preserved. Preserving them only covers the
+# tiles that exist, though -- `broadcast_select_operands` runs right after this
+# pass and adds the ones JAX never emitted (`jnp.where` broadcasts implicitly).
 _BROADCAST_OPS = frozenset({
     "add", "sub", "mul", "real_div",
     "maximum", "minimum",
@@ -37,21 +39,6 @@ _BROADCAST_OPS = frozenset({
 
 # The operand names of the (binary) ops above.
 _BINARY_OPERANDS = ("x", "y")
-
-
-def _aligned_dim(operand, out_axis: int, out_rank: int):
-    """``operand``'s dimension at output axis ``out_axis``, NumPy-aligned to the right.
-
-    Axes that broadcasting prepends to a lower-rank operand read as 1.
-    ``None`` when the operand's shape is unknown.
-    """
-    shape = operand.shape
-    if shape is None:
-        return None
-    axis = out_axis - (out_rank - len(shape))
-    if axis < 0:
-        return 1
-    return shape[axis]
 
 
 def _consumer_output_is_unchanged(consumer, tile_op, tile_out) -> bool:
@@ -98,7 +85,7 @@ def _consumer_output_is_unchanged(consumer, tile_op, tile_out) -> bool:
         if rep == 1:
             continue
         replicated = tile_out.shape[axis]
-        dims = [_aligned_dim(other, offset + axis, len(out_shape)) for other in others]
+        dims = [aligned_dim(other, offset + axis, len(out_shape)) for other in others]
         if not any(dim is not None and dims_equal(dim, replicated) for dim in dims):
             return False
     return True

--- a/stablehlo_coreml/passes/remove_broadcast_tiles.py
+++ b/stablehlo_coreml/passes/remove_broadcast_tiles.py
@@ -15,7 +15,7 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import broadcast_shapes, is_broadcast_tile, shapes_equal
+from .pattern_utils import const_int_list, dims_equal, is_broadcast_tile
 
 logger = logging.getLogger(__name__)
 
@@ -39,22 +39,69 @@ _BROADCAST_OPS = frozenset({
 _BINARY_OPERANDS = ("x", "y")
 
 
-def _consumer_output_is_unchanged(consumer, tile_out, tile_in) -> bool:
-    """True if replacing ``tile_out`` by ``tile_in`` keeps ``consumer``'s output shape."""
-    operand_shapes = []
+def _aligned_dim(operand, out_axis: int, out_rank: int):
+    """``operand``'s dimension at output axis ``out_axis``, NumPy-aligned to the right.
+
+    Axes that broadcasting prepends to a lower-rank operand read as 1.
+    ``None`` when the operand's shape is unknown.
+    """
+    shape = operand.shape
+    if shape is None:
+        return None
+    axis = out_axis - (out_rank - len(shape))
+    if axis < 0:
+        return 1
+    return shape[axis]
+
+
+def _consumer_output_is_unchanged(consumer, tile_op, tile_out) -> bool:
+    """True if bypassing ``tile_op`` keeps ``consumer``'s output shape.
+
+    The question is decided per axis rather than by re-broadcasting the whole
+    operand shapes. Re-broadcasting cannot answer it under dynamic shapes: MIL
+    mints a *fresh* symbol for a dynamic dimension at nearly every op, so the
+    two operands of an elementwise op routinely carry different symbols
+    (``is4`` vs ``dim_0``) for one and the same runtime value, and a symbolic
+    dimension is only ever provably equal to the identical symbol.
+
+    Per axis the reasoning needs no such comparison:
+
+    * ``reps[axis] == 1`` leaves the axis alone -- the tile's output dimension
+      *is* its input's, whatever either is called, so the consumer cannot tell
+      the two apart.
+    * ``reps[axis] > 1`` means the tile replicated a size-1 axis, and bypassing
+      it takes the operand back down to 1 there. The consumer's output only
+      stays the same if the other operand already carries the full size on that
+      axis. A replicated dimension is always ``1 * reps[axis]``, i.e. a literal
+      int, so this comparison never involves a symbol on the tile's side.
+    """
+    reps = const_int_list(tile_op.inputs.get("reps"))
+    if reps is None or tile_out.shape is None:
+        return False
+
+    out_shape = consumer.outputs[0].shape
+    if out_shape is None or len(out_shape) < len(reps):
+        return False
+
+    others = []
     for name in _BINARY_OPERANDS:
         operand = consumer.inputs.get(name)
         if operand is None:
             return False
-        shape = tile_in.shape if operand is tile_out else operand.shape
-        if shape is None:
-            return False
-        operand_shapes.append(tuple(shape))
+        # An operand that is the tile itself is bypassed too, so it cannot be
+        # the one supplying a replicated dimension.
+        if operand is not tile_out:
+            others.append(operand)
 
-    broadcast = broadcast_shapes(*operand_shapes)
-    if broadcast is None:
-        return False
-    return shapes_equal(broadcast, consumer.outputs[0].shape)
+    offset = len(out_shape) - len(reps)
+    for axis, rep in enumerate(reps):
+        if rep == 1:
+            continue
+        replicated = tile_out.shape[axis]
+        dims = [_aligned_dim(other, offset + axis, len(out_shape)) for other in others]
+        if not any(dim is not None and dims_equal(dim, replicated) for dim in dims):
+            return False
+    return True
 
 
 def _can_remove(op, block) -> bool:
@@ -76,7 +123,7 @@ def _can_remove(op, block) -> bool:
         # cond body) is not safe to rewrite from here.
         if consumer.enclosing_block is not block:
             return False
-        if not _consumer_output_is_unchanged(consumer, tile_out, op.x):
+        if not _consumer_output_is_unchanged(consumer, op, tile_out):
             return False
     return True
 
@@ -124,7 +171,10 @@ class remove_broadcast_tiles(AbstractGraphPass):
     2. Every consumer is an elementwise op with implicit broadcasting support
        (``select`` is excluded on purpose, see the module docstring), and lives
        in the same block as the tile.
-    3. No consumer changes its output shape when the tile is bypassed.
+    3. No consumer changes its output shape when the tile is bypassed: on every
+       axis the tile actually replicated (``reps[i] > 1``), the consumer's other
+       operand already carries the replicated size. Axes with ``reps[i] == 1``
+       need no check -- the tile passes them through unchanged.
 
     Given:
         %2 = tile(x=%1, reps=[1, 8])   # %1: (4, 1)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -11,6 +11,7 @@ import copy
 import coremltools as ct
 
 # Importing the pass modules registers them in coremltools' PASS_REGISTRY.
+from . import broadcast_select_operands as _broadcast_select_operands  # noqa: F401
 from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
 from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
 from . import fuse_logit_softcap as _fuse_logit_softcap  # noqa: F401
@@ -29,6 +30,11 @@ _DCE = "common::dead_code_elimination"
 # scalar constant is materialised at full size).
 CLEANUP_PASSES: list[str] = [
     "common::remove_broadcast_tiles",
+    # `remove_broadcast_tiles` keeps the tiles feeding a `select`; this one adds
+    # the ones JAX never emitted, so that no `select` operand broadcasts from 1
+    # into a symbolic dimension. It replaces the `select` in place and leaves no
+    # dead ops behind, so it needs no `_DCE` entry of its own.
+    "common::broadcast_select_operands",
     "common::fuse_reduce_keep_dims",
     # `fuse_reduce_keep_dims` leaves the old reduction behind when the reshape
     # was its sole consumer.

--- a/tests/passes/test_broadcast_select_operands.py
+++ b/tests/passes/test_broadcast_select_operands.py
@@ -1,0 +1,402 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+from coremltools.converters.mil.testing_utils import (
+    apply_pass_and_basic_check,
+    get_op_types_in_program,
+)
+
+from stablehlo_coreml.passes.pattern_utils import dims_equal, shapes_equal
+from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_symbolic
+
+PASS_NAME = "common::broadcast_select_operands"
+
+_OPERANDS = ("cond", "a", "b")
+
+
+def _apply(prog):
+    """Apply the pass, returning a deep copy of the program as it was before."""
+    prev_prog, _, _ = apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+    return prev_prog
+
+
+def _selects(prog, recurse: bool = True):
+    def collect(block):
+        found = []
+        for op in block.operations:
+            if recurse:
+                for nested in op.blocks:
+                    found += collect(nested)
+            if op.op_type == "select":
+                found.append(op)
+        return found
+
+    return [op for func in prog.functions.values() for op in collect(func)]
+
+
+def _sole_select(prog):
+    selects = _selects(prog)
+    assert len(selects) == 1, f"expected exactly one select, got {len(selects)}"
+    return selects[0]
+
+
+def _operand_shapes(select_op):
+    return {name: tuple(select_op.inputs[name].shape) for name in _OPERANDS}
+
+
+def _ct_inputs(prog, symbolic_dim: int, range_max: int = 64):
+    """``ct.TensorType``s for ``prog``, with a ``RangeDim`` on every symbolic axis."""
+    func = next(iter(prog.functions.values()))
+    return [
+        ct.TensorType(
+            name=name,
+            shape=[
+                ct.RangeDim(1, range_max, default=symbolic_dim) if is_symbolic(dim) else int(dim)
+                for dim in var.shape
+            ],
+        )
+        for name, var in func.inputs.items()
+    ]
+
+
+def _predict(prog, values, symbolic_dim: int):
+    """Convert ``prog`` and run it on ``values``, with ``symbolic_dim`` for the symbolic axes."""
+    model = ct.convert(
+        prog,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+        # Keep fp32 throughout, so the comparison is not limited by fp16 accuracy.
+        compute_precision=ct.precision.FLOAT32,
+        # coremltools' stock pipeline: the pass under test is applied by hand here.
+        pass_pipeline=ct.PassPipeline.DEFAULT,
+        inputs=_ct_inputs(prog, symbolic_dim),
+    )
+    names = [feature.name for feature in model.get_spec().description.input]
+    result = model.predict({name: values[name] for name in names})
+    return np.array(next(iter(result.values())))
+
+
+class TestBroadcastSelectOperands:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_widens_the_value_operand(self):
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        assert get_op_types_in_program(prog) == ["select"]
+        _apply(prog)
+
+        ops = get_op_types_in_program(prog)
+        assert ops == ["fill_like", "add", "select"]
+
+        select = _sole_select(prog)
+        out_shape = tuple(select.outputs[0].shape)
+        assert shapes_equal(out_shape, (1, length, 1, 8))
+        for name, shape in _operand_shapes(select).items():
+            assert shapes_equal(shape, out_shape), f"{name} has shape {shape}, expected {out_shape}"
+
+    def test_widens_the_cond_operand(self):
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+
+        # A bool operand is widened with `logical_or` against `False`, not `add`.
+        assert get_op_types_in_program(prog) == ["fill_like", "logical_or", "select"]
+
+        select = _sole_select(prog)
+        out_shape = tuple(select.outputs[0].shape)
+        assert select.inputs["cond"].dtype == types.bool
+        for shape in _operand_shapes(select).values():
+            assert shapes_equal(shape, out_shape)
+
+    def test_widens_cond_and_value_together(self):
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+
+        ops = get_op_types_in_program(prog)
+        assert ops.count("fill_like") == 2
+        assert ops.count("logical_or") == 1
+        assert ops.count("add") == 1
+
+        select = _sole_select(prog)
+        out_shape = tuple(select.outputs[0].shape)
+        for shape in _operand_shapes(select).values():
+            assert shapes_equal(shape, out_shape)
+
+    def test_widens_a_lower_rank_operand_that_hits_a_symbolic_axis(self):
+        """The axes broadcasting prepends read as 1, so they need widening too."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(8,)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+
+        assert get_op_types_in_program(prog) == ["fill_like", "add", "select"]
+        select = _sole_select(prog)
+        out_shape = tuple(select.outputs[0].shape)
+        for shape in _operand_shapes(select).values():
+            assert shapes_equal(shape, out_shape)
+
+    def test_not_widened_when_only_a_static_axis_broadcasts(self):
+        """``(1, L, 1, 1)`` carries the symbolic axis, so the runtime can size it."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 1)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+
+        assert get_op_types_in_program(prog) == ["select"]
+        assert _operand_shapes(_sole_select(prog))["a"] == (1, length, 1, 1)
+
+    def test_static_shapes_are_untouched(self):
+        """No symbolic dimension, no problem: E5RT sizes a static broadcast fine."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(2, 4, 8)),
+            mb.TensorSpec(shape=(1, 4, 8)),
+            mb.TensorSpec(shape=(2, 4, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        before = _apply(prog)
+
+        assert get_op_types_in_program(prog) == get_op_types_in_program(before) == ["select"]
+        assert _operand_shapes(_sole_select(prog)) == _operand_shapes(_sole_select(before))
+
+    def test_not_widened_without_a_full_shape_reference(self):
+        """No operand carries the whole output shape, so ``fill_like`` has nothing to size from."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 1)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        before = _apply(prog)
+
+        assert get_op_types_in_program(prog) == ["select"]
+        assert _operand_shapes(_sole_select(prog)) == _operand_shapes(_sole_select(before))
+        assert shapes_equal(_sole_select(prog).outputs[0].shape, (1, length, 1, 8))
+
+    def test_widened_inside_nested_block(self):
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+            mb.TensorSpec(shape=(1,), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask, pred):
+            def true_fn():
+                return mb.select(cond=mask, a=value, b=cache)
+
+            def false_fn():
+                return mb.identity(x=cache)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+
+        ops = get_op_types_in_program(prog, recurse=True)
+        assert ops.count("fill_like") == 1
+        assert ops.count("add") == 1
+
+        select = _sole_select(prog)
+        out_shape = tuple(select.outputs[0].shape)
+        for shape in _operand_shapes(select).values():
+            assert shapes_equal(shape, out_shape)
+
+    def test_widened_operands_keep_the_output_symbol(self):
+        """The widened operand carries the reference's symbol, not a fresh one."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+
+        widened = _sole_select(prog).inputs["a"]
+        assert dims_equal(widened.shape[1], length)
+
+    def test_is_idempotent(self):
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, length, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+    def test_widening_does_not_change_the_result(self):
+        """Widening is ``+ 0`` / ``or False``, so the values are exactly the ones ``select`` gave.
+
+        The reference is ``np.where``, i.e. the implicit-broadcast semantics of
+        the ``select`` before the rewrite. Predicting the *un-widened* program
+        would be the more direct comparison, but that is the construction this
+        pass exists to remove: running it makes Core ML log
+
+            E5RT encountered an STL exception. msg = Failed to
+            PropagateInputTensorShapes: Validation error during type inference
+            for select: at unknown location: Incompatible Dimension.
+
+        The runtime happens to recover from it here (it is a multifunction
+        ``.mlpackage`` load that fails outright), so the message can neither be
+        asserted on nor relied upon not to become a hard failure.
+        """
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, length, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8)),
+            mb.TensorSpec(shape=(1, 1, 1, 8), dtype=types.bool),
+        ], opset_version=ct.target.iOS18)
+        def prog(cache, value, mask):
+            return mb.select(cond=mask, a=value, b=cache)
+
+        _apply(prog)
+        # Both a float (`add`) and a bool (`logical_or`) widening are exercised.
+        assert get_op_types_in_program(prog).count("fill_like") == 2
+
+        concrete = 5
+        rng = np.random.default_rng(0)
+        mask = rng.random((1, 1, 1, 8)) > 0.5
+        values = {
+            "cache": rng.standard_normal((1, concrete, 1, 8)).astype(np.float32),
+            "value": rng.standard_normal((1, 1, 1, 8)).astype(np.float32),
+            # Core ML has no bool model input; it is exposed as fp32 and cast back.
+            "mask": mask.astype(np.float32),
+        }
+        expected = np.where(mask, values["value"], values["cache"])
+
+        np.testing.assert_allclose(_predict(prog, values, concrete), expected, atol=1e-6)
+
+
+class TestBroadcastSelectOperandsEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_where_widens_the_value_operand_under_symbolic_shapes(self):
+        """``jnp.where`` against a symbolic-length cache: the value is never tiled.
+
+        JAX emits a ``dynamic_broadcast_in_dim`` for the value operand, which the
+        converter cannot turn into a ``tile`` (the reps would be symbolic), so the
+        ``select`` reaching MIL broadcasts a static 1 into the symbolic length.
+
+        The E5RT load failure this guards against ("Failed to
+        PropagateInputTensorShapes ... Incompatible Dimension") only shows up when
+        a multifunction ``.mlpackage`` is loaded on device, which CI cannot
+        reproduce; the test asserts the graph shape that avoids it instead.
+        """
+        (length,) = jax.export.symbolic_shape("(L,)")
+
+        def f(cache, value, mask):
+            return jnp.where(mask, value, cache)
+
+        def sample(concrete, seed):
+            rng = np.random.default_rng(seed)
+            return (
+                rng.standard_normal((1, concrete, 2, 8)).astype(np.float32),
+                rng.standard_normal((1, 1, 2, 8)).astype(np.float32),
+                rng.random((1, concrete, 2, 8)) > 0.5,
+            )
+
+        cml_model = run_and_compare_symbolic(
+            f,
+            [
+                jax.ShapeDtypeStruct((1, length, 2, 8), jnp.float32),
+                jax.ShapeDtypeStruct((1, 1, 2, 8), jnp.float32),
+                jax.ShapeDtypeStruct((1, length, 2, 8), jnp.bool_),
+            ],
+            [sample(3, seed=0), sample(7, seed=1)],
+        )
+
+        ops = get_model_instruction_types(cml_model)
+        assert "select" in ops
+        assert "fill_like" in ops
+
+        selects = _selects(cml_model._mil_program)
+        assert len(selects) == 1
+        for select in selects:
+            out_shape = tuple(select.outputs[0].shape)
+            assert any(is_symbolic(dim) for dim in out_shape)
+            for name, operand in _operand_shapes(select).items():
+                assert len(operand) == len(out_shape), f"{name}: {operand} vs {out_shape}"
+                for dim, out_dim in zip(operand, out_shape):
+                    assert not (is_symbolic(out_dim) and not is_symbolic(dim) and int(dim) == 1), (
+                        f"{name} broadcasts from 1 into the symbolic dim of {out_shape}"
+                    )
+
+    def test_static_where_is_left_to_remove_broadcast_tiles(self):
+        """The static path is untouched: its tile already gives `select` full-shape operands.
+
+        ``test_where_keeps_its_tile`` in ``test_remove_broadcast_tiles.py`` covers
+        the tile itself; this asserts the new pass adds nothing on top of it.
+        """
+        def f(scores, mask):
+            return jnp.where(mask, scores, jnp.float32(-1e9))
+
+        cml_model = run_and_compare(
+            f,
+            [jax.ShapeDtypeStruct((2, 4, 8), jnp.float32), jax.ShapeDtypeStruct((2, 4, 8), jnp.bool_)],
+        )
+
+        assert "fill_like" not in get_model_instruction_types(cml_model)
+        select = _sole_select(cml_model._mil_program)
+        out_shape = tuple(select.outputs[0].shape)
+        assert all(shape == out_shape for shape in _operand_shapes(select).values())

--- a/tests/passes/test_remove_broadcast_tiles.py
+++ b/tests/passes/test_remove_broadcast_tiles.py
@@ -79,6 +79,60 @@ class TestRemoveBroadcastTiles:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["add"]
 
+    def test_removed_when_the_operands_carry_different_symbols(self):
+        """MIL mints a fresh symbol per op, so one runtime dimension gets several names.
+
+        `is5` and `dim_0` below are the same dimension at runtime, but no
+        compile-time comparison can say so. Only the axis the tile actually
+        replicated matters, and that one is a literal.
+        """
+        batch = get_new_symbol()
+        renamed_batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 8)), mb.TensorSpec(shape=(renamed_batch, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 8])
+            return mb.mul(x=x, y=tiled)
+
+        assert get_op_types_in_program(prog) == ["tile", "mul"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["mul"]
+
+    def test_not_removed_when_the_other_operand_lacks_the_replicated_size(self):
+        """Both operands are size 1 on the replicated axis, so the output would shrink."""
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 1)), mb.TensorSpec(shape=(batch, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 8])
+            return mb.add(x=x, y=tiled)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+        assert prog.functions["main"].outputs[0].shape == (batch, 8)
+
+    def test_not_removed_when_the_tile_is_both_operands(self):
+        """Bypassing the tile on both sides takes the output back down to (4, 1)."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            tiled = mb.tile(x=x, reps=[1, 8])
+            return mb.mul(x=tiled, y=tiled)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["tile", "mul"]
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
+    def test_removed_when_the_other_operand_has_a_lower_rank(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8,)), mb.TensorSpec(shape=(4, 1))])
+        def prog(x, y):
+            tiled = mb.tile(x=y, reps=[1, 8])
+            return mb.add(x=tiled, y=x)
+
+        assert get_op_types_in_program(prog) == ["tile", "add"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
     def test_not_removed_when_symbolic_dim_is_tiled(self):
         """A symbolic dim cannot be proven to be 1, so tiling it is not a broadcast."""
         batch = get_new_symbol()
@@ -225,6 +279,25 @@ class TestRemoveBroadcastTilesEndToEnd:
         cml_model = run_and_compare(
             f,
             [jax.ShapeDtypeStruct((2, 16, 64), jnp.float32), jax.ShapeDtypeStruct((1, 1, 64), jnp.float32)],
+        )
+        assert "tile" not in get_model_instruction_types(cml_model)
+
+    def test_symbolic_broadcast_leaves_no_tile(self):
+        """Dynamic shapes: the two `mul` operands reach MIL with different symbols."""
+        symbolic_shape = jax.export.symbolic_shape("(b, 8)")
+
+        def f(x):
+            return jnp.mean(x, axis=-1, keepdims=True) * x
+
+        from tests.utils import run_and_compare_symbolic  # noqa: PLC0415
+
+        cml_model = run_and_compare_symbolic(
+            f,
+            [jax.ShapeDtypeStruct(symbolic_shape, jnp.float32)],
+            [
+                (np.random.randn(3, 8).astype(np.float32),),
+                (np.random.randn(5, 8).astype(np.float32),),
+            ],
         )
         assert "tile" not in get_model_instruction_types(cml_model)
 

--- a/tests/passes/test_remove_broadcast_tiles.py
+++ b/tests/passes/test_remove_broadcast_tiles.py
@@ -2,6 +2,7 @@ import coremltools as ct
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
 from coremltools.converters.mil.testing_utils import (
@@ -132,6 +133,23 @@ class TestRemoveBroadcastTiles:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["add"]
         assert prog.functions["main"].outputs[0].shape == (4, 8)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="`matmul` broadcasts its batch dimensions natively (verified against the "
+               "runtime), but it is not in `_BROADCAST_OPS`: unlike the elementwise ops, "
+               "only its leading axes broadcast while the trailing two are contracted, so "
+               "it needs its own axis rule. `jnp.broadcast_to(x, (B, ...)) @ y` therefore "
+               "still materialises the full batch.",
+    )
+    def test_batch_broadcast_ahead_of_matmul_is_removed(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4, 8)), mb.TensorSpec(shape=(2, 8, 4))])
+        def prog(x, y):
+            tiled = mb.tile(x=x, reps=[2, 1, 1])
+            return mb.matmul(x=tiled, y=y)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["matmul"]
 
     def test_not_removed_when_symbolic_dim_is_tiled(self):
         """A symbolic dim cannot be proven to be 1, so tiling it is not a broadcast."""


### PR DESCRIPTION
`remove_broadcast_tiles` fires on static graphs but gives up on nearly every broadcast tile in a dynamically shaped one, leaving full-size materialisations of `(b, 1)` tensors in the exported model.

## Root cause

Under symbolic shapes MIL mints a *fresh* symbol for a dynamic dimension at almost every op -- `fill(shape=concat(...))` in particular -- so the two operands of one elementwise op routinely carry different symbols for the same runtime dimension. Converter output for `x * rsqrt(mean(x*x, -1, keepdims=True) + 1e-6)` over a `(b, 8)` input, with the symbols MIL assigned:

```
%expand_dims_0: (dim_0, 1, fp32)(Tensor) = expand_dims(x=%reduce_sum_0, axes=[1])
%fill_0:        (is1, 1, fp32)(Tensor)   = fill(shape=%concat_1, value=8.0)
%real_div_0:    (is2, 1, fp32)(Tensor)   = real_div(x=%expand_dims_0, y=%fill_0)
%add_0:         (is4, 1, fp32)(Tensor)   = add(x=%real_div_0, y=%fill_1)
%rsqrt_0:       (is4, 1, fp32)(Tensor)   = rsqrt(x=%add_0)
%tile_0:        (is4, 8, fp32)(Tensor)   = tile(x=%rsqrt_0, reps=[1, 8])
%mul_1:         (is6, 8, fp32)(Tensor)   = mul(x=%arg0, y=%tile_0)
```

`dim_0`, `is1`, `is2`, `is4`, `is6` are all the same dimension at runtime. `_consumer_output_is_unchanged` decided the tile by re-broadcasting the operand shapes:

```python
broadcast = broadcast_shapes(*operand_shapes)   # (dim_0, 8) against (is4, 1)
if broadcast is None:
    return False
```

and `_broadcast_dims` will only equate a symbolic dimension with the identical symbol, so `broadcast` comes back `None` and the tile stays. Instrumented trace of the pass on that program:

```
TILE tile_0 x=(is4, 1) reps=[1 8] bcast=True consumers=[('mul', (is6, 8))] -> remove=False
   consumer mul operand shapes -> [(dim_0, 8), (is4, 1)] broadcast=None out=(is6, 8)
```

Final models on `main`, running `build_pass_pipeline()` over a `(b, 8)` input: `mean(x, -1, keepdims=True) * x` keeps 1 tile, symbolic RMSNorm 1, symbolic LayerNorm 2, symbolic softmax 1. Each one is a full `(b, 8)` materialisation of a `(b, 1)` tensor.

## Fix

The re-broadcast was answering a harder question than the pass needs. Bypassing a tile only changes an operand on the axes the tile actually replicated, so the decision splits per axis:

- `reps[axis] == 1` -- the tile passes the axis through, so the operand's dimension there is literally the tile input's, whatever either is called. No comparison needed, and this is exactly where all the renamed symbols live.
- `reps[axis] > 1` -- the tile replicated a size-1 axis, and bypassing it takes the operand back down to 1 there. The consumer's output only stays the same if the other operand already carries the full size on that axis. `is_broadcast_tile` guarantees a replicated dimension is `1 * reps[axis]`, i.e. a literal int, so this comparison never involves a symbol on the tile's side either.

That is per-operand reasoning, so it never has to name the consumer's output shape. The soundness argument is unchanged from before: on untouched axes the operand is identical, and on replicated axes `broadcast(other, reps[axis])` and `broadcast(other, 1)` both come out as `other == reps[axis]`.

After the fix the symbolic-shape finals carry no tiles at all (`mean * x`, RMSNorm, LayerNorm, softmax: 1, 1, 2, 1 tiles -> 0).

Static graphs are unaffected. Re-running the flax/equinox probes (`LayerNorm`, `RMSNorm`, `GroupNorm`, `Linear`, `MultiHeadAttention`, `jnp.broadcast_to`, implicit rank-broadcasting, `jnp.where` masks) gives identical final op counts before and after -- including `flax_groupnorm`'s two surviving tiles, which feed a `reshape` rather than an elementwise op and are correctly still kept.

## The other half: `broadcast_select_operands`

`_BROADCAST_OPS` excludes `select` because E5RT cannot propagate shapes through a `select` that broadcasts from 1 into a symbolic dimension, so tiles feeding a `select` are preserved. That only covers tiles that *exist*. For the most common dynamic-shape `select` -- a whole-tensor cache write `jnp.where(mask, value, cache)` with `cache: (1, L, nkv, hd)` (symbolic `L`) and `value: (1, 1, nkv, hd)` -- the converter never emits one: `op_dynamic_broadcast_in_dim` only tiles axes whose output size is static, so the `select` reaches MIL as

```
cond <- tile   [1, SYM, 1, 512]   <- preserved by remove_broadcast_tiles
a    <- concat [1,   1, 1, 512]   <- never tiled
b    <- input  [1, SYM, 1, 512]
```

and the export fails to load with the same `Failed to PropagateInputTensorShapes ... Incompatible Dimension` error the `_BROADCAST_OPS` comment cites. An explicit `jnp.broadcast_to` in the source does not help -- it is folded before MIL (the emitted graphs are byte-identical).

This PR therefore also adds `common::broadcast_select_operands`, inserted right after `remove_broadcast_tiles` in `CLEANUP_PASSES`. For every `select` whose output has a symbolic dim it widens each operand (`cond`, `a`, `b`) that has a static 1 -- or no axis at all -- on a symbolic output axis, using `fill_like` against an operand that already carries the output shape, plus `add` (or `logical_or` for the bool `cond`). A `tile` is not an option since its `reps` would be symbolic; adding zero is exact in fp16. Only a literal 1 counts as a broadcast, so differently named symbols for one runtime dim never trigger a rewrite, and static-shape `select`s are untouched. `_aligned_dim` moved to `pattern_utils.aligned_dim` since both passes need it.

Ported from a downstream prototype (kasper0406/gemma-coreml-chat@4e53341), where it turned a `--no-materialize` export of a 35-layer LLM from "does not load" into one that loads and predicts (6 selects widened, all KV-cache writes). Changes vs the prototype: `cond` is handled too, a lower-rank operand is only widened where it actually hits a symbolic axis, no cast path (`fill_like`'s dtype follows `value`, not `ref_tensor`), and logging instead of `print`.

Tests (`tests/passes/test_broadcast_select_operands.py`): 11 unit tests on hand-built MIL (value / cond / both widened, lower-rank operand, static-only broadcast left alone, static shapes untouched, no reference operand, nested block, idempotence, numerics vs `np.where`) and two end-to-end tests: `jnp.where` over a symbolic-length cache exported via `run_and_compare_symbolic` and checked against JAX at two lengths, asserting no `select` operand still broadcasts a 1 into the symbolic dim, plus the static `jnp.where` path asserting the pass adds nothing there. The E5RT load failure itself cannot be asserted in CI; predicting the un-widened program does print that exact message on stderr, though.

## Known gap left as an xfail

`_BROADCAST_OPS` lists only elementwise ops, so a tile feeding a `matmul` is always kept. MIL's `matmul` does broadcast its batch dimensions natively -- `matmul((1, 4, 8), (2, 8, 4))` type-infers to `(2, 4, 4)` and predicts bit-identically to numpy on the runtime -- so `jnp.broadcast_to(x, (B, ...)) @ y` materialises the full batch for nothing. Supporting it is not a matter of adding one name to the set: unlike the elementwise ops, only a `matmul`'s leading axes broadcast while the trailing two are contracted, so it needs an axis rule of its own. None of the flax or equinox layers probed produce the pattern, so it is a `strict=True` xfail here rather than a fix.

## Tests

Unit (hand-built MIL):

- `test_removed_when_the_operands_carry_different_symbols` -- a `mul` whose operands are `(batch, 8)` and `tile((renamed_batch, 1), reps=[1, 8])`, the shape the converter actually produces. Fails on `main`.
- `test_removed_when_the_other_operand_has_a_lower_rank`.
- Negatives: `test_not_removed_when_the_other_operand_lacks_the_replicated_size` (both operands size 1 on the replicated axis, so the output would shrink) and `test_not_removed_when_the_tile_is_both_operands`.
- `test_batch_broadcast_ahead_of_matmul_is_removed` -- strict xfail, documenting the gap above.

End-to-end:

- `test_symbolic_broadcast_leaves_no_tile` -- `jnp.mean(x, -1, keepdims=True) * x` exported with `jax.export.symbolic_shape("(b, 8)")`, numerics checked against JAX at two concrete batch sizes, asserts no `tile` survives. Fails on `main`.

## Verification

Full suite on this branch: `445 passed, 1 skipped, 1 xfailed` (`python -m pytest tests/`). `ruff check .` clean.

Also confirmed while auditing: the pass does sit before the first `common::const_elimination` in the assembled pipeline (indices 10 vs 14), so the module docstring's claim about tiled scalar constants holds; and re-running the pass at the *end* of the pipeline on the flax/equinox models changes nothing, so its position is not starving it either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4T3UHepKPR65o5aiXEw5E

