### PR TITLE
passes: share the block walker and apply() via RewritePass

### DIFF
--- a/stablehlo_coreml/passes/broadcast_select_operands.py
+++ b/stablehlo_coreml/passes/broadcast_select_operands.py
@@ -32,12 +32,10 @@ import logging
 
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
-from .pattern_utils import aligned_dim, dims_equal
+from .pattern_utils import RewritePass, aligned_dim, dims_equal
 
 logger = logging.getLogger(__name__)
 
@@ -132,61 +130,8 @@ def _widen(operand, reference, op, name: str):
     return combine(x=operand, y=zeros, before_op=op, name=f"{op.name}_{name}_broadcast")
 
 
-@block_context_manager
-def _broadcast_select_operands(block) -> int:
-    widened = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            widened += _broadcast_select_operands(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        if op.op_type != "select":
-            continue
-
-        out_shape = op.outputs[0].shape
-        if out_shape is None or not any(is_symbolic(dim) for dim in out_shape):
-            continue
-
-        under_shaped = [name for name in _OPERANDS if _needs_widening(op.inputs.get(name), out_shape)]
-        if not under_shaped:
-            continue
-
-        reference = _fill_reference(op, out_shape)
-        if reference is None:
-            logger.debug(
-                "broadcast_select_operands: no operand of '%s' carries the full output shape %s",
-                op.name,
-                out_shape,
-            )
-            continue
-
-        operands = {name: op.inputs[name] for name in _OPERANDS}
-        for name in under_shaped:
-            operands[name] = _widen(operands[name], reference, op, name)
-
-        # The operands changed shape, so type inference on the new `select` must
-        # not be re-run against the old output type (`no_check_var_types`). The
-        # output itself is unaffected: widening only replaces implicit
-        # broadcasting with explicit, so the broadcast result is the same shape.
-        widened_select = mb.select(**operands, before_op=op, name=op.outputs[0].name)
-        block.replace_uses_of_var_after_op(
-            anchor_op=op,
-            old_var=op.outputs[0],
-            new_var=widened_select,
-            no_check_var_types=True,
-        )
-        block.remove_ops([op])
-        widened += 1
-
-    return widened
-
-
 @register_pass(namespace="common")
-class broadcast_select_operands(AbstractGraphPass):
+class broadcast_select_operands(RewritePass):
     """
     Widen the operands of a ``select`` that broadcast into a symbolic dimension.
 
@@ -207,8 +152,43 @@ class broadcast_select_operands(AbstractGraphPass):
         %3 = select(cond=%c, a=%2, b=%cache)
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            widened = _broadcast_select_operands(f)
-            if widened:
-                logger.debug("broadcast_select_operands: widened %d select op(s)", widened)
+    _REWRITES = "select op(s)"
+
+    def visit(self, op, block) -> bool:
+        if op.op_type != "select":
+            return False
+
+        out_shape = op.outputs[0].shape
+        if out_shape is None or not any(is_symbolic(dim) for dim in out_shape):
+            return False
+
+        under_shaped = [name for name in _OPERANDS if _needs_widening(op.inputs.get(name), out_shape)]
+        if not under_shaped:
+            return False
+
+        reference = _fill_reference(op, out_shape)
+        if reference is None:
+            logger.debug(
+                "broadcast_select_operands: no operand of '%s' carries the full output shape %s",
+                op.name,
+                out_shape,
+            )
+            return False
+
+        operands = {name: op.inputs[name] for name in _OPERANDS}
+        for name in under_shaped:
+            operands[name] = _widen(operands[name], reference, op, name)
+
+        # The operands changed shape, so type inference on the new `select` must
+        # not be re-run against the old output type (`no_check_var_types`). The
+        # output itself is unaffected: widening only replaces implicit
+        # broadcasting with explicit, so the broadcast result is the same shape.
+        widened_select = mb.select(**operands, before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=widened_select,
+            no_check_var_types=True,
+        )
+        block.remove_ops([op])
+        return True

--- a/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
+++ b/stablehlo_coreml/passes/fuse_attention_to_sdpa.py
@@ -52,18 +52,16 @@ as well, but only when the matched mask proves that no row can be entirely
 """
 
 import dataclasses
-import logging
 import math
 
 import numpy as np
 from coremltools.converters.mil import Builder as mb
 from coremltools.converters.mil.mil import types
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
 from .pattern_utils import (
+    RewritePass,
     broadcast_shapes,
     const_int_list,
     dims_equal,
@@ -74,8 +72,6 @@ from .pattern_utils import (
     uniform_const_operand,
     uniform_scalar_value,
 )
-
-logger = logging.getLogger(__name__)
 
 # Ops that only re-group axes; they never reorder elements within an axis.
 _LAYOUT_OPS = frozenset({"reshape", "expand_dims", "squeeze", "transpose"})
@@ -1103,30 +1099,8 @@ def _try_fuse(softmax_op, block, options: _Options) -> bool:
     return True
 
 
-@block_context_manager
-def _fuse_attention_to_sdpa(block, options: _Options) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_attention_to_sdpa(nested_block, options)
-        if len(op.blocks) > 0:
-            continue
-
-        if op.op_type != "softmax":
-            continue
-        # `_try_fuse` may build some replacement ops before a late check makes it
-        # give up; those are left dead in the block for `dead_code_elimination`.
-        if _try_fuse(op, block, options):
-            fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_attention_to_sdpa(AbstractGraphPass):
+class fuse_attention_to_sdpa(RewritePass):
     """
     Fuse ``matmul -> [scale] -> [bias] -> [mask] -> softmax -> matmul`` into
     ``scaled_dot_product_attention``.
@@ -1173,6 +1147,8 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
         %out = scaled_dot_product_attention(query=%q, key=%k, value=%v, attn_mask=...)
     """
 
+    _REWRITES = "attention block(s)"
+
     _finite_fill_mask = "additive"
     _max_head_dim = None
     _max_key_len = None
@@ -1217,9 +1193,10 @@ class fuse_attention_to_sdpa(AbstractGraphPass):
     def max_key_len(self, value):
         self._max_key_len = self._parse_bound("max_key_len", value)
 
-    def apply(self, prog):
+    def visit(self, op, block) -> bool:
+        if op.op_type != "softmax":
+            return False
         options = _Options(self._finite_fill_mask, self._max_head_dim, self._max_key_len)
-        for f in prog.functions.values():
-            fused = _fuse_attention_to_sdpa(f, options)
-            if fused:
-                logger.debug("fuse_attention_to_sdpa: fused %d attention block(s)", fused)
+        # `_try_fuse` may build some replacement ops before a late check makes it
+        # give up; those are left dead in the block for `dead_code_elimination`.
+        return _try_fuse(op, block, options)

--- a/stablehlo_coreml/passes/fuse_gelu_erfc.py
+++ b/stablehlo_coreml/passes/fuse_gelu_erfc.py
@@ -17,23 +17,19 @@ only recognises the algebraically equivalent but structurally different
 than duplicating it.
 """
 
-import logging
 import math
 
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
 from .pattern_utils import (
+    RewritePass,
     peel_to_scaled_input,
     shapes_equal,
     sole_consumer,
     uniform_const_operand,
     uniform_scalar_value,
 )
-
-logger = logging.getLogger(__name__)
 
 # Absolute tolerances on the constants of the pattern.
 _HALF_TOLERANCE = 1e-4
@@ -111,31 +107,8 @@ def _match(mul_op, block):
     return None
 
 
-@block_context_manager
-def _fuse_gelu_erfc(block) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_gelu_erfc(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        x = _match(op, block)
-        if x is None:
-            continue
-
-        gelu = mb.gelu(x=x, mode="EXACT", before_op=op, name=op.outputs[0].name)
-        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
-        fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_gelu_erfc(AbstractGraphPass):
+class fuse_gelu_erfc(RewritePass):
     """
     Fuse ``0.5 * x * (1 - erf(k * x))`` with ``k == -1/sqrt(2)`` into
     ``gelu(x, mode="EXACT")``.
@@ -157,8 +130,13 @@ class fuse_gelu_erfc(AbstractGraphPass):
         %6 = gelu(x=%0, mode="EXACT")
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            fused = _fuse_gelu_erfc(f)
-            if fused:
-                logger.debug("fuse_gelu_erfc: fused %d exact GELU(s)", fused)
+    _REWRITES = "exact GELU(s)"
+
+    def visit(self, op, block) -> bool:
+        x = _match(op, block)
+        if x is None:
+            return False
+
+        gelu = mb.gelu(x=x, mode="EXACT", before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
+        return True

--- a/stablehlo_coreml/passes/fuse_gelu_tanh.py
+++ b/stablehlo_coreml/passes/fuse_gelu_tanh.py
@@ -26,15 +26,13 @@ associativity does not matter: ``x * (0.5 * (1 + tanh(t)))`` and
 written in distributed form (``k*x + k*a*x**3``) rather than factored.
 """
 
-import logging
 import math
 
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
 from .pattern_utils import (
+    RewritePass,
     dtype_epsilon,
     peel_to_scaled_input,
     shapes_equal,
@@ -42,8 +40,6 @@ from .pattern_utils import (
     uniform_const_operand,
     uniform_scalar_value,
 )
-
-logger = logging.getLogger(__name__)
 
 # The coefficients of the tanh approximation, as the paper writes them.
 _SQRT_2_OVER_PI = math.sqrt(2.0 / math.pi)
@@ -177,31 +173,8 @@ def _match(mul_op, block):
     return None
 
 
-@block_context_manager
-def _fuse_gelu_tanh(block) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_gelu_tanh(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        x = _match(op, block)
-        if x is None:
-            continue
-
-        gelu = mb.gelu(x=x, mode="TANH_APPROXIMATION", before_op=op, name=op.outputs[0].name)
-        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
-        fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_gelu_tanh(AbstractGraphPass):
+class fuse_gelu_tanh(RewritePass):
     """
     Fuse ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x**3)))`` into
     ``gelu(x, mode="TANH_APPROXIMATION")``.
