### PR TITLE
build_pass_pipeline: idempotent for any base; drop DEFAULT_HLO_PIPELINE

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ cml_model = ct.convert(
 `build_pass_pipeline()` returns a fresh `ct.PassPipeline` built from
 `ct.PassPipeline.DEFAULT` with the stablehlo-coreml graph passes inserted at the right
 places. Pass your own `base` pipeline to customise it, e.g.
-`build_pass_pipeline(my_pipeline)` — the base is left untouched, and the returned
-pipeline is yours to mutate.
+`build_pass_pipeline(my_pipeline)`. The pre-built `stablehlo_coreml.DEFAULT_HLO_PIPELINE`
+is the same thing, constructed once at import time — copy it before mutating it.
 
 ### Obtaining a StableHLO Module from JAX
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ cml_model = ct.convert(
 `build_pass_pipeline()` returns a fresh `ct.PassPipeline` built from
 `ct.PassPipeline.DEFAULT` with the stablehlo-coreml graph passes inserted at the right
 places. Pass your own `base` pipeline to customise it, e.g.
-`build_pass_pipeline(my_pipeline)`. The pre-built `stablehlo_coreml.DEFAULT_HLO_PIPELINE`
-is the same thing, constructed once at import time — copy it before mutating it.
+`build_pass_pipeline(my_pipeline)` — the base is left untouched, and the returned
+pipeline is yours to mutate.
 
 ### Obtaining a StableHLO Module from JAX
 

--- a/stablehlo_coreml/__init__.py
+++ b/stablehlo_coreml/__init__.py
@@ -1,6 +1,6 @@
 from .converter import convert
-from .passes.utils import DEFAULT_HLO_PIPELINE, build_pass_pipeline
+from .passes.utils import build_pass_pipeline
 from .state import StateSpec
 
 __version__ = "0.0.0"
-__all__ = ['DEFAULT_HLO_PIPELINE', 'StateSpec', 'build_pass_pipeline', 'convert']
+__all__ = ['StateSpec', 'build_pass_pipeline', 'convert']

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -91,6 +91,11 @@ _FUSION_ANCHOR = "common::fuse_matmul_weight_bias"
 _LATE_FUSION_ANCHOR = "common::fuse_reduce_mean"
 
 
+def _contains_group(passes: list[str], group: list[str]) -> bool:
+    """Whether ``group`` appears as a contiguous run anywhere in ``passes``."""
+    return any(passes[i:i + len(group)] == group for i in range(len(passes) - len(group) + 1))
+
+
 def _insert_passes(
     pipeline: ct.PassPipeline,
     pass_names: list[str],
@@ -106,12 +111,14 @@ def _insert_passes(
     we need them right between our own passes. A pass may legitimately appear in
     more than one group (``fuse_reduce_keep_dims`` runs both in ``CLEANUP_PASSES``
     and in ``LATE_FUSION_PASSES``), so "already inserted" is decided per group --
-    the group is skipped only when it already occupies the slot next to its
-    anchor, which is what makes re-inserting into a pipeline that already has the
-    groups a no-op. If ``anchor`` is not part of the pipeline, ``fallback_index``
-    is used instead (``None`` meaning "append at the end").
+    the group is skipped when its whole sequence already runs somewhere in the
+    pipeline, wherever that is. Looking for the group itself rather than at the
+    slot next to the anchor is what keeps re-inserting a no-op even for a base
+    that has no anchors at all (where every group lands on a fallback index). If
+    ``anchor`` is not part of the pipeline, ``fallback_index`` is used instead
+    (``None`` meaning "append at the end").
     """
-    if len(pass_names) == 0:
+    if _contains_group(pipeline.passes, pass_names):
         return
 
     if anchor in pipeline.passes:
@@ -120,13 +127,6 @@ def _insert_passes(
         index = len(pipeline.passes)
     else:
         index = fallback_index
-
-    if after:
-        occupied = pipeline.passes[index:index + len(pass_names)]
-    else:
-        occupied = pipeline.passes[max(index - len(pass_names), 0):index]
-    if occupied == pass_names:
-        return
 
     for offset, pass_name in enumerate(pass_names):
         pipeline.insert_pass(index=index + offset, pass_name=pass_name)

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -2,8 +2,7 @@
 
 Importing this module registers every pass in ``stablehlo_coreml.passes`` with
 coremltools' ``PASS_REGISTRY``. Use :func:`build_pass_pipeline` to obtain a
-pipeline with the passes inserted at the right places, or the pre-built
-:data:`DEFAULT_HLO_PIPELINE` convenience object.
+pipeline with the passes inserted at the right places.
 """
 
 import copy
@@ -147,6 +146,3 @@ def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
     _insert_passes(pipeline, LATE_FUSION_PASSES, _LATE_FUSION_ANCHOR, fallback_index=None, after=True)
 
     return pipeline
-
-
-DEFAULT_HLO_PIPELINE: ct.PassPipeline = build_pass_pipeline()

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -90,6 +90,17 @@ def test_build_pass_pipeline_is_idempotent():
     assert twice.passes == once.passes
 
 
+def test_build_pass_pipeline_is_idempotent_without_the_anchors():
+    """Without the anchors every group lands on a fallback index, which is no
+    slot the second call could look at -- it has to find the groups themselves."""
+    base = ct.PassPipeline.EMPTY
+    base.passes = ["common::noop_elimination"]
+
+    once = build_pass_pipeline(base)
+    twice = build_pass_pipeline(once)
+    assert twice.passes == once.passes
+
+
 def test_build_pass_pipeline_with_base_missing_the_anchors():
     """Without the anchors, cleanup passes go first and fusion passes last."""
     base = ct.PassPipeline.EMPTY
@@ -116,11 +127,11 @@ def test_group_is_inserted_even_when_the_base_already_has_one_of_its_passes():
     """Insertion is decided per group, not per pass.
 
     A pass may belong to two groups (`fuse_reduce_keep_dims`), so "already in the
-    pipeline" cannot mean "skip it". The group is skipped only when it already
-    occupies the slot next to its anchor -- which is what keeps
-    `build_pass_pipeline` idempotent. A stray copy elsewhere in the base is
-    therefore left where it is and the group is inserted anyway; our passes are
-    idempotent, so the duplicate is harmless.
+    pipeline" cannot mean "skip it". The group is skipped only when its whole
+    sequence already runs somewhere in the pipeline -- which is what keeps
+    `build_pass_pipeline` idempotent. A stray copy of a single pass is therefore
+    left where it is and the group is inserted anyway; our passes are idempotent,
+    so the duplicate is harmless.
     """
     base = ct.PassPipeline.EMPTY
     base.passes = ["common::fuse_reduce_keep_dims", "common::const_elimination"]

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -6,7 +6,6 @@ import pytest
 from stablehlo_coreml import build_pass_pipeline
 from stablehlo_coreml.passes.utils import (
     CLEANUP_PASSES,
-    DEFAULT_HLO_PIPELINE,
     FUSION_PASSES,
     LATE_FUSION_PASSES,
 )
@@ -33,7 +32,7 @@ def test_pass_is_registered(pass_name):
 
 @pytest.mark.parametrize("pass_name", OUR_PASSES)
 def test_default_pipeline_contains_each_pass_once_per_group(pass_name):
-    assert DEFAULT_HLO_PIPELINE.passes.count(pass_name) == EXPECTED_PASS_COUNTS[pass_name]
+    assert build_pass_pipeline().passes.count(pass_name) == EXPECTED_PASS_COUNTS[pass_name]
 
 
 def test_fuse_reduce_keep_dims_runs_again_in_the_late_fusion_group():
@@ -74,7 +73,7 @@ def test_build_pass_pipeline_returns_distinct_objects():
 
     first.append_pass(DCE_PASS_NAME)
     assert first.passes != second.passes
-    assert DEFAULT_HLO_PIPELINE.passes == second.passes
+    assert build_pass_pipeline().passes == second.passes
 
 
 def test_build_pass_pipeline_does_not_mutate_the_base():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import copy
 from collections.abc import Mapping
 
 import coremltools as ct
@@ -11,7 +10,7 @@ from jax._src.interpreters import mlir as jax_mlir
 from jax._src.lib.mlir import ir
 from jax.export import export as _jax_export
 
-from stablehlo_coreml import DEFAULT_HLO_PIPELINE
+from stablehlo_coreml import build_pass_pipeline
 from stablehlo_coreml.converter import convert
 from stablehlo_coreml.function_interface import sanitize_name
 from stablehlo_coreml.state import preferred_argument_name, resolve_state_map
@@ -120,7 +119,7 @@ def _convert_mil_to_coreml(
             f"max allowed complexity is {max_complexity}"
         )
 
-    pipeline = copy.deepcopy(DEFAULT_HLO_PIPELINE)
+    pipeline = build_pass_pipeline()
     pipeline.remove_passes(['common::add_fp16_cast'])
 
     convert_kwargs = dict(


### PR DESCRIPTION
Two commits.

## 1. Make `build_pass_pipeline()` idempotent for any base

`_insert_passes` decided "already inserted" by looking at the slice adjacent to the anchor. When the base has no anchor pass, every group lands on a fallback index (0 or the end), the adjacent slice is empty, and the group is re-inserted on every call — despite the docstring promising a no-op. Verified: base `["common::noop_elimination"]` → 20 passes after one call, 39 after two (even the FUSION group doubled, because LATE_FUSION is appended after it and pushes it out of the tail slice).

Now a group is skipped when its exact sequence already appears as a contiguous run anywhere in the pipeline. A stray copy of a single pass still doesn't count, so `fuse_reduce_keep_dims` belonging to two groups keeps working. Also drops the unreachable `len(pass_names) == 0` early-return. New test builds twice from an anchorless base.

## 2. Drop `DEFAULT_HLO_PIPELINE`

It was literally `build_pass_pipeline()` computed at import time. `ct.PassPipeline` is mutable, so the README had to warn "copy it before mutating it", `tests/utils.py` deep-copied it, and `test_pass_pipeline.py` asserted on the global's contents under `randomize = true`. Replaced with `build_pass_pipeline()` everywhere; the two tests now assert on a fresh build (and that mutating one result doesn't leak into the next). Removed from `__all__` and the README.

Full suite: 621 passed, 1 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
