### PR TITLE
fuse_logit_softcap: drop the alpha*beta ≈ 1 gate and its tolerance machinery

### DIFF
--- a/stablehlo_coreml/passes/fuse_logit_softcap.py
+++ b/stablehlo_coreml/passes/fuse_logit_softcap.py
@@ -1,7 +1,7 @@
-"""MIL pass: fuse a "logit softcap" ``tanh`` sandwich into ``scaled_tanh``.
+"""MIL pass: fuse a ``tanh`` sandwiched between two constant scalings into ``scaled_tanh``.
 
-Attention logit softcapping (Gemma-style) is written in JAX as
-``jnp.tanh(x / cap) * cap``, which the converter lowers to::
+The motivating case is attention logit softcapping (Gemma-style), written in JAX
+as ``jnp.tanh(x / cap) * cap``, which the converter lowers to::
 
     %1 = real_div(x=%x, y=30.0)     # or mul(x=%x, y=1/30)
     %2 = tanh(x=%1)
@@ -10,11 +10,9 @@ Attention logit softcapping (Gemma-style) is written in JAX as
 MIL has a single op for that: ``scaled_tanh(x, alpha, beta) = alpha * tanh(beta * x)``.
 Fusing saves two elementwise passes over a (usually large) logits tensor.
 
-Only the exact ``alpha * beta ~= 1`` shape is fused -- i.e. a genuine softcap,
-where the composition is the identity for small ``x``. A general
-``a * tanh(b * x)`` would also be expressible as ``scaled_tanh``, but scaling by
-an arbitrary constant is not necessarily a softcap and is left alone so that the
-pass stays a targeted, easily reviewable rewrite.
+``scaled_tanh`` computes exactly the matched expression, so any pair of constants
+is fused; the softcap shape (``alpha * beta == 1``, where the composition is the
+identity for small ``x``) is just the common case, not a requirement.
 """
 
 import logging
@@ -30,37 +28,12 @@ from .pattern_utils import sole_consumer, uniform_const_operand
 
 logger = logging.getLogger(__name__)
 
-# Absolute tolerance on `alpha * beta == 1`, for constants that carry full fp32
-# precision. It is a lower bound only: `_tolerance` widens it for narrower
-# element types, where `1 / cap` cannot be represented anywhere near this well.
-_TOLERANCE = 1e-4
-# How many ulps of the operand type the product may be away from 1. Both `alpha`
-# and `beta` are rounded to that type, and JAX already evaluates `1 / cap` in it,
-# so the product drifts by a small multiple of the type's epsilon.
-_TOLERANCE_ULPS = 4.0
-
-
-def _dtype_epsilon(var) -> float:
-    """Machine epsilon of ``var``'s element type (``0.0`` if it is not a float)."""
-    if var is None:
-        return 0.0
-    dtype = getattr(var, "dtype", None)
-    if dtype is None or not types.is_float(dtype):
-        return 0.0
-    return float(np.finfo(types.nptype_from_builtin(dtype)).eps)
-
-
-def _tolerance(*vars_) -> float:
-    """Tolerance on ``alpha * beta == 1`` for constants stored in these vars' types."""
-    epsilon = max((_dtype_epsilon(var) for var in vars_), default=0.0)
-    return max(_TOLERANCE, _TOLERANCE_ULPS * epsilon)
-
 
 def _scalar_operand(op):
     """Like :func:`uniform_const_operand`, but only for single-element constants.
 
-    Returns ``(const_value, other_var, const_var)``, or ``None`` when no operand
-    is a uniform compile-time constant or when that constant is not rank-0/1 (a
+    Returns ``(const_value, other_var)``, or ``None`` when no operand is a
+    uniform compile-time constant or when that constant is not rank-0/1 (a
     constant with a real shape would broadcast the output, which ``scaled_tanh``
     cannot do).
     """
@@ -71,42 +44,41 @@ def _scalar_operand(op):
     const = op.y if op.x is other else op.x
     if const.shape is not None and int(np.prod(const.shape)) != 1:
         return None
-    return value, other, const
+    return value, other
 
 
 def _inner_scale(tanh_op):