@@ -234,8 +207,13 @@ class fuse_gelu_tanh(AbstractGraphPass):
     ``x`` itself, which the pattern reads three times.
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            fused = _fuse_gelu_tanh(f)
-            if fused:
-                logger.debug("fuse_gelu_tanh: fused %d approximated GELU(s)", fused)
+    _REWRITES = "approximated GELU(s)"
+
+    def visit(self, op, block) -> bool:
+        x = _match(op, block)
+        if x is None:
+            return False
+
+        gelu = mb.gelu(x=x, mode="TANH_APPROXIMATION", before_op=op, name=op.outputs[0].name)
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=gelu)
+        return True

--- a/stablehlo_coreml/passes/fuse_logit_softcap.py
+++ b/stablehlo_coreml/passes/fuse_logit_softcap.py
@@ -15,18 +15,13 @@ is fused; the softcap shape (``alpha * beta == 1``, where the composition is the
 identity for small ``x``) is just the common case, not a requirement.
 """
 
-import logging
 
 import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import sole_consumer, uniform_const_operand
-
-logger = logging.getLogger(__name__)
+from .pattern_utils import RewritePass, sole_consumer, uniform_const_operand
 
 
 def _scalar_operand(op):
@@ -103,40 +98,8 @@ def _match(mul_op, block):
     return None
 
 
-@block_context_manager
-def _fuse_logit_softcap(block) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_logit_softcap(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        match = _match(op, block)
-        if match is None:
-            continue
-        x, alpha, beta = match
-
-        # `alpha`/`beta` are `const T`, with T the element type of `x`.
-        dtype = types.nptype_from_builtin(x.dtype)
-        capped = mb.scaled_tanh(
-            x=x,
-            alpha=dtype(alpha),
-            beta=dtype(beta),
-            before_op=op,
-            name=op.outputs[0].name,
-        )
-        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=capped)
-        fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_logit_softcap(AbstractGraphPass):
+class fuse_logit_softcap(RewritePass):
     """
     Fuse ``alpha * tanh(beta * x)`` into ``scaled_tanh(x, alpha, beta)``.
 
