### PR TITLE
remove_noop_slice_update: symbol-aware matching, end_mask as coverage, squeeze_mask guard

### DIFF
--- a/stablehlo_coreml/passes/remove_noop_slice_update.py
+++ b/stablehlo_coreml/passes/remove_noop_slice_update.py
@@ -14,28 +14,69 @@ from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
 from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
+from .pattern_utils import const_int_list, dims_equal, shapes_equal
+
+
+def _mask_values(var, rank) -> list[bool] | None:
+    """A ``slice_update`` boolean mask as a list of ``rank`` values.
+
+    An absent mask reads as all-``False``, which is what the op defaults to.
+    ``None`` when the mask is present but not a compile-time constant of the
+    expected length, so that callers give up on the match.
+    """
+    if var is None:
+        return [False] * rank
+    val = getattr(var, "val", None)
+    if val is None:
+        return None
+    values = [bool(v) for v in np.asarray(val).reshape(-1)]
+    return values if len(values) == rank else None
+
 
 def _match_pattern(op):
-    if op.op_type == "slice_update":
-        if op.x.shape is None or op.update.shape is None:
-            return False
+    if op.op_type != "slice_update":
+        return False
 
-        x_rank = len(op.x.shape)
+    if op.x.shape is None:
+        return False
 
-        x_and_update_shape_matches = op.x.shape == op.update.shape
+    x_shape = tuple(op.x.shape)
+    x_rank = len(x_shape)
 
-        all_zeros_start_indices_array = np.array([0] * x_rank, dtype=np.int32)
-        start_values_all_zero = np.array_equal(op.begin.val, all_zeros_start_indices_array)
+    # `begin_mask[i]` neglects `begin[i]`, and `squeeze_mask[i]` turns the axis
+    # into a pure index that drops out of the result. Neither is the plain
+    # full-tensor write this pass rewrites. A squeeze also lowers the update's
+    # rank, so the shape check below rejects it anyway -- the explicit guard
+    # keeps that from being an accident.
+    begin_mask = _mask_values(op.begin_mask, x_rank)
+    squeeze_mask = _mask_values(op.squeeze_mask, x_rank)
+    if begin_mask is None or squeeze_mask is None or any(begin_mask) or any(squeeze_mask):
+        return False
 
-        end_values_matches_x_shape = np.array_equal(op.end.val, op.x.shape)
+    # Symbolic dimensions compare structurally: the update has to be shaped by
+    # the very same symbols as the buffer it overwrites.
+    if not shapes_equal(x_shape, op.update.shape):
+        return False
 
-        all_one_strides_array = np.array([1] * x_rank, dtype=np.int32)
-        strides_all_one = not op.stride or np.array_equal(op.stride.val, all_one_strides_array)
-        no_extra_options = strides_all_one and not op.begin_mask and not op.end_mask
+    if const_int_list(op.begin) != [0] * x_rank:
+        return False
 
-        return x_and_update_shape_matches and start_values_all_zero and end_values_matches_x_shape and no_extra_options
+    if op.stride is not None and const_int_list(op.stride) != [1] * x_rank:
+        return False
 
-    return False
+    end_mask = _mask_values(op.end_mask, x_rank)
+    end = const_int_list(op.end)
+    if end_mask is None or end is None or len(end) != x_rank:
+        return False
+
+    # `end_mask[i] == True` *means* "up to the end of axis i", so it covers the
+    # axis whatever its size. Without it the axis has to be concrete for
+    # `end[i]` to provably cover it: `end` holds constant ints, and a symbolic
+    # dimension is never provably equal to one.
+    return all(
+        covers_axis or dims_equal(dim, stop)
+        for covers_axis, dim, stop in zip(end_mask, x_shape, end)
+    )
 
 
 def _renames_function_input(slice_update_op, new_var) -> bool:
@@ -89,9 +130,7 @@ def _remove_noop_slice_update(block):
             continue
 
         for b in op.blocks:
-            block_changed = True
-            while block_changed:
-                block_changed = _remove_noop_slice_update(b)
+            did_optimize |= _remove_noop_slice_update(b)
         if len(op.blocks) > 0:
             continue
 
@@ -120,6 +159,9 @@ class remove_noop_slice_update(AbstractGraphPass):
         %1 = <tensor of shape S>
         %3 = some_op(%1)
         ...