-    """Return ``(x, beta, beta_const)`` for ``tanh(x * beta)``.
+    """Return ``(x, beta)`` for ``tanh(x * beta)``.
 
     A ``mul``/``real_div`` by a compile-time constant is peeled off the ``tanh``
-    argument; ``beta_const`` is the ``Var`` holding that constant, or ``None``
-    when nothing was peeled (``beta == 1``).
+    argument; ``beta == 1`` when there is nothing to peel.
     """
     inner = tanh_op.x.op
     if inner is None or inner.enclosing_block is not tanh_op.enclosing_block:
-        return tanh_op.x, 1.0, None
+        return tanh_op.x, 1.0
     if sole_consumer(tanh_op.x) is not tanh_op:
         # The scaled value is used elsewhere, so removing the scaling op would
         # not pay off (and it has to stay in the graph anyway).
-        return tanh_op.x, 1.0, None
+        return tanh_op.x, 1.0
 
     if inner.op_type == "mul":
         scalar = _scalar_operand(inner)
         if scalar is not None:
-            beta, operand, const = scalar
-            return operand, beta, const
-        return tanh_op.x, 1.0, None
+            beta, operand = scalar
+            return operand, beta
+        return tanh_op.x, 1.0
 
     if inner.op_type == "real_div":
         # Only `x / c` is a scaling; `c / x` is not.
         scalar = _scalar_operand(inner)
         if scalar is not None and scalar[1] is inner.x and scalar[0] != 0.0:
-            return inner.x, 1.0 / scalar[0], scalar[2]
+            return inner.x, 1.0 / scalar[0]
 
-    return tanh_op.x, 1.0, None
+    return tanh_op.x, 1.0
 
 
 def _match(mul_op, block):
-    """Return ``(x, alpha, beta)`` if ``mul_op`` completes a softcap pattern."""
+    """Return ``(x, alpha, beta)`` if ``mul_op`` computes ``alpha * tanh(beta * x)``."""
     if mul_op.op_type != "mul":
         return None
 
@@ -123,12 +95,9 @@ def _match(mul_op, block):
         scalar = _scalar_operand(mul_op)
         if scalar is None or scalar[1] is not tanh_var:
             continue
-        alpha, _, alpha_const = scalar
+        alpha = scalar[0]
 
-        x, beta, beta_const = _inner_scale(tanh_op)
-        if abs(alpha * beta - 1.0) > _tolerance(x, alpha_const, beta_const):
-            continue
-
+        x, beta = _inner_scale(tanh_op)
         return x, alpha, beta
 
     return None
@@ -169,18 +138,17 @@ def _fuse_logit_softcap(block) -> int:
 @register_pass(namespace="common")
 class fuse_logit_softcap(AbstractGraphPass):
     """
-    Fuse ``alpha * tanh(x * beta)`` (with ``alpha * beta == 1``) into
-    ``scaled_tanh(x, alpha, beta)``.
+    Fuse ``alpha * tanh(beta * x)`` into ``scaled_tanh(x, alpha, beta)``.
+
+    The motivating case is Gemma-style logit softcapping, ``cap * tanh(x / cap)``,
+    but ``scaled_tanh`` is exactly the matched expression, so no relation between
+    ``alpha`` and ``beta`` is required.
 
     Both operand orders of the multiplications are accepted, and the inner
-    scaling may be written as ``mul(x, beta)`` or ``real_div(x, 1/beta)``.
-    The scaling constants must be uniform, single-element, compile-time
-    constants, and the ``tanh`` output must have exactly one consumer.
-
-    ``alpha * beta == 1`` is checked with a tolerance that grows with the
-    element type of the operands: for an fp16 model ``1 / cap`` is rounded to
-    fp16 before it ever reaches MIL, so the product is only unity to within a
-    few fp16 ulps (``30.0 * fp16(1/30) == 0.99976``).
+    scaling may be written as ``mul(x, beta)`` or ``real_div(x, 1/beta)``, or be
+    missing entirely (``beta == 1``). The scaling constants must be uniform,
+    single-element, compile-time constants, and the ``tanh`` output must have
+    exactly one consumer.
 
     Given:
         %1 = real_div(x=%0, y=30.0)