@@ -159,8 +122,22 @@ class fuse_logit_softcap(AbstractGraphPass):
         %3 = scaled_tanh(x=%0, alpha=30.0, beta=0.0333)
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            fused = _fuse_logit_softcap(f)
-            if fused:
-                logger.debug("fuse_logit_softcap: fused %d scaled tanh(s)", fused)
+    _REWRITES = "scaled tanh(s)"
+
+    def visit(self, op, block) -> bool:
+        match = _match(op, block)
+        if match is None:
+            return False
+        x, alpha, beta = match
+
+        # `alpha`/`beta` are `const T`, with T the element type of `x`.
+        dtype = types.nptype_from_builtin(x.dtype)
+        capped = mb.scaled_tanh(
+            x=x,
+            alpha=dtype(alpha),
+            beta=dtype(beta),
+            before_op=op,
+            name=op.outputs[0].name,
+        )
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=capped)
+        return True

--- a/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
+++ b/stablehlo_coreml/passes/fuse_reduce_keep_dims.py
@@ -26,17 +26,12 @@ would need the runtime shape as an operand)::
 so both spellings are matched.
 """
 
-import logging
 
 import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import shapes_equal
-
-logger = logging.getLogger(__name__)
+from .pattern_utils import RewritePass, shapes_equal
 
 # The MIL reduction ops whose builder takes an `axes` + `keep_dims` pair.
 # The arg-reductions (`reduce_argmax`/`reduce_argmin`) take a single `axis` and
@@ -123,47 +118,8 @@ def _match(reshape_op, block):
     return reduce_op, axes
 
 
-@block_context_manager
-def _fuse_reduce_keep_dims(block) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_reduce_keep_dims(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        match = _match(op, block)
-        if match is None:
-            continue
-        reduce_op, axes = match
-
-        # A fresh reduction with `keep_dims=True` replaces the reshape. The
-        # original reduction is left in place; if the reshape was its sole
-        # consumer it becomes dead and `dead_code_elimination` picks it up
-        # (otherwise the other consumers, which expect the squeezed shape, keep
-        # using it).
-        keep_dims_var = getattr(mb, reduce_op.op_type)(
-            x=reduce_op.x,
-            axes=axes,
-            keep_dims=True,
-            before_op=op,
-            name=op.outputs[0].name,
-        )
-        block.replace_uses_of_var_after_op(
-            anchor_op=op,
-            old_var=op.outputs[0],
-            new_var=keep_dims_var,
-        )
-        fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_reduce_keep_dims(AbstractGraphPass):
+class fuse_reduce_keep_dims(RewritePass):
     """
     Fuse ``reduce_*(keep_dims=False) -> reshape/expand_dims(<keep-dims shape>)``
     into a single ``reduce_*(keep_dims=True)``.