+
+    A symbolic dimension of S is only ever covered through `end_mask`, since a
+    constant `end` is never provably equal to a symbol.
     """
     def apply(self, prog):
         for f in prog.functions.values():

--- a/tests/passes/test_remove_noop_slice_update.py
+++ b/tests/passes/test_remove_noop_slice_update.py
@@ -1,6 +1,7 @@
 import coremltools as ct
 import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol
 from coremltools.converters.mil.testing_utils import (
     apply_pass_and_basic_check,
     assert_model_is_valid,
@@ -111,13 +112,60 @@ class TestRemoveNoopSliceUpdate:
             return x
         self.__test_program(prog, should_remove=False)
 
-    def test_not_removed_if_end_mask(self):
+    def test_removed_if_end_mask(self):
+        """`end_mask[i]` means "to the end of axis i", so the axis is covered."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(10, 20))])
         def prog(x):
             buffer = np.zeros((10, 20))
-            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=buffer.shape, end_mask=[True, False])
+            # `end[0]` is neglected because of the mask
+            x = mb.slice_update(x=buffer, update=x, begin=[0, 0], end=[0, 20], end_mask=[True, False], name="x")
             return x
-        self.__test_program(prog, should_remove=False)
+        self.__test_program(prog, should_remove=True)
+
+    def test_not_removed_if_squeeze_mask(self):
+        """A squeezed axis is a pure index, not a write of the whole axis."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(20,))])
+        def prog(x):
+            buffer = np.zeros((10, 20))
+            updated = mb.slice_update(
+                x=buffer, update=x, begin=[0, 0], end=[10, 20], squeeze_mask=[True, False]
+            )
+            return mb.mul(x=updated, y=np.float32(2.0))
+
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
+        apply_pass_and_basic_check(prog, "common::remove_noop_slice_update")
+        apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
+
+    def test_removed_for_symbolic_shape_covered_by_end_mask(self):
+        """A symbolic dimension can only be covered by `end_mask`."""
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 20)), mb.TensorSpec(shape=(batch, 20))])
+        def prog(buffer, update):
+            updated = mb.slice_update(
+                x=buffer, update=update, begin=[0, 0], end=[0, 20], end_mask=[True, False]
+            )
+            return mb.mul(x=updated, y=np.float32(2.0))
+
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
+        apply_pass_and_basic_check(prog, "common::remove_noop_slice_update")
+        apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+        assert get_op_types_in_program(prog) == ["mul"]
+
+    def test_not_removed_for_symbolic_shape_with_constant_end(self):
+        """`end` is a constant, so it can never provably cover a symbolic axis."""
+        batch = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(batch, 20)), mb.TensorSpec(shape=(batch, 20))])
+        def prog(buffer, update):
+            updated = mb.slice_update(x=buffer, update=update, begin=[0, 0], end=[10, 20])
+            return mb.mul(x=updated, y=np.float32(2.0))
+
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
+        apply_pass_and_basic_check(prog, "common::remove_noop_slice_update")
+        apply_pass_and_basic_check(prog, "common::dead_code_elimination")
+        assert get_op_types_in_program(prog) == ["slice_update", "mul"]
 
     def __test_program(self, prog, should_remove: bool):
         assert get_op_types_in_program(prog) == ["slice_update"]


### PR DESCRIPTION
## Problem

`remove_noop_slice_update` was the only pass not using `pattern_utils`. It compared shapes with raw `==` and `np.array_equal(op.end.val, op.x.shape)`, so with any symbolic dimension it silently never fired (a constant `end` is never equal to a symbol). It also rejected `end_mask` outright, although per the iOS18 `slice_update` definition `end_mask[i] == True` *means* "up to the end of axis i" — the one way a symbolic axis can be provably covered. And `squeeze_mask` was unchecked (safe only by accident: a squeezed axis lowers the update's rank).

## Change

- Shapes via `shapes_equal` / `dims_equal`; `begin` / `stride` / `end` via `const_int_list` (a non-const value now bails out cleanly).
- Per axis: `end_mask[i]` **or** (concrete dim and `end[i] == dim`). `begin_mask` and `squeeze_mask` still decline.
- The nested-block fixpoint that discarded its result is folded into `did_optimize`; one fixpoint loop remains in `apply()`.

Tests: `test_not_removed_if_end_mask` → `test_removed_if_end_mask` (the old expectation was wrong under the op's semantics; it now passes `end=[0, 20]` to show `end[0]` is genuinely neglected); new tests for `squeeze_mask`, a symbolic buffer covered via `end_mask` (removed), and a symbolic buffer with a constant `end` (kept). `tests/passes` 397 passed / 1 xfailed, `tests/test_jax.py` 115 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
