### PR TITLE
tests/passes: share apply_pass / ops_of_type / predict helpers

### DIFF
--- a/tests/passes/helpers.py
+++ b/tests/passes/helpers.py
@@ -1,0 +1,87 @@
+"""Helpers shared by the MIL pass tests.
+
+Every test in this package has the same shape: build a small MIL program by
+hand, run one pass over it, and look at what is left. These are the pieces all
+of them need.
+"""
+
+import coremltools as ct
+import numpy as np
+from coremltools.converters.mil.mil.passes.pass_pipeline import PassPipelineManager
+from coremltools.converters.mil.testing_utils import apply_pass_and_basic_check
+
+DCE_PASS_NAME = "common::dead_code_elimination"
+
+
+def apply_pass(prog, pass_name, *, dce=True, skip_output_shape_check=False, **options):
+    """Apply ``pass_name`` to ``prog`` in place, returning the program as it was before.
+
+    Our passes leave the ops they matched behind, so dead code elimination runs
+    afterwards unless ``dce=False``.
+
+    ``options`` are pass options. Setting those requires running the pass from a
+    pipeline, which is the only way coremltools lets them through; that path
+    skips the basic checks and returns ``prog`` itself rather than a copy of the
+    program as it was before.
+    """
+    pass_names = [pass_name, DCE_PASS_NAME] if dce else [pass_name]
+
+    if options:
+        pipeline = ct.PassPipeline(pass_names, "pass_under_test")
+        pipeline.set_options(pass_name, options)
+        PassPipelineManager.apply_pipeline(prog, pipeline)
+        return prog
+
+    prev_prog, _, _ = apply_pass_and_basic_check(
+        prog, pass_name, skip_output_shape_check=skip_output_shape_check
+    )
+    if dce:
+        apply_pass_and_basic_check(
+            prog, DCE_PASS_NAME, skip_output_shape_check=skip_output_shape_check
+        )
+    return prev_prog
+
+
+def ops_of_type(prog, op_type, fname="main", *, recurse=False):
+    """The ``op_type`` ops of ``prog``'s ``fname`` function, in program order.
+
+    ``recurse`` also descends into the blocks nested inside ops.
+    """
+    def collect(block):
+        found = []
+        for op in block.operations:
+            if op.op_type == op_type:
+                found.append(op)
+            if recurse:
+                for nested in op.blocks:
+                    found += collect(nested)
+        return found
+
+    return collect(prog.functions[fname])
+
+
+def count_ops(prog, op_type, fname="main", *, recurse=False):
+    """How many ``op_type`` ops ``prog``'s ``fname`` function holds."""
+    return len(ops_of_type(prog, op_type, fname, recurse=recurse))
+
+
+def predict(prog, *, ct_inputs=None, **inputs):
+    """Convert ``prog`` and run it on ``inputs``; returns the single output as an ndarray.
+
+    Keeps fp32 throughout, so a comparison is not limited by fp16 accuracy, and
+    runs coremltools' stock pipeline: the pass under test is applied by hand
+    before this is called. ``ct_inputs`` are ``ct.TensorType``s, needed only when
+    the program has symbolic dimensions to pin down.
+    """
+    model = ct.convert(
+        prog,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+        compute_precision=ct.precision.FLOAT32,
+        pass_pipeline=ct.PassPipeline.DEFAULT,
+        inputs=ct_inputs,
+    )
+    names = [feature.name for feature in model.get_spec().description.input]
+    result = model.predict({name: inputs[name] for name in names})
+    return np.array(next(iter(result.values())))

--- a/tests/passes/test_broadcast_select_operands.py
+++ b/tests/passes/test_broadcast_select_operands.py
@@ -5,12 +5,10 @@ import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
-from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
-    get_op_types_in_program,
-)
+from coremltools.converters.mil.testing_utils import get_op_types_in_program
 
 from stablehlo_coreml.passes.pattern_utils import dims_equal, shapes_equal
+from tests.passes.helpers import apply_pass, ops_of_type, predict
 from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_symbolic
 
 PASS_NAME = "common::broadcast_select_operands"
@@ -20,26 +18,11 @@ _OPERANDS = ("cond", "a", "b")
 
 def _apply(prog):
     """Apply the pass, returning a deep copy of the program as it was before."""