@@ -199,8 +155,29 @@ class fuse_reduce_keep_dims(AbstractGraphPass):
         %2 = reduce_sum(x=%0, axes=[1], keep_dims=True)
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            fused = _fuse_reduce_keep_dims(f)
-            if fused:
-                logger.debug("fuse_reduce_keep_dims: fused %d reduce/reshape pair(s)", fused)
+    _REWRITES = "reduce/reshape pair(s)"
+
+    def visit(self, op, block) -> bool:
+        match = _match(op, block)
+        if match is None:
+            return False
+        reduce_op, axes = match
+
+        # A fresh reduction with `keep_dims=True` replaces the reshape. The
+        # original reduction is left in place; if the reshape was its sole
+        # consumer it becomes dead and `dead_code_elimination` picks it up
+        # (otherwise the other consumers, which expect the squeezed shape, keep
+        # using it).
+        keep_dims_var = getattr(mb, reduce_op.op_type)(
+            x=reduce_op.x,
+            axes=axes,
+            keep_dims=True,
+            before_op=op,
+            name=op.outputs[0].name,
+        )
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=keep_dims_var,
+        )
+        return True

--- a/stablehlo_coreml/passes/fuse_rmsnorm.py
+++ b/stablehlo_coreml/passes/fuse_rmsnorm.py
@@ -75,20 +75,15 @@ percent of the estimated cost, against ~21% for the ``matmul``s. Op-count work
 of this kind should be judged on graph size, not on latency.
 """
 
-import logging
 import math
 
 import numpy as np
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import types
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 from coremltools.converters.mil.mil.types.symbolic import any_symbolic
 
-from .pattern_utils import sole_consumer, uniform_const_operand, uniform_scalar_value
-
-logger = logging.getLogger(__name__)
+from .pattern_utils import RewritePass, sole_consumer, uniform_const_operand, uniform_scalar_value
 
 
 def _matches_scale_shape(val, x_shape) -> bool:
@@ -270,46 +265,8 @@ def _match(rsqrt_op, block):
     return x32, eps, tail_op, scale, dead
 
 
-@block_context_manager
-def _fuse_rmsnorm(block) -> int:
-    fused = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            fused += _fuse_rmsnorm(nested_block)
-        if len(op.blocks) > 0 or op.op_type != "rsqrt":
-            continue
-
-        match = _match(op, block)
-        if match is None:
-            continue
-        x32, eps, tail_op, scale, dead = match
-
-        d = int(x32.shape[-1])
-        np_dtype = types.nptype_from_builtin(x32.dtype)
-
-        normalized = mb.l2_norm(
-            x=x32, epsilon=np_dtype(d * eps), before_op=tail_op, name=tail_op.name + "_l2"
-        )
-        # The `sqrt(d)` the identity above pulls out, folded into the scale.
-        factor = math.sqrt(d) if scale is None else np.sqrt(d) * scale.astype(np.float64)
-        rescaled = mb.mul(x=normalized, y=np_dtype(factor), before_op=tail_op, name=tail_op.name)
-
-        block.replace_uses_of_var_after_op(
-            anchor_op=tail_op,
-            old_var=tail_op.outputs[0],
-            new_var=rescaled,
-        )
-        block.remove_ops(dead)
-        fused += 1
-
-    return fused
-
-
 @register_pass(namespace="common")
-class fuse_rmsnorm(AbstractGraphPass):
+class fuse_rmsnorm(RewritePass):
     """
     Fuse the RMSNorm elementwise chain into ``l2_norm`` + a constant ``mul``.
 
