### PR TITLE
Give each dot_general operand the matmul orientation it already has

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -596,9 +596,40 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         lhs_result_dim = [d for d in range(lhs_rank) if d not in lhs_batching_dim + lhs_contracting_dim]
         rhs_result_dim = [d for d in range(rhs_rank) if d not in rhs_batching_dim + rhs_contracting_dim]
 
-        # Transpose to [batch…, result…, contract…]
-        lhs_perm = lhs_batching_dim + lhs_result_dim + lhs_contracting_dim
-        rhs_perm = rhs_batching_dim + rhs_result_dim + rhs_contracting_dim
+        # Each operand has two layouts `matmul` accepts, and its transpose flag
+        # expresses the difference between them for free:
+        #
+        #   lhs: [batch…, result…, contract…] plain, or
+        #        [batch…, contract…, result…] with `transpose_x`
+        #   rhs: [batch…, contract…, result…] plain, or
+        #        [batch…, result…, contract…] with `transpose_y`
+        #
+        # So pick, per operand, the one it is already in — no `mb.transpose` at
+        # all, and the flag carries the difference. Only when neither layout is
+        # reachable for free is a real transpose emitted, and then it goes to
+        # [batch…, result…, contract…], which is what this lowering has always
+        # produced.
+        def _orient(rank, batching, contracting, result, flag_is_result_first):
+            """Return ``(perm, transpose_flag)`` for one matmul operand."""
+            result_first = batching + result + contracting
+            contract_first = batching + contracting + result
+            if flag_is_result_first:
+                plain, flagged = contract_first, result_first
+            else:
+                plain, flagged = result_first, contract_first
+            identity = list(range(rank))
+            if plain == identity:
+                return plain, False
+            if flagged == identity:
+                return flagged, True
+            return result_first, flag_is_result_first
+
+        lhs_perm, transpose_x = _orient(
+            lhs_rank, lhs_batching_dim, lhs_contracting_dim, lhs_result_dim, False
+        )
+        rhs_perm, transpose_y = _orient(
+            rhs_rank, rhs_batching_dim, rhs_contracting_dim, rhs_result_dim, True
+        )
         t_lhs = lhs if lhs_perm == list(range(lhs_rank)) else mb.transpose(x=lhs, perm=lhs_perm)
         t_rhs = rhs if rhs_perm == list(range(rhs_rank)) else mb.transpose(x=rhs, perm=rhs_perm)
 
@@ -619,28 +650,31 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         lhs_result_count = _safe_product(lhs_result_shapes) if lhs_result_shapes else 1
         rhs_result_count = _safe_product(rhs_result_shapes) if rhs_result_shapes else 1
 
-        # Reshape each operand to (batch…, M, K) / (batch…, N, K).
+        # Reshape each operand to the 3D layout `_orient` picked for it, which
+        # is (batch…, M, K) / (batch…, K, N) for a plain operand and
+        # (batch…, K, M) / (batch…, N, K) for a flagged one. `contracting_first`
+        # is which of the two it is.
         # When len(result_dims)==1 and len(contract_dims)==1 the tensor is
         # already in the right layout and we can skip the reshape entirely,
         # which avoids the two-unknown-dims problem when both are symbolic.
-        def _reshape_to_3d(tensor, result_count, result_dims, side_name):
+        def _reshape_to_3d(tensor, result_count, result_dims, contracting_first, side_name):
             if len(result_dims) == 1 and len(lhs_contracting_dim) == 1:
                 return tensor
-            rc = result_count if result_count != -1 else -1
-            cc = contracted_count if contracted_count != -1 else -1
+            rc = result_count
+            cc = contracted_count
             if rc == -1 and cc == -1:
                 raise ValueError(
                     f"dot_general: cannot reshape {side_name} — "
                     f"both result-dim product and contracting-dim product are symbolic."
                 )
-            target = list(batch_shape) + [rc if rc != -1 else -1, cc if cc != -1 else -1]
-            return mb.reshape(x=tensor, shape=target)
+            trailing = [cc, rc] if contracting_first else [rc, cc]
+            return mb.reshape(x=tensor, shape=list(batch_shape) + trailing)
 