-    prev_prog, _, _ = apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
-    return prev_prog
-
-
-def _selects(prog, recurse: bool = True):
-    def collect(block):
-        found = []
-        for op in block.operations:
-            if recurse:
-                for nested in op.blocks:
-                    found += collect(nested)
-            if op.op_type == "select":
-                found.append(op)
-        return found
-
-    return [op for func in prog.functions.values() for op in collect(func)]
+    return apply_pass(prog, PASS_NAME, dce=False, skip_output_shape_check=True)
 
 
 def _sole_select(prog):
-    selects = _selects(prog)
+    selects = ops_of_type(prog, "select", recurse=True)
     assert len(selects) == 1, f"expected exactly one select, got {len(selects)}"
     return selects[0]
 
@@ -65,20 +48,7 @@ def _ct_inputs(prog, symbolic_dim: int, range_max: int = 64):
 
 def _predict(prog, values, symbolic_dim: int):
     """Convert ``prog`` and run it on ``values``, with ``symbolic_dim`` for the symbolic axes."""
-    model = ct.convert(
-        prog,
-        source="milinternal",
-        minimum_deployment_target=ct.target.iOS18,
-        compute_units=ct.ComputeUnit.CPU_ONLY,
-        # Keep fp32 throughout, so the comparison is not limited by fp16 accuracy.
-        compute_precision=ct.precision.FLOAT32,
-        # coremltools' stock pipeline: the pass under test is applied by hand here.
-        pass_pipeline=ct.PassPipeline.DEFAULT,
-        inputs=_ct_inputs(prog, symbolic_dim),
-    )
-    names = [feature.name for feature in model.get_spec().description.input]
-    result = model.predict({name: values[name] for name in names})
-    return np.array(next(iter(result.values())))
+    return predict(prog, ct_inputs=_ct_inputs(prog, symbolic_dim), **values)
 
 
 class TestBroadcastSelectOperands:
@@ -370,7 +340,7 @@ class TestBroadcastSelectOperandsEndToEnd:
         assert "select" in ops
         assert "fill_like" in ops
 
-        selects = _selects(cml_model._mil_program)
+        selects = ops_of_type(cml_model._mil_program, "select", recurse=True)
         assert len(selects) == 1
         for select in selects:
             out_shape = tuple(select.outputs[0].shape)

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -7,18 +7,16 @@ import numpy as np
 import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
-from coremltools.converters.mil.mil.passes.pass_pipeline import PassPipelineManager
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 
 from stablehlo_coreml.passes.fuse_attention_to_sdpa import _Atom, _regroup
+from tests.passes.helpers import apply_pass, count_ops, predict
 from tests.utils import get_model_instruction_types, run_and_compare
 
 PASS_NAME = "common::fuse_attention_to_sdpa"
-DCE_PASS_NAME = "common::dead_code_elimination"
 
 # [B, H, L, S] scores from [B, H, L, E] queries and [B, H, S, E] keys.
 B, H, L, S, E = 2, 3, 5, 7, 4
@@ -30,15 +28,7 @@ TORCH_MIN_FILL = np.float32(np.finfo(np.float32).min)
 
 
 def _apply(prog, **options):
-    # The pass leaves the matched ops behind; DCE is what removes them.
-    if not options:
-        result = apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
-        apply_pass_and_basic_check(prog, DCE_PASS_NAME, skip_output_shape_check=True)
-        return result
-    pipeline = ct.PassPipeline([PASS_NAME, DCE_PASS_NAME], "fuse_attention")
-    pipeline.set_options(PASS_NAME, options)
-    PassPipelineManager.apply_pipeline(prog, pipeline)
-    return prog
+    return apply_pass(prog, PASS_NAME, skip_output_shape_check=True, **options)
 
 
 def _ops(prog):
@@ -46,7 +36,7 @@ def _ops(prog):
 
 
 def _sdpa_ops(prog, recurse: bool = True) -> int:
-    return get_op_types_in_program(prog, recurse=recurse).count("scaled_dot_product_attention")
+    return count_ops(prog, "scaled_dot_product_attention", recurse=recurse)
 
 
 def _all_neg_inf_rows(scores, shape=(B, H, L, S)):
@@ -67,22 +57,6 @@ def _qkv_specs():
         mb.TensorSpec(shape=(B, H, S, E)),
         mb.TensorSpec(shape=(B, H, S, E)),
     ]