@@ -348,8 +305,31 @@ class fuse_rmsnorm(AbstractGraphPass):
         %6 = mul(x=%5, y=<const sqrt(d) * scale>)
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            fused = _fuse_rmsnorm(f)
-            if fused:
-                logger.debug("fuse_rmsnorm: fused %d RMSNorm chain(s)", fused)
+    _REWRITES = "RMSNorm chain(s)"
+
+    def visit(self, op, block) -> bool:
+        if op.op_type != "rsqrt":
+            return False
+
+        match = _match(op, block)
+        if match is None:
+            return False
+        x32, eps, tail_op, scale, dead = match
+
+        d = int(x32.shape[-1])
+        np_dtype = types.nptype_from_builtin(x32.dtype)
+
+        normalized = mb.l2_norm(
+            x=x32, epsilon=np_dtype(d * eps), before_op=tail_op, name=tail_op.name + "_l2"
+        )
+        # The `sqrt(d)` the identity above pulls out, folded into the scale.
+        factor = math.sqrt(d) if scale is None else np.sqrt(d) * scale.astype(np.float64)
+        rescaled = mb.mul(x=normalized, y=np_dtype(factor), before_op=tail_op, name=tail_op.name)
+
+        block.replace_uses_of_var_after_op(
+            anchor_op=tail_op,
+            old_var=tail_op.outputs[0],
+            new_var=rescaled,
+        )
+        block.remove_ops(dead)
+        return True

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -17,22 +17,6 @@ import numpy as np
 from coremltools.converters.mil.mil import types
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
-__all__ = [
-    "aligned_dim",
-    "broadcast_shapes",
-    "const_int_list",
-    "const_scaled_operand",
-    "dims_equal",
-    "dtype_epsilon",
-    "is_broadcast_tile",
-    "normalize_axis",
-    "peel_to_scaled_input",
-    "shapes_equal",
-    "sole_consumer",
-    "uniform_const_operand",
-    "uniform_scalar_value",
-]
-
 # Upper bound on the number of scaling/negation ops `peel_to_scaled_input` walks
 # back over. The converter emits at most two or three; the bound just keeps the
 # search finite for hand-written graphs.
@@ -235,7 +219,7 @@ def is_broadcast_tile(op) -> bool:
     return all(rep == 1 or dims_equal(dim, 1) for dim, rep in zip(x_shape, reps))
 
 
-def const_scaled_operand(op):
+def _const_scaled_operand(op):
     """Split a ``mul``/``real_div``/``sub`` op into ``(input_var, factor)``.
 
     Recognises the ops that scale or negate a value by a compile-time constant:
@@ -283,7 +267,7 @@ def peel_to_scaled_input(var, block):
             break
         if sole_consumer(current) is None:
             break
-        split = const_scaled_operand(op)
+        split = _const_scaled_operand(op)
         if split is None:
             break
         current, step = split

--- a/stablehlo_coreml/passes/pattern_utils.py
+++ b/stablehlo_coreml/passes/pattern_utils.py
@@ -2,6 +2,8 @@
 
 The passes in this package all have to deal with the same handful of problems:
 
+* walking every op of a program, nested blocks included, and rewriting the ones
+  that match (:class:`RewritePass` and :func:`rewrite_leaf_ops`),
 * recognising constants that hold a single repeated value (either a ``const``
   or a ``fill`` op),
 * comparing shapes that may contain symbolic (sympy) dimensions,
@@ -13,8 +15,12 @@ proven (typically because a dimension is symbolic) the helpers report the
 "unknown" answer (``None``/``False``) so that callers skip the optimization.
 """
 
+import logging
+
 import numpy as np
 from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
+from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
 # Upper bound on the number of scaling/negation ops `peel_to_scaled_input` walks
@@ -289,3 +295,63 @@ def dtype_epsilon(var) -> float:
     if dtype is None or not types.is_float(dtype):
         return 0.0
     return float(np.finfo(types.nptype_from_builtin(dtype)).eps)
