### PR TITLE
replace_decomposed_softmax: reject a squeezed denominator on a non-leading axis

### DIFF
--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -141,6 +141,13 @@ def _match(real_div_op):
         if not any(shapes_equal(op.outputs[0].shape, shape) for shape in allowed):
             return None
 
+    # ... and the denominator itself has to broadcast back along `axis`. A
+    # `reduced_shape` denominator only does so when `axis` is the leading one:
+    # NumPy aligns shapes to the right, so a rank-1 gap anywhere else lines the
+    # sum up against the wrong axes and the quotient is not a softmax.
+    if not _is_constant_along(denominator, axis, rank):
+        return None
+
     # The exp output must not be observed anywhere else.
     block = real_div_op.enclosing_block
     matched_set = set(matched)

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -363,6 +363,46 @@ class TestReplaceDecomposedSoftmax:
         _apply(prog)
         assert "softmax" not in get_op_types_in_program(prog)
 
+    def test_not_replaced_for_a_squeezed_sum_on_a_middle_axis(self):
+        """A `keep_dims=False` sum right-aligns onto the wrong axes.
+
+        The denominator has shape (4, 4), which `real_div` broadcasts over axes
+        1 and 2 of the (4, 4, 4) numerator -- not over axis 1 alone, so this is
+        not `softmax(x, axis=1)`.
+        """
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 4, 4))])
+        def prog(x):
+            exponentiated = mb.exp(x=x)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=False)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_not_replaced_when_the_sum_is_squeezed_on_a_middle_axis(self):
+        """Same as above, with the dimension dropped by an explicit `squeeze`."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 4, 4))])
+        def prog(x):
+            exponentiated = mb.exp(x=x)
+            total = mb.reduce_sum(x=exponentiated, axes=[1], keep_dims=True)
+            squeezed = mb.squeeze(x=total, axes=[1])
+            return mb.real_div(x=exponentiated, y=squeezed)
+
+        _apply(prog)
+        assert "softmax" not in get_op_types_in_program(prog)
+
+    def test_replaces_a_squeezed_sum_on_the_leading_axis(self):
+        """Dropping the leading dimension *is* the broadcast that softmax needs."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 4, 4))])
+        def prog(x):
+            exponentiated = mb.exp(x=x)
+            total = mb.reduce_sum(x=exponentiated, axes=[0], keep_dims=False)
+            return mb.real_div(x=exponentiated, y=total)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["softmax"]
+        assert prog.functions["main"].operations[-1].axis.val == 0
+
     def test_not_replaced_when_denominator_is_not_a_sum(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
         def prog(x):


### PR DESCRIPTION
## Bug

`replace_decomposed_softmax` allowed the denominator of `exp(x) / sum` to have the reduced (`keep_dims=False`, or `squeeze`d) shape. That is only a valid broadcast when `axis == 0`; for any other axis NumPy's right-alignment lines the sum up against the wrong axes, yet the pass still rewrote to `softmax(x, axis)`.

Repro: `x: (4,4,4)`, `e = exp(x)`, `s = reduce_sum(e, axes=[1], keep_dims=False)` → `(4,4)`, `out = real_div(e, s)`. Old behaviour: emits `softmax(axis=1)`, which is numerically different from the original graph.

## Fix

After the shape walk, require `_is_constant_along(denominator, axis, rank)` on the var that actually reaches the `real_div` — the same helper the `sub` peel already uses. Gating `reduced_shape` in the walk instead would break the ordinary JAX chain, which legitimately passes *through* the reduced shape (`reduce_sum(keep_dims=False) → reshape`) on any axis.

Tests: middle-axis `keep_dims=False` and explicit `squeeze` are no longer rewritten (both fail on the old code); axis-0 `keep_dims=False` still fuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
