### PR TITLE
fuse_attention_to_sdpa: cast a bias-only mask to the query dtype; fix finite-fill docs

### DIFF
--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -928,8 +928,12 @@ def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
         return mask
 
     # A finite fill (-1e9, torch's `finfo(dtype).min`, ...) keeps a fully masked
-    # row finite -- softmax turns it into a uniform row -- while a boolean mask
-    # would turn it into NaN. Reproduce it as an additive mask.
+    # row finite, where a boolean mask would turn it into NaN. An additive mask
+    # preserves that -- and only that. `select` *replaces* the row with `fill`,
+    # so softmax makes it uniform; adding `fill` shifts the scores instead, and
+    # softmax is shift invariant, so the row comes out as softmax(scores). The
+    # two agree once |fill| is large enough that `score + fill` rounds back to
+    # `fill` in the operand dtype, which is the regime the usual fills live in.
     float_mask = mb.cast(
         x=mask,
         dtype=types.builtin_to_string(query.dtype),
@@ -1131,10 +1135,17 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
 
     - ``finite_fill_mask``: how to translate a ``select`` whose fill value is a
       large but finite negative number (``-1e9``, ``torch.finfo(dtype).min``).
-      ``"additive"`` (the default) emits a float mask so that a fully masked row
-      stays finite, exactly like the original graph; ``"bool"`` emits the
-      boolean condition instead, which is cheaper but turns such rows into NaN.
-      Only a fill of exactly ``-inf`` maps to a boolean mask unconditionally.
+      ``"additive"`` (the default) emits a float mask, which keeps a fully
+      masked row finite and NaN-free as the original graph did; ``"bool"``
+      emits the boolean condition instead, which is cheaper but turns such rows
+      into NaN. What ``"additive"`` does *not* reproduce is the value of a
+      fully masked row: ``select`` replaces the scores with ``fill`` and
+      softmax makes the row uniform, whereas adding ``fill`` leaves
+      softmax(scores) untouched. The two only coincide once ``|fill|`` is large
+      enough for ``score + fill`` to round back to ``fill`` in the operand
+      dtype -- which is what the fills in use do, but a fill sitting just at
+      the threshold does not. Only a fill of exactly ``-inf`` maps to a boolean
+      mask unconditionally.
     - ``max_head_dim`` / ``max_key_len``: leave an attention block unfused when
       its head dimension ``E``, respectively its key length ``S``, is larger
       than the bound (or symbolic, i.e. unknown). ``None`` (the default) fuses

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -869,6 +869,19 @@ def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
             _peel_broadcast_tile(var), space, softmax_op.x.shape, seq_len, before_op, name
         )
 
+    def to_query_dtype(var, name):
+        # SDPA wants `attn_mask` in the operand dtype. The backward walk tolerates
+        # casts around the scores, so a mask picked up on the far side of one can
+        # be wider (or narrower) than the operands.
+        if var.dtype == query.dtype:
+            return var
+        return mb.cast(
+            x=var,
+            dtype=types.builtin_to_string(query.dtype),
+            before_op=before_op,
+            name=name,
+        )
+
     bias = None
     if pattern.add_var is not None:
         bias = to_sdpa_space(pattern.add_var, softmax_op.name + "_bias")
@@ -883,7 +896,7 @@ def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
             )
 
     if pattern.select_cond is None:
-        return bias
+        return to_query_dtype(bias, softmax_op.name + "_bias_cast")
 
     mask = to_sdpa_space(pattern.select_cond, softmax_op.name + "_mask")
     if mask is None:
@@ -908,14 +921,7 @@ def _build_mask(pattern, space, before_op, seq_len, query, finite_fill_mask):
             before_op=before_op,
             name=softmax_op.name + "_mask_bias",
         )
-        if combined.dtype != query.dtype:
-            combined = mb.cast(
-                x=combined,
-                dtype=types.builtin_to_string(query.dtype),
-                before_op=before_op,
-                name=softmax_op.name + "_mask_bias_cast",
-            )
-        return combined
+        return to_query_dtype(combined, softmax_op.name + "_mask_bias_cast")
 
     if math.isinf(fill) or finite_fill_mask == "bool":
         # A -inf fill and SDPA's boolean mask have identical semantics.

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -223,6 +223,43 @@ class TestFuseAttentionToSdpa:
         sdpa = _ops(prog)[-1]
         assert sdpa.attn_mask is prog.functions["main"].inputs["bias"]
 