+
+
+@block_context_manager
+def rewrite_leaf_ops(block, visit) -> int:
+    """Run ``visit(op, block)`` over every leaf operation of ``block``, and return
+    the number of rewrites.
+
+    A *leaf* op is one that does not itself contain blocks. Ops that do
+    (``cond``, ``while_loop``, ...) are descended into instead, so ``visit``
+    only ever sees ops it can rewrite in place, together with the block that
+    holds them.
+
+    ``visit`` returns a truthy value when it rewrote the op it was given; those
+    are what is counted. It may remove other ops as well: the walk iterates over
+    a snapshot of the block and skips ops that a previous rewrite has already
+    taken out of it.
+
+    The whole walk runs inside ``with block`` (:func:`block_context_manager`),
+    which is what lets ``visit`` build replacement ops -- and keeps coremltools
+    from re-running its expensive block bookkeeping once per rewrite.
+    """
+    rewrites = 0
+    for op in list(block.operations):
+        if op.enclosing_block is None:
+            continue
+
+        for nested_block in op.blocks:
+            rewrites += rewrite_leaf_ops(nested_block, visit)
+        if len(op.blocks) > 0:
+            continue
+
+        if visit(op, block):
+            rewrites += 1
+
+    return rewrites
+
+
+class RewritePass(AbstractGraphPass):
+    """Base class for a pass that rewrites one matched op at a time.
+
+    Subclasses implement :meth:`visit`, which :func:`rewrite_leaf_ops` calls for
+    every leaf op of every function of the program, and set ``_REWRITES`` to a
+    plural noun naming what they rewrite (it only appears in the debug log).
+    """
+
+    # What one truthy `visit` amounts to, for the debug log.
+    _REWRITES = "op(s)"
+
+    def visit(self, op, block) -> bool:
+        """Rewrite ``op`` if it matches the pass' pattern; return whether it did."""
+        raise NotImplementedError
+
+    def apply(self, prog):
+        for f in prog.functions.values():
+            rewrites = rewrite_leaf_ops(f, self.visit)
+            if rewrites:
+                # Log under the subclass' own module, as a hand-written pass would.
+                logging.getLogger(type(self).__module__).debug(
+                    "%s: rewrote %d %s", type(self).__name__, rewrites, self._REWRITES
+                )

--- a/stablehlo_coreml/passes/remove_broadcast_tiles.py
+++ b/stablehlo_coreml/passes/remove_broadcast_tiles.py
@@ -9,15 +9,10 @@ constant weights). The pass therefore runs before the first
 ``const_elimination`` in the pipeline.
 """
 
-import logging
 
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
-from .pattern_utils import aligned_dim, const_int_list, dims_equal, is_broadcast_tile
-
-logger = logging.getLogger(__name__)
+from .pattern_utils import RewritePass, aligned_dim, const_int_list, dims_equal, is_broadcast_tile
 
 # Ops that support implicit NumPy-style broadcasting of their operands.
 #
@@ -115,38 +110,8 @@ def _can_remove(op, block) -> bool:
     return True
 
 
-@block_context_manager
-def _remove_broadcast_tiles(block) -> int:
-    removed = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            removed += _remove_broadcast_tiles(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        if not _can_remove(op, block):
-            continue
-
-        # The replacement changes the shape of the operand, so type inference on
-        # the consumers must be skipped (`no_check_var_types`). That is safe: we
-        # verified above that every consumer keeps its current output shape.
-        block.replace_uses_of_var_after_op(
-            anchor_op=op,
-            old_var=op.outputs[0],
-            new_var=op.x,
-            no_check_var_types=True,
-        )
-        op.remove_from_block()
-        removed += 1
-
-    return removed
-
-
 @register_pass(namespace="common")
-class remove_broadcast_tiles(AbstractGraphPass):
+class remove_broadcast_tiles(RewritePass):
     """
     Remove ``tile`` ops that only implement NumPy broadcasting for consumers
     that broadcast natively.
@@ -171,8 +136,20 @@ class remove_broadcast_tiles(AbstractGraphPass):
         %3 = add(x=%0, y=%1)
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            removed = _remove_broadcast_tiles(f)
-            if removed:
-                logger.debug("remove_broadcast_tiles: removed %d tile op(s)", removed)
+    _REWRITES = "tile op(s)"
+
+    def visit(self, op, block) -> bool:
+        if not _can_remove(op, block):
+            return False
+
+        # The replacement changes the shape of the operand, so type inference on
+        # the consumers must be skipped (`no_check_var_types`). That is safe: we
+        # verified above that every consumer keeps its current output shape.
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=op.x,
+            no_check_var_types=True,
+        )
+        op.remove_from_block()
+        return True