-
-
-def _predict(prog, **inputs):
-    """Convert ``prog`` and run it; returns the single output as an ndarray."""
-    model = ct.convert(
-        prog,
-        source="milinternal",
-        minimum_deployment_target=ct.target.iOS18,
-        compute_units=ct.ComputeUnit.CPU_ONLY,
-        # Keep fp32 throughout; the default pipeline would otherwise downcast and
-        # leave only ~1e-3 of accuracy to compare against.
-        compute_precision=ct.precision.FLOAT32,
-    )
-    names = [feature.name for feature in model.get_spec().description.input]
-    result = model.predict({name: inputs[name] for name in names})
-    return np.array(next(iter(result.values())))
 
 
 def _reference_attention(q, k, v, mask=None, fill=-1e9, bias=None):
@@ -718,7 +692,7 @@ class TestAdditiveBiasAndSelectMask:
             q / math.sqrt(E), k, v, mask=mask, fill=-np.inf, bias=bias
         )
         # Core ML has no boolean model input; it exposes the mask as fp32.
-        got = _predict(prog, q=q, k=k, v=v, bias=bias, mask=mask.astype(np.float32))
+        got = predict(prog, q=q, k=k, v=v, bias=bias, mask=mask.astype(np.float32))
         np.testing.assert_allclose(got, expected, atol=1e-4, rtol=1e-4)
 
     def test_a_bias_applied_after_the_mask_is_not_fused(self):
@@ -963,7 +937,7 @@ class TestUnitQueryLength:
 
         expected = _reference_attention(q, k, v, mask.reshape(1, 1, keys), fill=float(FINITE_FILL))
         # Core ML has no boolean model input; it exposes the mask as fp32.
-        got = _predict(prog, q=q, k=k, v=v, mask=mask.astype(np.float32))
+        got = predict(prog, q=q, k=k, v=v, mask=mask.astype(np.float32))
         np.testing.assert_allclose(got, expected, atol=1e-4, rtol=1e-4)
 
     def test_not_fused_when_a_transpose_permutes_real_batch_axes(self):

--- a/tests/passes/test_fuse_gelu_erfc.py
+++ b/tests/passes/test_fuse_gelu_erfc.py
@@ -8,22 +8,19 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 
+from tests.passes.helpers import apply_pass
 from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_jit_lowering
 
 PASS_NAME = "common::fuse_gelu_erfc"
-DCE_PASS_NAME = "common::dead_code_elimination"
 INV_SQRT2 = 1.0 / math.sqrt(2.0)
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME)
-    # The pass leaves the matched ops behind; DCE is what removes them.
-    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
+    apply_pass(prog, PASS_NAME)
 
 
 def _erfc_gelu(x, negate_first=True, factor=INV_SQRT2, half=0.5, one=1.0):

--- a/tests/passes/test_fuse_gelu_tanh.py
+++ b/tests/passes/test_fuse_gelu_tanh.py
@@ -10,12 +10,12 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 from flax import nnx
 