@@ -195,4 +163,4 @@ class fuse_logit_softcap(AbstractGraphPass):
         for f in prog.functions.values():
             fused = _fuse_logit_softcap(f)
             if fused:
-                logger.debug("fuse_logit_softcap: fused %d softcap(s)", fused)
+                logger.debug("fuse_logit_softcap: fused %d scaled tanh(s)", fused)

--- a/tests/passes/test_fuse_logit_softcap.py
+++ b/tests/passes/test_fuse_logit_softcap.py
@@ -77,14 +77,9 @@ class TestFuseLogitSoftcap:
         assert get_op_types_in_program(prog) == ["scaled_tanh"]
 
     @pytest.mark.parametrize("cap", [30.0, 50.0])
-    def test_fp16_reciprocal_rounding_is_still_fused(self, cap):
-        """``1 / cap`` is rounded to fp16 long before MIL sees it.
-
-        ``fp16(1/30) * 30 == 0.99976``, which is 2.4e-4 away from unity -- more
-        than the fp32 tolerance allows, but well inside one fp16 ulp.
-        """
+    def test_fp16_softcap_is_fused(self, cap):
+        """The emitted constants take the element type of the fused input."""
         beta = np.float16(1.0) / np.float16(cap)
-        assert abs(float(beta) * cap - 1.0) > 1e-4
 
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8), dtype=types.fp16)])
         def prog(x):
@@ -99,34 +94,31 @@ class TestFuseLogitSoftcap:
         assert np.isclose(fused.alpha.val, cap)
         assert fused.beta.val == beta
 
-    def test_fp32_keeps_the_tight_tolerance(self):
-        """The widened tolerance is fp16-only; fp32 constants stay tightly checked."""
+    def test_arbitrary_scalings_are_fused(self):
+        """``scaled_tanh`` is the matched expression, so no softcap shape is required."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
         def prog(x):
-            scaled = mb.mul(x=x, y=np.float32(1.0 / 30.0))
-            # 5e-4 off unity: representable in fp32, so not a rounding artifact.
-            return mb.mul(x=mb.tanh(x=scaled), y=np.float32(30.0 * 1.0005))
+            scaled = mb.mul(x=x, y=2.0)
+            return mb.mul(x=mb.tanh(x=scaled), y=0.5)
 
         _apply(prog)
-        assert "scaled_tanh" not in get_op_types_in_program(prog)
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
 
-    def test_not_fused_in_fp16_when_the_product_is_far_from_one(self):
-        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8), dtype=types.fp16)])
-        def prog(x):
-            scaled = mb.mul(x=x, y=np.float16(1.0 / 30.0))
-            return mb.mul(x=mb.tanh(x=scaled), y=np.float16(20.0))
+        fused = _scaled_tanh_ops(prog)[0]
+        assert np.isclose(fused.alpha.val, 0.5)
+        assert np.isclose(fused.beta.val, 2.0)
 
-        _apply(prog)
-        assert "scaled_tanh" not in get_op_types_in_program(prog)
-
-    def test_not_fused_when_product_is_not_one(self):
+    def test_outer_scale_only_gives_beta_one(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
         def prog(x):
-            scaled = mb.real_div(x=x, y=30.0)
-            return mb.mul(x=mb.tanh(x=scaled), y=20.0)
+            return mb.mul(x=mb.tanh(x=x), y=20.0)
 
         _apply(prog)
-        assert get_op_types_in_program(prog) == ["real_div", "tanh", "mul"]
+        assert get_op_types_in_program(prog) == ["scaled_tanh"]
+
+        fused = _scaled_tanh_ops(prog)[0]
+        assert np.isclose(fused.alpha.val, 20.0)
+        assert np.isclose(fused.beta.val, 1.0)
 
     def test_not_fused_without_outer_scale(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8)), mb.TensorSpec(shape=(2, 8))])
@@ -157,15 +149,18 @@ class TestFuseLogitSoftcap:
         assert "scaled_tanh" not in get_op_types_in_program(prog)
 
     def test_inner_scale_shared_keeps_beta_one(self):
-        """When the scaled value escapes, only `a * tanh(v)` may be fused (a == 1)."""
+        """When the scaled value escapes, the division stays and only ``alpha`` is fused."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
         def prog(x):
             scaled = mb.real_div(x=x, y=30.0)
             return mb.mul(x=mb.tanh(x=scaled), y=30.0), scaled
 
         _apply(prog)
