### PR TITLE
Do not fuse a GELU whose constants broadcast x

### DIFF
--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -27,6 +27,7 @@ from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
 from .pattern_utils import (
     peel_to_scaled_input,
+    shapes_equal,
     sole_consumer,
     uniform_const_operand,
     uniform_scalar_value,
@@ -99,6 +100,11 @@ def _match(mul_op, block):
             if abs(factor - _FACTOR) > _FACTOR_TOLERANCE:
                 continue
             if not _match_half_x(half_var, candidate, block):
+                continue
+            # A uniform constant of the pattern is accepted whatever its shape, so
+            # it may broadcast `x`; `gelu(x)` has `x`'s shape and cannot replace a
+            # wider result.
+            if not shapes_equal(mul_op.outputs[0].shape, candidate.shape):
                 continue
             return candidate
 

--- a/stablehlo_coreml/passes/fuse_gelu_tanh.py
+++ b/stablehlo_coreml/passes/fuse_gelu_tanh.py
@@ -37,6 +37,7 @@ from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 from .pattern_utils import (
     dtype_epsilon,
     peel_to_scaled_input,
+    shapes_equal,
     sole_consumer,
     uniform_const_operand,
     uniform_scalar_value,
@@ -161,6 +162,11 @@ def _match(mul_op, block):
 
             x = _match_tanh_argument(tanh_op.x, block, tolerance)
             if x is None:
+                continue
+            # A uniform constant of the pattern is accepted whatever its shape, so
+            # it may broadcast `x`; `gelu(x)` has `x`'s shape and cannot replace a
+            # wider result.
+            if not shapes_equal(mul_op.outputs[0].shape, x.shape):
                 continue
 
             # What is left of the product must be `0.5 * x`.

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -92,6 +92,30 @@ class TestFuseGeluErfc:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["gelu"]
 
+    def test_not_fused_when_a_uniform_constant_broadcasts_x(self):
+        """A uniform constant is matched whatever its shape -- including a wider one.
+
+        `0.5 * x` is then `(4, 8)` while `gelu(x)` would be `(4, 1)`, so fusing
+        would silently drop the broadcast.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            return _erfc_gelu(x, half=np.full((4, 8), 0.5, dtype=np.float32))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
+    def test_not_fused_when_a_fill_broadcasts_x(self):
+        """Same, for the `fill` spelling of a uniform constant."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            return _erfc_gelu(x, half=mb.fill(shape=(4, 8), value=0.5))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
     def test_not_fused_for_the_wrong_factor(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
         def prog(x):

--- a/tests/passes/test_fuse_gelu_tanh.py
+++ b/tests/passes/test_fuse_gelu_tanh.py
@@ -156,6 +156,30 @@ class TestFuseGeluTanh:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["gelu"]
 
+    def test_not_fused_when_a_uniform_constant_broadcasts_x(self):
+        """A uniform constant is matched whatever its shape -- including a wider one.
+
+        The product is then `(4, 8)` while `gelu(x)` would be `(4, 1)`, so fusing
+        would silently drop the broadcast.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            return _tanh_gelu(x, half=np.full((4, 8), 0.5, dtype=np.float32))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
+    def test_not_fused_when_a_fill_broadcasts_x(self):
+        """Same, for the `fill` spelling of a uniform constant."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 1))])
+        def prog(x):
+            return _tanh_gelu(x, half=mb.fill(shape=(4, 8), value=0.5))
+
+        _apply(prog)
+        assert "gelu" not in get_op_types_in_program(prog)
+        assert prog.functions["main"].outputs[0].shape == (4, 8)
+
     def test_not_fused_for_the_wrong_cube_coefficient(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(4, 8))])
         def prog(x):


### PR DESCRIPTION
## Bug

`uniform_scalar_value` deliberately accepts a uniform tensor constant of any shape (and a `fill`), so both GELU passes could match a pattern where the `0.5` constant *broadcasts* `x`. Neither pass checked that `gelu(x)` has the shape of the value it replaces. With `x: (4,1)` and a uniform `(4,8)` constant the function output silently changed to `(4,1)`; with a downstream consumer it raised `New var ... doesn't have compatible subtype`.

Reachable from JAX: `0.5 * x_broadcast` keeps its `tile` (removing it would shrink the output), which `const_elimination` then folds into a full-size uniform constant.

## Fix

Decline the match unless `shapes_equal(mul.out.shape, x.shape)` (symbol-aware, conservative on unknown shapes) — the same check `fuse_rmsnorm` already does via `_is_broadcast_partner`. Two regression tests per pass (uniform tensor constant, `fill`); reverting the pass change makes exactly those four fail.

Found in a review pass before cutting the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