-        c_lhs = _reshape_to_3d(t_lhs, lhs_result_count, lhs_result_dim, "lhs")
-        c_rhs = _reshape_to_3d(t_rhs, rhs_result_count, rhs_result_dim, "rhs")
+        c_lhs = _reshape_to_3d(t_lhs, lhs_result_count, lhs_result_dim, transpose_x, "lhs")
+        c_rhs = _reshape_to_3d(t_rhs, rhs_result_count, rhs_result_dim, not transpose_y, "rhs")
 
-        # (batch…, M, K) × (batch…, N, K)^T → (batch…, M, N)
-        result = mb.matmul(x=c_lhs, y=c_rhs, transpose_y=True)
+        # → (batch…, M, N)
+        result = mb.matmul(x=c_lhs, y=c_rhs, transpose_x=transpose_x, transpose_y=transpose_y)
 
         # Squeeze fake dims when a side has no result dims
         if len(lhs_result_dim) == 0 and len(rhs_result_dim) == 0:

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -1,15 +1,19 @@
 """MIL pass: fuse a decomposed attention block into ``scaled_dot_product_attention``.
 
 Attention arrives from StableHLO as two ``dot_general``\\ s with a softmax in
-between. ``dot_general`` lowers to ``[transpose] -> [reshape] -> matmul(...,
-transpose_y=True) -> [reshape] -> [transpose]``, so an attention block looks
-like::
+between. ``dot_general`` lowers to ``[transpose] -> [reshape] -> matmul ->
+[reshape] -> [transpose]``, so an attention block looks like::
 
-    matmul_0(Q, K, transpose_y=True) -> [reshape/transpose]* -> [scale] ->
+    matmul_0(Q, K_t) -> [reshape/transpose]* -> [scale] ->
       [mask] -> [cast] -> softmax(axis=-1) -> [reshape/transpose]* ->
-      matmul_1(W, V, transpose_y=True)
+      matmul_1(W, V)
 
 The pass matches that and emits a single ``scaled_dot_product_attention``.
+
+Neither matmul is assumed to be in any particular orientation: each operand may
+arrive already transposed (with the matmul's ``transpose_y`` flag set) or laid
+out for a plain matmul, and the softmax weights may enter ``matmul_1`` on either
+side, contracting over either of their two trailing axes.
 
 Everything happens in "matmul space": the SDPA operands are exactly the matmul
 operands, so nothing is assumed about how the model laid out heads, groups or
@@ -629,6 +633,20 @@ def _softmax_axis_atom(dim, m_atom: _Atom, n_atom: _Atom) -> _Atom | None:
     return whole[0] if len(whole) == 1 else None
 
 
+def _weights_key_axis(pattern) -> int:
+    """Which axis of ``weights_var`` ``matmul_1`` contracts over: ``-1`` or ``-2``.
+
+    The softmax weights are ``[..., L', S]`` when the contraction runs over their
+    last axis and ``[..., S, L']`` when it runs over the one before it. Which one
+    it is follows from the side ``weights_var`` enters ``matmul_1`` on and that
+    side's transpose flag.
+    """
+    matmul_1 = pattern.matmul_1
+    if matmul_1.inputs["x"] is pattern.weights_var:
+        return -2 if bool(matmul_1.transpose_x.val) else -1
+    return -1 if bool(matmul_1.transpose_y.val) else -2
+
+
 def _analyse_space(pattern) -> _Space | None:
     """Work out the S/L roles and the row permutation between the two matmuls."""
     scores_shape = tuple(pattern.matmul_0.outputs[0].shape)
@@ -636,8 +654,13 @@ def _analyse_space(pattern) -> _Space | None:
     if n_batch < 1:
         return None
 
+    key_axis = _weights_key_axis(pattern)
+
     if not pattern.back_layout_ops and not pattern.fwd_layout_ops:
-        # Softmax runs directly on the matmul result, so S is its last axis.
+        # Softmax runs directly on the matmul result, so S is its last axis, and
+        # `matmul_1` has to contract over that one.
+        if key_axis != -1:
+            return None
         return _Space(n_batch, scores_shape[:n_batch])
 
     if any(is_symbolic(dim) for dim in scores_shape):
@@ -665,7 +688,7 @@ def _analyse_space(pattern) -> _Space | None:
     if s_atom.children is not None:
         # The key axis itself was split; it is no longer a single SDPA axis.
         return None
-    if not _same_ordering(_expand(weights_layout[-1]), [s_atom]):
+    if not _same_ordering(_expand(weights_layout[key_axis]), [s_atom]):
         return None
     for atom, dim in zip(batch_atoms, weights_layout):
         # The batch layout of both matmuls has to agree: SDPA keeps it as is.
@@ -673,7 +696,8 @@ def _analyse_space(pattern) -> _Space | None:
             return None
 
     l_leaves = _ordering(l_atom.leaves())
-    l_prime = _ordering(_expand(weights_layout[n_batch]))
+    # The query rows sit on whichever of the two trailing axes is not the key one.
+    l_prime = _ordering(_expand(weights_layout[-1 if key_axis == -2 else -2]))
     if len(l_prime) != len(l_leaves) or {id(a) for a in l_prime} != {id(a) for a in l_leaves}:
         return None
 
@@ -925,9 +949,11 @@ def _try_fuse(softmax_op, block, finite_fill_mask: str) -> bool:
         value_t = bool(matmul_1.transpose_y.val)
         output_transposed = False
     elif matmul_1.inputs["y"] is pattern.weights_var:
-        if not bool(matmul_1.transpose_y.val):
-            # The contracting axis would not be the last one of the weights.
-            return False
+        # The weights are the right-hand operand, so the value is the left one
+        # and carries its embedding axis first: `[batch…, E, S] × [batch…, S, L']`
+        # (or the `transpose_y=True` spelling of it, which `_analyse_space` has
+        # already accounted for). Both need the value transposed, and both
+        # produce `[batch…, E, L']` instead of SDPA's `[batch…, L, E]`.
         value_src = matmul_1.inputs["x"]
         value_t = True
         output_transposed = True

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -1057,6 +1057,28 @@ class TestFuseAttentionToSdpaEndToEnd:
         ops = self._assert_fused(cml_model)
         assert ops == ["scaled_dot_product_attention"]
 
+    def test_attention_written_as_transposed_value_times_transposed_weights(self):
+        """``(Vᵀ Wᵀ)``: the weights are the *right* operand and contract on axis -2.
+
+        Both of the second matmul's spellings are reachable, because
+        ``dot_general`` gives each operand whichever of the two layouts
+        ``matmul`` accepts it is already in. Here that puts the weights on the
+        right with no ``transpose_y``, so the pass has to work out the key axis
+        from the operand side and the flag rather than assuming it is the last
+        one.
+        """
+        def attention(q, k, v):
+            scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0)
+            weights = jnp.swapaxes(jax.nn.softmax(scores, axis=-1), -2, -1)
+            return jnp.swapaxes(jnp.einsum("bhds,bhsl->bhdl", v, weights), -2, -1)
+
+        cml_model = run_and_compare(attention, [
+            jax.ShapeDtypeStruct((2, 3, 5, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 7, 4), jnp.float32),
+            jax.ShapeDtypeStruct((2, 3, 4, 7), jnp.float32),
+        ])
+        self._assert_fused(cml_model)
+
     def test_attention_with_additive_bias(self):
         def attention(q, k, v, bias):
             scores = jnp.einsum("bhld,bhsd->bhls", q, k) / jnp.sqrt(4.0) + bias

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -9,6 +9,8 @@ from jax._src.lib.mlir import ir
 from jax.lax import GatherDimensionNumbers, ScatterDimensionNumbers
 
 from tests.utils import (
+    converted_mil_program,
+    get_matmul_specs,
     get_model_instruction_types,
     run_and_compare,
     run_and_compare_hlo_module,
@@ -112,6 +114,72 @@ def test_tensor_multiplication():
     run_and_compare(full_tensor_product_3_2, (jnp.zeros((2, 2, 3)), jnp.zeros((2, 3))))
     run_and_compare(full_tensor_product_4_1, (jnp.zeros((15, 20, 5, 3)), jnp.zeros((10,))))
     run_and_compare(full_tensor_product_4_1, (jnp.zeros((2, 2, 2, 3)), jnp.zeros((2,))))
+
+
+@pytest.mark.parametrize(
+    "einsum, lhs_shape, rhs_shape, transpose_x, transpose_y",
+    [
+        # `A @ B`, the shape of every dense layer: the rhs already contracts on
+        # its first axis, which is what a plain matmul wants.
+        ("mk,kn->mn", (3, 4), (4, 5), False, False),
+        # The rhs contracts on its last axis instead; `transpose_y` says so.
+        ("mk,nk->mn", (3, 4), (5, 4), False, True),
+        # The same on the lhs, expressed with `transpose_x`.
+        ("km,kn->mn", (4, 3), (4, 5), True, False),
+        ("km,nk->mn", (4, 3), (5, 4), True, True),
+        # Batched, and with more than one batch dimension.
+        ("bmk,bkn->bmn", (2, 3, 4), (2, 4, 5), False, False),
+        ("abcd,abde->abce", (2, 3, 4, 5), (2, 3, 5, 6), False, False),
+        # A QKV-style projection: the rhs has two result dims, so it is reshaped
+        # — but not transposed, which is the case the pass pipeline could not
+        # clean up for us.
+        ("bsd,dhk->bshk", (1, 7, 6), (6, 2, 3), False, False),
+        # The two attention matmuls.
+        ("bhsd,bhtd->bhst", (1, 2, 5, 4), (1, 2, 7, 4), False, True),
+        ("bhst,bhtd->bhsd", (1, 2, 5, 7), (1, 2, 7, 4), False, False),
+    ],
+)
+def test_dot_general_uses_the_operand_orientation_that_needs_no_transpose(
+    einsum, lhs_shape, rhs_shape, transpose_x, transpose_y
+):
+    """``dot_general`` picks, per operand, the layout the operand is already in.
+
+    ``matmul`` accepts each operand in two layouts and its ``transpose_x`` /
+    ``transpose_y`` flags express the difference between them for free, so an
+    ``mb.transpose`` is only ever needed when *neither* layout is reachable
+    without one. Every shape here reaches one of them, so the converter emits no
+    ``transpose`` at all.
+    """
+    def jax_func(a, b):
+        return jnp.einsum(einsum, a, b)
+
+    inputs = (jnp.zeros(lhs_shape), jnp.zeros(rhs_shape))
+    mil_program = converted_mil_program(jax_func, inputs)
+    assert "transpose" not in get_model_instruction_types(mil_program)
+    specs = get_matmul_specs(mil_program)
+    assert len(specs) == 1, f"expected one matmul, got {specs}"
+    assert (specs[0].transpose_x, specs[0].transpose_y) == (transpose_x, transpose_y)
+
+    run_and_compare(jax_func, inputs)
+
+
+def test_dot_general_transposes_when_neither_orientation_is_free():
+    """Several contracting dims can force a real transpose, and that still works.
+
+    ``ackd`` has to become ``a(kc)d`` — its result dim sits between the two
+    contracting ones — which no ``transpose`` flag can express, so the converter
+    falls back to emitting one.
+    """
+    def jax_func(a, b):
+        return jnp.einsum("abcd,ackd->abk", a, b)
+
+    inputs = (jnp.zeros((2, 3, 4, 5)), jnp.zeros((2, 4, 6, 5)))
+    mil_program = converted_mil_program(jax_func, inputs)
+    assert get_model_instruction_types(mil_program).count("transpose") == 1
+    specs = get_matmul_specs(mil_program)
+    assert len(specs) == 1 and specs[0].transpose_y and not specs[0].transpose_x
+
+    run_and_compare(jax_func, inputs)
 
 
 def test_simple_reductions():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import copy
 from collections.abc import Mapping
+from typing import NamedTuple
 
 import coremltools as ct
 import jax
@@ -378,7 +379,14 @@ def run_and_compare_jit_lowering(
     )
 
 
-def get_model_instruction_types(cml_model) -> list[str]:
+def _mil_program_of(model_or_program) -> Program:
+    """Accept either a converted Core ML model or a bare MIL program."""
+    if isinstance(model_or_program, Program):
+        return model_or_program
+    return model_or_program._mil_program
+
+
+def get_model_instruction_types(model_or_program) -> list[str]:
     def collect_ops(ops: list) -> list[str]:
         collected_ops = []
         for op in ops:
@@ -388,11 +396,44 @@ def get_model_instruction_types(cml_model) -> list[str]:
 
         return collected_ops
 
-    mil_program = cml_model._mil_program
     all_ops = []
-    for func in mil_program.functions.values():
+    for func in _mil_program_of(model_or_program).functions.values():
         all_ops += collect_ops(func.operations)
     return all_ops
+
+
+class MatmulSpec(NamedTuple):
+    """How one ``matmul`` in a program is spelled."""
+
+    transpose_x: bool
+    transpose_y: bool
+    x_shape: tuple
+    y_shape: tuple
+
+
+def get_matmul_specs(model_or_program) -> list[MatmulSpec]:
+    """Describe every ``matmul`` in a converted model or a MIL program."""
+    def flag(value):
+        return False if value is None else bool(value.val)
+
+    def collect(ops):
+        specs = []
+        for op in ops:
+            if op.op_type == "matmul":
+                specs.append(MatmulSpec(
+                    flag(op.transpose_x),
+                    flag(op.transpose_y),
+                    tuple(op.inputs["x"].shape),
+                    tuple(op.inputs["y"].shape),
+                ))
+            for block in op.blocks:
+                specs += collect(block.operations)
+        return specs
+
+    all_specs = []
+    for func in _mil_program_of(model_or_program).functions.values():
+        all_specs += collect(func.operations)
+    return all_specs
 
 
 def export_hlo_module(jax_func, inputs):
@@ -401,6 +442,11 @@ def export_hlo_module(jax_func, inputs):
     exported = jax_export(jax_func, inputs)
     context = jax_mlir.make_ir_context()
     return ir.Module.parse(exported.mlir_module(), context=context)
+
+
+def converted_mil_program(jax_func, inputs) -> Program:
+    """The MIL program the converter emits for ``jax_func``, before any pass runs."""
+    return convert(export_hlo_module(jax_func, inputs), minimum_deployment_target=ct.target.iOS18)
 
 
 def run_and_compare_stateful(


### PR DESCRIPTION
Rescoped per [this comment](https://github.com/kasper0406/stablehlo-coreml/pull/92#issuecomment-5392054803): the constant-orientation half is gone — no `rhs_is_const` branch, no numpy baking, no `bake` flag. What is left does exactly one thing: **stop `op_dot_general` emitting `mb.transpose` ops it never needed to emit.**

### The rule

`matmul` accepts each operand in two layouts, and its `transpose_x` / `transpose_y` flags express the difference between them for free:

|  | plain | flagged |
|---|---|---|
| lhs | `[batch…, result…, contract…]` | `[batch…, contract…, result…]` |
| rhs | `[batch…, contract…, result…]` | `[batch…, result…, contract…]` |

So for each operand, pick whichever of the two it is **already** in — then no `mb.transpose` is needed and the flag carries the difference. Only when neither is reachable for free does the converter emit a transpose, and then it emits the same `[batch…, result…, contract…]` one it always did.

| einsum | perm for plain | perm for flagged | pick |
|---|---|---|---|
| `mk,kn->mn` | identity | swap | plain |
| `mk,nk->mn` | swap | identity | `transpose_y` |
| `km,kn->mn` | swap (lhs) | identity (lhs) | `transpose_x` |
| `bsd,dhk->bshk` (QKV) | identity | `[1,2,0]` | plain |
| `bhsd,bhtd->bhst` (QKᵀ) | `[0,1,3,2]` | identity | `transpose_y` |
| `bhst,bhtd->bhsd` (·V) | identity | `[0,1,3,2]` | plain |
| `abcd,ackd->abk` | `[0,1,3,2]` | `[0,2,1,3]` | neither — transpose, as before |

The lhs case is real too: `km,kn->mn` emitted two transposes on `main` and emits none now.

### What it removes

12-layer flax transformer (d_model 128, 4 heads), decode and prefill, identical numbers for both:

| | `main` | this PR |
|---|---|---|
| converter output, total ops | 3218 | **3072** |
| converter output, `transpose` | 169 | **96** |
| final program, total ops | 1420 | 1420 |
| final program, transpose / reshape / matmul | 61 / 196 / 73 | 61 / 196 / 73 |
| SDPA fusions | 12/12 | 12/12 |

146 ops fewer out of the converter: 73 transposes and their 73 permutation constants, one per matmul.

**That is mostly a compile-time saving, and it should be described as one.** The pipeline was already removing those transposes — `fuse_transpose_matmul` folds a last-two-axes transpose into the flag, `const_elimination` folds one applied to a constant — so the final program has the same op histogram as before. The single shape where a transpose *survived* into the final program is a QKV-style projection off an activation:

| `bsd,dhk->bshk` | ops |
|---|---|
| `main`, final program | `reshape, transpose, reshape, matmul, reshape` |
| this PR, final program | `reshape, reshape, matmul, reshape` |

Its rhs permutation is `[1, 2, 0]`, which no transpose flag can express, so nothing downstream could fold it.

There is **no separate redundant-reshape saving**. A scan for literal no-op reshapes (input shape == output shape) across the shapes above finds none, and the reshape count is unchanged everywhere except alongside that one transpose.

### Constant orientation is out of scope

Reorienting constant weights is a constant-folding decision and belongs to coremltools' pass pipeline, not here — `const_elimination` (10), `fuse_transpose_matmul` (52) and `merge_affine_dequantize_with_consecutive_ops` (83) all own parts of it. The converter cannot even reliably tell what is constant: `rhs.val is not None` caught 1 of 277 weight matmuls on a real flax/JAX export, because weights arrive through intervening shape ops. And the bad orientation for quantized weights is a coremltools bug being filed separately. All of that reasoning is [in the comment](https://github.com/kasper0406/stablehlo-coreml/pull/92#issuecomment-5392054803).

Accordingly the converter never touches a constant here: it does not permute one, does not reshape one, and emits no op against one that it would not emit against an activation.

### ⚠️ It does still move where the *pipeline* lands for constants

Flagging this loudly rather than burying it, because it is the class of change that caused the regression on the previous revision.

Not emitting the transpose leaves the pipeline nothing to fold into the constant, so the orientation it settles on changes. On the 12-layer transformer all 73 weights move from `matmul(const[N, K], transpose_y=True)` to `matmul(const[K, N])`. Measured on `x @ W`, `W` of shape `(128, 256)`:

| flow | `main` | this PR |
|---|---|---|
| unquantized | `const[256,128]`, `transpose_y=True` | `const[128,256]`, no flag |
| `ct.optimize.coreml.linear_quantize_weights` after conversion | `constexpr[256,128]`, `transpose_y=True` | `constexpr[128,256]`, no flag |
| `compression::linear_quantize_weights` inside the pipeline | `constexpr[128,256]`, no flag | `constexpr[128,256]`, no flag |

The two quantization orderings now agree, which they did not before. But they agree on `[K, N]` / no flag, and per the downstream measurement in [this comment](https://github.com/kasper0406/stablehlo-coreml/pull/92#issuecomment-5391404711) that is the *slow* side for an int4 `constexpr` on the GPU backend — so the post-conversion quantization flow, which was landing on the fast side by accident of `const_elimination` running first, no longer does.

There is no converter-side rule that avoids this: for a constant operand the transpose costs nothing in the final program (the pipeline folds it either way), so *any* rule that stops emitting it is purely a layout change. Worth deciding explicitly before merging — the op-count win above is entirely on the activation side and at compile time.

### `fuse_attention_to_sdpa`

Kept from the previous revision and still load-bearing: both spellings of the second attention matmul are reachable, so the pass has to derive the key axis from the side `weights_var` enters `matmul_1` on and that side's transpose flag instead of assuming it is the last one. Reverting just that file drops attention written as `(Vᵀ Wᵀ)ᵀ` — weights on the right of `matmul_1`, contracting over axis -2 — from fused to unfused, which `main` fused; `test_attention_written_as_transposed_value_times_transposed_weights` covers it. The 12-layer transformer fuses 12/12 blocks with or without it.

### Tests

`tests/utils.py` gains `converted_mil_program` and `get_matmul_specs`, so the new tests assert on what the converter emits rather than on what survives the pipeline. `test_dot_general_uses_the_operand_orientation_that_needs_no_transpose` parametrises the nine shapes above; `test_dot_general_transposes_when_neither_orientation_is_free` covers the fallback. Symbolic/dynamic shapes, the single-`-1`-per-reshape constraint, the empty-result-dims squeezes and the final reshape are untouched. `pytest tests/ --ignore=tests/pytorch`: 436 passed. `ruff check .`: clean.