-        # beta would have to be 1 (the div cannot be peeled), and 30 * 1 != 1.
-        assert "scaled_tanh" not in get_op_types_in_program(prog)
+        assert get_op_types_in_program(prog) == ["real_div", "scaled_tanh"]
+
+        fused = _scaled_tanh_ops(prog)[0]
+        assert np.isclose(fused.alpha.val, 30.0)
+        assert np.isclose(fused.beta.val, 1.0)
 
     def test_fused_inside_nested_block(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
@@ -217,14 +212,28 @@ class TestFuseLogitSoftcapEndToEnd:
         assert ops.count("scaled_tanh") == 1
         assert "tanh" not in ops
 
-    def test_unbalanced_scaling_is_not_fused(self):
+    def test_unbalanced_scaling_is_fused(self):
+        """``alpha * beta != 1`` is still exactly ``scaled_tanh``."""
         def f(x):
             return jnp.tanh(x / 30.0) * 20.0
 
         cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
         ops = get_model_instruction_types(cml_model)
-        assert "scaled_tanh" not in ops
-        assert ops.count("tanh") == 1
+        assert ops.count("scaled_tanh") == 1
+        assert "tanh" not in ops
+
+    @pytest.mark.parametrize(
+        "f",
+        [
+            pytest.param(lambda x: 0.5 * jnp.tanh(2.0 * x), id="half_tanh_of_double"),
+            pytest.param(lambda x: jnp.tanh(x) * 3.0, id="outer_scale_only"),
+        ],
+    )
+    def test_general_scalings_are_fused(self, f):
+        cml_model = run_and_compare(f, [jax.ShapeDtypeStruct((4, 16), jnp.float32)])
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("scaled_tanh") == 1
+        assert "tanh" not in ops
 
     @pytest.mark.parametrize("cap", [30.0, 50.0])
     @pytest.mark.parametrize(
@@ -241,11 +250,7 @@ class TestFuseLogitSoftcapEndToEnd:
     )
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float16])
     def test_gemma_style_softcap_spellings(self, spelling, cap, dtype):
-        """Every way Gemma-2 writes ``cap * tanh(logits / cap)`` must fuse.
-
-        The fp16 cases matter: JAX folds ``1 / cap`` in the operand dtype, so
-        ``alpha * beta`` only reaches unity to within an fp16 ulp.
-        """
+        """Every way Gemma-2 writes ``cap * tanh(logits / cap)`` must fuse."""
         precision_loss = jnp.finfo(dtype).eps / jnp.finfo(jnp.float32).eps
         cml_model = run_and_compare(
             lambda x: spelling(x, cap),


### PR DESCRIPTION
## Why

`scaled_tanh(x, alpha, beta) = alpha * tanh(beta * x)` is *exactly* the expression the pass matches, for any `alpha`, `beta`. The `alpha * beta ≈ 1` gate therefore bought no correctness — it only restricted what fuses, and it was the sole reason the pass carried numerical-tolerance machinery (`_TOLERANCE`, `_TOLERANCE_ULPS`, a verbatim copy of `pattern_utils.dtype_epsilon`, `_tolerance`, and three fp16-rounding tests).

## What

- Drop the gate and everything that existed only for it; `_scalar_operand` / `_inner_scale` no longer return the const `Var`s that were needed only to derive the tolerance.
- Docstrings now describe the general `alpha * tanh(beta * x)` fusion with logit softcap as the motivating case.
- Tests: `0.5 * tanh(2x)`, `tanh(x) * 20` (beta = 1) and `tanh(x/30) * 20` now fuse (with numerics checked end-to-end); fp16 softcap still fuses.

`fuse_logit_softcap.py`: 198 → 166 lines; net −27 lines including tests. Structural guards (sole consumer, uniform single-element constants, block scoping, `real_div` direction) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
