### PR TITLE
README: drop the stale DEFAULT_HLO_PIPELINE reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ cml_model = ct.convert(
 `build_pass_pipeline()` returns a fresh `ct.PassPipeline` built from
 `ct.PassPipeline.DEFAULT` with the stablehlo-coreml graph passes inserted at the right
 places. Pass your own `base` pipeline to customise it, e.g.
-`build_pass_pipeline(my_pipeline)`. The pre-built `stablehlo_coreml.DEFAULT_HLO_PIPELINE`
-is the same thing, constructed once at import time — copy it before mutating it.
+`build_pass_pipeline(my_pipeline)`. Since 0.1.6 there is no pre-built module-level
+pipeline any more (`DEFAULT_HLO_PIPELINE` / `register_optimizations()` from 0.1.3 were
+removed in #96); call `build_pass_pipeline()` and set options on the returned object, e.g.
+`pipeline.set_options("common::const_elimination", {"skip_const_by_size": "1e2"})`.
 
 ### Obtaining a StableHLO Module from JAX
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ cml_model = ct.convert(
 `build_pass_pipeline()` returns a fresh `ct.PassPipeline` built from
 `ct.PassPipeline.DEFAULT` with the stablehlo-coreml graph passes inserted at the right
 places. Pass your own `base` pipeline to customise it, e.g.
-`build_pass_pipeline(my_pipeline)`. Since 0.1.6 there is no pre-built module-level
-pipeline any more (`DEFAULT_HLO_PIPELINE` / `register_optimizations()` from 0.1.3 were
-removed in #96); call `build_pass_pipeline()` and set options on the returned object, e.g.
+`build_pass_pipeline(my_pipeline)`. Set options on the returned pipeline, e.g.
 `pipeline.set_options("common::const_elimination", {"skip_const_by_size": "1e2"})`.
 
 ### Obtaining a StableHLO Module from JAX


### PR DESCRIPTION
## What

`DEFAULT_HLO_PIPELINE` and `register_optimizations()` were removed in #96, but the README still described the pre-built pipeline and told readers to copy it before mutating. Replace that sentence with the 0.1.6 way: call `build_pass_pipeline()` and set options on the returned object.

Found while bumping sphere-detector from 0.1.3 to 0.1.6: its export imported both removed names, and the README was the first place I looked for the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWnpV2yYCekx4wC2NyanuJ