+from tests.passes.helpers import apply_pass, ops_of_type
 from tests.utils import (
     get_model_instruction_types,
     run_and_compare,
@@ -24,16 +24,13 @@ from tests.utils import (
 )
 
 PASS_NAME = "common::fuse_gelu_tanh"
-DCE_PASS_NAME = "common::dead_code_elimination"
 
 SQRT_2_OVER_PI = math.sqrt(2.0 / math.pi)
 CUBE_COEFFICIENT = 0.044715
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME)
-    # The pass leaves the matched ops behind; DCE is what removes them.
-    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
+    apply_pass(prog, PASS_NAME)
 
 
 def _tanh_gelu(
@@ -58,10 +55,6 @@ def _tanh_gelu(
     return mb.mul(x=x, y=mb.mul(x=half, y=cdf))
 
 
-def _gelu_ops(prog):
-    return [op for op in prog.functions["main"].operations if op.op_type == "gelu"]
-
-
 class TestFuseGeluTanh:
     """Unit tests on hand-built MIL programs."""
 
@@ -75,7 +68,7 @@ class TestFuseGeluTanh:
         ]
         _apply(prog)
         assert get_op_types_in_program(prog) == ["gelu"]
-        assert _gelu_ops(prog)[0].mode.val == "TANH_APPROXIMATION"
+        assert ops_of_type(prog, "gelu")[0].mode.val == "TANH_APPROXIMATION"
         assert_model_is_valid(
             prog, {"x": (4, 8)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
         )

--- a/tests/passes/test_fuse_reduce_keep_dims.py
+++ b/tests/passes/test_fuse_reduce_keep_dims.py
@@ -6,26 +6,19 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 
 from stablehlo_coreml.passes.fuse_reduce_keep_dims import _REDUCE_OPS
+from tests.passes.helpers import apply_pass, ops_of_type
 from tests.utils import get_model_instruction_types, run_and_compare
 
 PASS_NAME = "common::fuse_reduce_keep_dims"
-DCE_PASS_NAME = "common::dead_code_elimination"
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME)
-    # The pass leaves the matched ops behind; DCE is what removes them.
-    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
-
-
-def _ops_of_type(prog, op_type):
-    return [op for op in prog.functions["main"].operations if op.op_type == op_type]
+    apply_pass(prog, PASS_NAME)
 
 
 class TestFuseReduceKeepDims:
@@ -42,7 +35,7 @@ class TestFuseReduceKeepDims:
         _apply(prog)
         assert get_op_types_in_program(prog) == [reduce_op]
 
-        fused = _ops_of_type(prog, reduce_op)
+        fused = ops_of_type(prog, reduce_op)
         assert len(fused) == 1
         assert fused[0].keep_dims.val
         assert prog.functions["main"].outputs[0].shape == (2, 8, 1)
@@ -68,7 +61,7 @@ class TestFuseReduceKeepDims:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["reduce_mean"]
-        assert list(_ops_of_type(prog, "reduce_mean")[0].axes.val) == [2]
+        assert list(ops_of_type(prog, "reduce_mean")[0].axes.val) == [2]
 
     def test_reduce_over_all_axes_is_fused(self):
         @mb.program(input_specs=[mb.TensorSpec(shape=(2, 8))])
@@ -104,7 +97,7 @@ class TestFuseReduceKeepDims:
         _apply(prog)
         assert get_op_types_in_program(prog) == [reduce_op]
 
-        fused = _ops_of_type(prog, reduce_op)
+        fused = ops_of_type(prog, reduce_op)
         assert len(fused) == 1
         assert fused[0].keep_dims.val
         assert prog.functions["main"].outputs[0].shape == (2, 8, 1)

--- a/tests/passes/test_fuse_rmsnorm.py
+++ b/tests/passes/test_fuse_rmsnorm.py
@@ -10,16 +10,15 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 from flax import nnx
 
+from tests.passes.helpers import apply_pass, ops_of_type
 from tests.utils import get_model_instruction_types, run_and_compare
 
 PASS_NAME = "common::fuse_rmsnorm"
-DCE_PASS_NAME = "common::dead_code_elimination"
 # `mb.rsqrt`'s own epsilon, folded into the one the `add` contributes.
 RSQRT_EPSILON = 1e-12
 EPSILON = 1e-6
@@ -28,9 +27,8 @@ D = 16
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME)
-    # The pass removes the chain itself, but leaves its constants behind.
-    apply_pass_and_basic_check(prog, DCE_PASS_NAME)
+    # The pass removes the chain itself, but leaves its constants behind for DCE.
+    apply_pass(prog, PASS_NAME)
 
 
 def _rmsnorm(x, scale=None, axes=(-1,), keep_dims=True, epsilon=EPSILON):
@@ -40,10 +38,6 @@ def _rmsnorm(x, scale=None, axes=(-1,), keep_dims=True, epsilon=EPSILON):
     if scale is None:
         return normalized
     return mb.mul(x=normalized, y=scale)
-
-
-def _ops_of_type(prog, op_type):
-    return [op for op in prog.functions["main"].operations if op.op_type == op_type]
 
 
 def _expected_epsilon(d, epsilon=EPSILON):
@@ -65,10 +59,10 @@ class TestFuseRmsNorm:
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
 
-        l2_norm = _ops_of_type(prog, "l2_norm")[0]
+        l2_norm = ops_of_type(prog, "l2_norm")[0]
         assert np.isclose(l2_norm.epsilon.val, _expected_epsilon(16))
         # The `sqrt(d)` of the identity is folded into the scale constant.