--- a/stablehlo_coreml/passes/replace_decomposed_softmax.py
+++ b/stablehlo_coreml/passes/replace_decomposed_softmax.py
@@ -31,15 +31,13 @@ exponentiate to exactly 0, so the ``select`` inside the sum is redundant and
 the whole thing is ``select(mask, softmax(select(mask, x, -inf)), 0)``.
 """
 
-import logging
 
 import numpy as np
 from coremltools.converters.mil import Builder as mb
-from coremltools.converters.mil.mil.passes.graph_pass import AbstractGraphPass
-from coremltools.converters.mil.mil.passes.helper import block_context_manager
 from coremltools.converters.mil.mil.passes.pass_registry import register_pass
 
 from .pattern_utils import (
+    RewritePass,
     const_int_list,
     dims_equal,
     is_broadcast_tile,
@@ -48,8 +46,6 @@ from .pattern_utils import (
     sole_consumer,
     uniform_scalar_value,
 )
-
-logger = logging.getLogger(__name__)
 
 # Shape/dtype-only ops that broadcast the reduction result back over the input.
 _BROADCAST_BACK_OPS = frozenset({"reshape", "expand_dims", "squeeze", "tile", "cast", "identity"})
@@ -269,36 +265,8 @@ def _is_statically_nonfinite(var) -> bool:
     return np.issubdtype(arr.dtype, np.floating) and not bool(np.all(np.isfinite(arr)))
 
 
-@block_context_manager
-def _replace_decomposed_softmax(block) -> int:
-    replaced = 0
-    for op in list(block.operations):
-        if op.enclosing_block is None:
-            continue
-
-        for nested_block in op.blocks:
-            replaced += _replace_decomposed_softmax(nested_block)
-        if len(op.blocks) > 0:
-            continue
-
-        match = _match(op)
-        if match is None:
-            continue
-        softmax_input, axis = match
-
-        softmax_var = mb.softmax(x=softmax_input, axis=axis, before_op=op, name=op.name + "_softmax")
-        block.replace_uses_of_var_after_op(
-            anchor_op=op,
-            old_var=op.outputs[0],
-            new_var=softmax_var,
-        )
-        replaced += 1
-
-    return replaced
-
-
 @register_pass(namespace="common")
-class replace_decomposed_softmax(AbstractGraphPass):
+class replace_decomposed_softmax(RewritePass):
     """
     Replace the decomposed softmax that JAX emits with MIL's ``softmax`` op.
 