+    def test_additive_float_mask_is_cast_to_the_query_dtype(self):
+        """SDPA wants `attn_mask` in the operand dtype; a bias behind a cast is not.
+
+        Keeping the softmax in fp32 while Q/K/V stay fp16 is what torch and JAX
+        emit; the backward walk follows the bias across that cast.
+        """
+        bias = np.linspace(-2.0, 2.0, L * S, dtype=np.float32).reshape(1, 1, L, S)
+
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(B, H, L, E), dtype=types.fp16),
+                mb.TensorSpec(shape=(B, H, S, E), dtype=types.fp16),
+                mb.TensorSpec(shape=(B, H, S, E), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(q, k, v):
+            scores = mb.matmul(x=q, y=k, transpose_y=True)
+            scaled = mb.mul(x=scores, y=np.float16(1.0 / math.sqrt(E)))
+            biased = mb.add(x=mb.cast(x=scaled, dtype="fp32"), y=bias)
+            weights = mb.softmax(x=biased, axis=-1)
+            return mb.matmul(x=mb.cast(x=weights, dtype="fp16"), y=v, transpose_y=False)
+
+        _apply(prog)
+        sdpa = next(op for op in _ops(prog) if op.op_type == "scaled_dot_product_attention")
+        assert sdpa.query.dtype == types.fp16
+        assert sdpa.attn_mask.dtype == sdpa.query.dtype
+
+        rng = np.random.RandomState(0)
+        q = rng.randn(B, H, L, E).astype(np.float16)
+        k = rng.randn(B, H, S, E).astype(np.float16)
+        v = rng.randn(B, H, S, E).astype(np.float16)
+        expected = _reference_attention(
+            q.astype(np.float32) / math.sqrt(E), k.astype(np.float32), v.astype(np.float32), bias=bias
+        )
+        np.testing.assert_allclose(_predict(prog, q=q, k=k, v=v), expected, atol=2e-2, rtol=2e-2)
+
     def test_scale_applied_after_the_mask_scales_the_fill(self):
         @mb.program(
             input_specs=[*_qkv_specs(), mb.TensorSpec(shape=(B, 1, 1, S), dtype=types.bool)],

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -1394,7 +1394,15 @@ class TestFuseAttentionToSdpaEndToEnd:
         self._assert_fused(cml_model, expected=2)
 
     def test_fully_masked_row_stays_finite(self):
-        """The additive mask keeps a fully masked row finite, as -1e9 did."""
+        """The additive mask keeps a fully masked row finite, as -1e9 did.
+
+        The *values* of that row only match because -1e9 swamps the scores: in
+        fp32 an ulp at 1e9 is 64, so `score + (-1e9) == -1e9` for the O(1)
+        scores below and softmax sees the uniform row the `select` produced. A
+        fill close to `_MASK_FILL_THRESHOLD` (-1e4) would not round the scores
+        away and the fused row would differ; see `finite_fill_mask` in the pass
+        docstring.
+        """
         from tests.utils import run_and_compare_specific_input  # noqa: PLC0415
 
         def attention(q, k, v, mask):


### PR DESCRIPTION
Two commits.

## 1. Cast a bias-only `attn_mask` to the query dtype

The bias + `select` path already reconciled the mask dtype with the operands; the bias-only path returned the additive bias as-is. With fp16 Q/K/V and an fp32 bias — reachable, since `_match_backward` tolerates casts around the scores — the pass emitted `scaled_dot_product_attention(query: fp16, …, attn_mask: fp32)`. Both exits now go through one `to_query_dtype` helper (no-op when the dtypes already agree, so `test_additive_float_mask`'s identity assertion still holds).

New test: fp16 Q/K/V, fp32 softmax across a cast, fp32 constant bias → `attn_mask.dtype == query.dtype == fp16`, numerics checked against the reference. Fails on the old code.

## 2. Correct the `finite_fill_mask="additive"` docs

They claimed a fully masked row is handled "exactly like the original graph". It is finite and NaN-free like the original, but not the same value: `select` *replaces* the row with `fill` (softmax → uniform), while adding `fill` merely shifts the scores and softmax is shift-invariant (row → `softmax(scores)`). With `fill = -1e4` (the matcher threshold): original `[0.25]*4`, fused `[0.14, 0.07, 0.66, 0.13]`. The two agree once `score + fill` rounds back to `fill` in the operand dtype — which the usual fills do. Docs only; no thresholds or behaviour changed. `test_fully_masked_row_stays_finite`'s docstring now says why it passes (an fp32 ulp at 1e9 is 64).

Not changed: `_try_fuse` can still leave dead ops behind on a late `return False`. Hoisting the two late checks would not remove that (`_build_mask` itself builds before it can fail), and the dead ops only attach to Q/K/V/mask operands, never to a score-chain var that a later `sole_consumer` check looks at — so it stays as documented DCE fodder.

`tests/passes/test_fuse_attention_to_sdpa.py`: 98 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