-        factor = _ops_of_type(prog, "mul")[0].y.val
+        factor = ops_of_type(prog, "mul")[0].y.val
         np.testing.assert_allclose(factor, math.sqrt(16) * scale, rtol=1e-6)
         assert_model_is_valid(
             prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
@@ -81,7 +75,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+        assert np.isclose(ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
 
     def test_batch_dimensions_are_fused(self):
         """`l2_norm` treats everything before the last three dims as batch."""
@@ -99,7 +93,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, 2.0 * math.sqrt(16))
+        assert np.isclose(ops_of_type(prog, "mul")[0].y.val, 2.0 * math.sqrt(16))
 
     @pytest.mark.parametrize("shape", [(1, 4, 8, 16), (1, 8, 16), (4, 16)])
     def test_off_canonical_shape_is_left_alone(self, shape):
@@ -228,7 +222,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul", "mul"]
-        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+        assert np.isclose(ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
 
     def test_keep_dims_false_is_fused(self):
         """A squeezed `(1, 1)` statistic left-pads to the keep-dims `(1, 1, 1)`,
@@ -239,7 +233,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        assert np.isclose(_ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
+        assert np.isclose(ops_of_type(prog, "mul")[0].y.val, math.sqrt(16))
         assert_model_is_valid(
             prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
         )
@@ -257,7 +251,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        factor = _ops_of_type(prog, "mul")[0].y.val
+        factor = ops_of_type(prog, "mul")[0].y.val
         np.testing.assert_allclose(factor, math.sqrt(16) * scale, rtol=1e-6)
         assert_model_is_valid(
             prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
@@ -276,7 +270,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        factor = _ops_of_type(prog, "mul")[0].y.val
+        factor = ops_of_type(prog, "mul")[0].y.val
         np.testing.assert_allclose(factor, math.sqrt(16) * weight, rtol=1e-6)
         assert_model_is_valid(
             prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
@@ -294,7 +288,7 @@ class TestFuseRmsNorm:
 
         _apply(prog)
         assert get_op_types_in_program(prog) == ["l2_norm", "mul"]
-        factor = _ops_of_type(prog, "mul")[0].y.val
+        factor = ops_of_type(prog, "mul")[0].y.val
         np.testing.assert_allclose(factor, math.sqrt(16) * pre * post, rtol=1e-6)
         assert_model_is_valid(
             prog, {"x": (1, 1, 16)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
@@ -441,15 +435,6 @@ class TestFuseRmsNormEndToEnd:
 
 
 
-def _model_ops_of_type(cml_model, op_type):
-    return [
-        op
-        for func in cml_model._mil_program.functions.values()
-        for op in func.operations
-        if op.op_type == op_type
-    ]
-
-
 def _assert_norm_is_fused(cml_model):
     """The whole statistics chain is gone, replaced by a single `l2_norm`."""
     ops = get_model_instruction_types(cml_model)
@@ -514,7 +499,7 @@ class TestFuseRmsNormLibraryLayers:
         )
         _assert_norm_is_fused(cml_model)
         # The scale flax folded onto the rsqrt is part of the single constant.
-        factor = _model_ops_of_type(cml_model, "mul")[0].y.val
+        factor = ops_of_type(cml_model._mil_program, "mul")[0].y.val
         assert factor.shape == (1, 1, D)
 
     def test_flax_nnx_rmsnorm_without_a_scale_is_fused(self):
@@ -523,7 +508,7 @@ class TestFuseRmsNormLibraryLayers:
             [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
         )
         _assert_norm_is_fused(cml_model)
-        assert np.isclose(_model_ops_of_type(cml_model, "mul")[0].y.val, math.sqrt(D))
+        assert np.isclose(ops_of_type(cml_model._mil_program, "mul")[0].y.val, math.sqrt(D))
 
     def test_equinox_rmsnorm_is_fused(self):
         cml_model = run_and_compare(
@@ -531,7 +516,7 @@ class TestFuseRmsNormLibraryLayers:
             [jax.ShapeDtypeStruct((1, 1, D), jnp.float32)],
         )
         _assert_norm_is_fused(cml_model)
-        factor = _model_ops_of_type(cml_model, "mul")[0].y.val
+        factor = ops_of_type(cml_model._mil_program, "mul")[0].y.val
         assert factor.shape == (1, 1, D)
 
     def test_equinox_rmsnorm_with_a_bias_is_fused(self):

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -10,8 +10,8 @@ from stablehlo_coreml.passes.utils import (
     FUSION_PASSES,
     LATE_FUSION_PASSES,
 )
+from tests.passes.helpers import DCE_PASS_NAME
 
-DCE_PASS_NAME = "common::dead_code_elimination"
 # The groups interleave coremltools' DCE with our own passes, so the same name
 # appears several times; only our own passes are expected in the pipeline exactly
 # once.

--- a/tests/passes/test_remove_broadcast_tiles.py
+++ b/tests/passes/test_remove_broadcast_tiles.py
@@ -6,22 +6,22 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 
-from tests.utils import get_model_instruction_types, run_and_compare
+from tests.passes.helpers import apply_pass, count_ops, ops_of_type
+from tests.utils import get_model_instruction_types, run_and_compare, run_and_compare_symbolic
 
 PASS_NAME = "common::remove_broadcast_tiles"
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
+    apply_pass(prog, PASS_NAME, dce=False, skip_output_shape_check=True)
 
 
 def _count_tiles(prog, recurse: bool = True) -> int:
-    return get_op_types_in_program(prog, recurse=recurse).count("tile")
+    return count_ops(prog, "tile", recurse=recurse)
 
 
 class TestRemoveBroadcastTiles:
@@ -272,13 +272,10 @@ class TestRemoveBroadcastTilesEndToEnd:
     @staticmethod
     def _large_constants(cml_model, max_elements: int = 16):
         large = []
-        for func in cml_model._mil_program.functions.values():
-            for op in func.operations:
-                if op.op_type != "const":
-                    continue
-                val = op.outputs[0].val
-                if val is not None and np.asarray(val).size > max_elements:
-                    large.append((op.name, np.asarray(val).shape))
+        for op in ops_of_type(cml_model._mil_program, "const"):
+            val = op.outputs[0].val
+            if val is not None and np.asarray(val).size > max_elements:
+                large.append((op.name, np.asarray(val).shape))
         return large
 
     def test_scalar_broadcast_leaves_no_tile_and_no_large_const(self):
@@ -306,8 +303,6 @@ class TestRemoveBroadcastTilesEndToEnd:
 
         def f(x):
             return jnp.mean(x, axis=-1, keepdims=True) * x
-
-        from tests.utils import run_and_compare_symbolic  # noqa: PLC0415
 
         cml_model = run_and_compare_symbolic(
             f,

--- a/tests/passes/test_replace_decomposed_softmax.py
+++ b/tests/passes/test_replace_decomposed_softmax.py
@@ -8,12 +8,12 @@ import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol, types
 from coremltools.converters.mil.testing_utils import (
-    apply_pass_and_basic_check,
     assert_model_is_valid,
     get_op_types_in_program,
 )
 from flax import nnx
 
+from tests.passes.helpers import apply_pass
 from tests.utils import (
     get_model_instruction_types,
     run_and_compare,
@@ -21,15 +21,12 @@ from tests.utils import (
 )
 
 PASS_NAME = "common::replace_decomposed_softmax"
-DCE_PASS_NAME = "common::dead_code_elimination"
 
 NEG_INF = np.float32(-np.inf)
 
 
 def _apply(prog):
-    apply_pass_and_basic_check(prog, PASS_NAME, skip_output_shape_check=True)
-    # The pass leaves the matched ops behind; DCE is what removes them.
-    apply_pass_and_basic_check(prog, DCE_PASS_NAME, skip_output_shape_check=True)
+    apply_pass(prog, PASS_NAME, skip_output_shape_check=True)
 
 
 def _decomposed_softmax(x, axis, shape, *, clamps=1, keep_dims=False, tile=False):


### PR DESCRIPTION
**Merge last** — it touches the helper headers of most `tests/passes/*` files, so it will need a trivial rebase after #93/#95/#97/#98 (which add tests to the same files; #98 adds a test that calls `_predict`, which becomes `predict`).

## What

`tests/passes/` had no shared helpers: `_apply(prog)` was defined in 8 files (four variants: with/without DCE, `skip_output_shape_check`, and a pass-options path), `_ops_of_type` twice identically plus five hard-coded specialisations, and the convert-and-run `_predict` twice. New `tests/passes/helpers.py` (explicitly imported, matching the `tests/utils.py` style — the repo has no conftest) provides `apply_pass`, `ops_of_type`, `count_ops`, `predict`, and `DCE_PASS_NAME`; the per-file copies are gone. The `_apply` one-line alias stays in each file so the ~250 call sites don't churn.

Also moves a function-local `from tests.utils import run_and_compare_symbolic  # noqa: PLC0415` to the module top.

Net −9 lines (−96 in the test files, +87 for the helper module). Same 394 passed / 1 xfailed as before; no assertion changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