@@ -339,8 +307,18 @@ class replace_decomposed_softmax(AbstractGraphPass):
     ``sub`` output becomes the softmax input.
     """
 
-    def apply(self, prog):
-        for f in prog.functions.values():
-            replaced = _replace_decomposed_softmax(f)
-            if replaced:
-                logger.debug("replace_decomposed_softmax: replaced %d softmax chain(s)", replaced)
+    _REWRITES = "softmax chain(s)"
+
+    def visit(self, op, block) -> bool:
+        match = _match(op)
+        if match is None:
+            return False
+        softmax_input, axis = match
+
+        softmax_var = mb.softmax(x=softmax_input, axis=axis, before_op=op, name=op.name + "_softmax")
+        block.replace_uses_of_var_after_op(
+            anchor_op=op,
+            old_var=op.outputs[0],
+            new_var=softmax_var,
+        )
+        return True

--- a/tests/passes/test_fuse_attention_to_sdpa.py
+++ b/tests/passes/test_fuse_attention_to_sdpa.py
@@ -232,7 +232,7 @@ class TestFuseAttentionToSdpa:
         expected = _reference_attention(
             q.astype(np.float32) / math.sqrt(E), k.astype(np.float32), v.astype(np.float32), bias=bias
         )
-        np.testing.assert_allclose(_predict(prog, q=q, k=k, v=v), expected, atol=2e-2, rtol=2e-2)
+        np.testing.assert_allclose(predict(prog, q=q, k=k, v=v), expected, atol=2e-2, rtol=2e-2)
 
     def test_scale_applied_after_the_mask_scales_the_fill(self):
         @mb.program(

--- a/tests/passes/test_pattern_utils.py
+++ b/tests/passes/test_pattern_utils.py
@@ -8,6 +8,7 @@ from stablehlo_coreml.passes.pattern_utils import (
     dims_equal,
     dtype_epsilon,
     peel_to_scaled_input,
+    rewrite_leaf_ops,
     shapes_equal,
     sole_consumer,
     uniform_scalar_value,
@@ -229,3 +230,67 @@ class TestDtypeEpsilon:
 
         assert dtype_epsilon(captured["v"]) == 0.0
         assert dtype_epsilon(None) == 0.0
+
+
+class TestRewriteLeafOps:
+
+    @staticmethod
+    def _cond_prog():
+        """A program whose only ``cond`` holds an ``add`` and a ``mul``."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1,))])
+        def prog(x):
+            pred = mb.squeeze(x=mb.less(x=x, y=1.0))
+            return mb.cond(
+                pred=pred,
+                _true_fn=lambda: mb.add(x=x, y=1.0),
+                _false_fn=lambda: mb.mul(x=x, y=2.0),
+            )
+
+        return prog
+
+    def test_descends_into_nested_blocks_instead_of_visiting_their_parent(self):
+        main = self._cond_prog().functions["main"]
+        seen = []
+
+        def visit(op, block):
+            seen.append((op.op_type, block is main))
+
+        assert rewrite_leaf_ops(main, visit) == 0
+        assert ("cond", True) not in seen
+        assert ("less", True) in seen
+        # The ops of the two branches are visited with their own block.
+        assert ("add", False) in seen
+        assert ("mul", False) in seen
+
+    def test_counts_the_truthy_visits_of_every_block(self):
+        main = self._cond_prog().functions["main"]
+        assert rewrite_leaf_ops(main, lambda op, block: op.op_type in ("add", "mul")) == 2
+
+    def test_skips_ops_a_previous_visit_removed(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4,))])
+        def prog(x):
+            a = mb.identity(x=x, name="a")
+            b = mb.identity(x=a, name="b")
+            return mb.identity(x=b, name="c")
+
+        seen = []
+
+        def visit(op, block):
+            """Fuse ``a -> b`` into a single op, the way a real pass would."""
+            seen.append(op.name)
+            if op.name != "a":
+                return False
+            consumer = op.outputs[0].child_ops[0]
+            fused = mb.identity(x=op.x, before_op=op, name="fused")
+            block.replace_uses_of_var_after_op(
+                anchor_op=consumer, old_var=consumer.outputs[0], new_var=fused
+            )
+            block.remove_ops([consumer, op])
+            return True
+
+        main = prog.functions["main"]
+        assert rewrite_leaf_ops(main, visit) == 1
+        # `b` is gone by the time the walk reaches it, and the replacement op is
+        # not visited either -- the walk iterates over a snapshot of the block.
+        assert seen == ["a", "c"]
+        assert [op.name for op in main.operations] == ["fused", "c"]


### PR DESCRIPTION
**Merge after the fix PRs** (#93, #95, #97, #98) — this rewrites the walker/`apply()` in every pass module, so it will need a rebase over whatever lands first. Matcher and rewrite bodies are untouched, so the conflicts should be mechanical.

## What

Nine pass modules carried the same ~20-line block walker (`for op in list(block.operations): if op.enclosing_block is None: continue; for nested in op.blocks: …; if op.blocks: continue; …`) and the same `apply()` differing only in a log string.

- `pattern_utils.rewrite_leaf_ops(block, visit) -> int`: the walker, once (snapshot iteration, skips ops removed by an earlier rewrite, descends into nested blocks, never hands `visit` an op that owns blocks, runs under `block_context_manager`).
- `pattern_utils.RewritePass(AbstractGraphPass)`: `apply()` runs the walker over every function and logs `"<pass>: rewrote N <_REWRITES>"` under the subclass' own module logger.
- Each pass becomes `class X(RewritePass)` with a `visit(op, block) -> bool` whose body is the old per-op code verbatim (`continue` → `return False`). `fuse_attention_to_sdpa` keeps its three option properties; `fuse_rmsnorm`'s folded `op_type != "rsqrt"` guard is now an explicit first line.
- `pattern_utils.__all__` deleted (nothing star-imports it); `const_scaled_operand` → `_const_scaled_operand` (only caller is `peel_to_scaled_input` in the same module).
- Three new tests for the walker (nested `cond` blocks, count across blocks, skipping an op removed by an earlier visit).

11 files, +311/−394: production code −148 lines, +65 lines of tests. `tests/passes` 397 passed / 1 xfailed; full suite 623 passed, 1 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ohznhojTFSSgjzJBWHWAv
