### PR TITLE
passes: simplify_concat drops no-op concat operands and flattens same-axis chains

### DIFF
--- a/stablehlo_coreml/passes/simplify_concat.py
+++ b/stablehlo_coreml/passes/simplify_concat.py
@@ -113,15 +113,26 @@ def _concat_shape(values, axis: int):
     return tuple(shape)
 
 
-def _renames_function_input(op, new_var) -> bool:
-    """True if replacing ``op``'s output by ``new_var`` would rename a function input.
+def _breaks_function_outputs(op, new_var) -> bool:
+    """True if bypassing ``op`` in favour of ``new_var`` would damage the function outputs.
 
     coremltools carries the name of a replaced block output over to its
-    replacement so that the model keeps its output names, and refuses to do that
-    to a function input (``Block.replace_block_output_var`` raises ``ValueError:
-    It is not allowed to modify function inputs name.``, aborting the whole
-    conversion). That happens for e.g. a single-input ``concat`` of an argument
-    returned as the function's result.
+    replacement so that the model keeps its output names
+    (``Block.replace_block_output_var``). When ``op``'s output is a function
+    output, that rename has two failure modes:
+
+    * ``new_var`` is a function input: the rename is refused outright
+      (``ValueError: It is not allowed to modify function inputs name.``), which
+      aborts the whole conversion. That is e.g. a single-input ``concat`` of an
+      argument returned as the function's result.
+    * ``new_var`` is already an output of the same function: the two output
+      slots collapse onto one ``Var``, which then takes ``op``'s output name --
+      so the converted model is left with one output where the program had two,
+      and the other output name silently disappears.
+
+    Neither applies to a nested block: ``replace_block_output_var`` only renames
+    on a ``Function``, and a ``cond``/``while_loop`` block may perfectly well
+    list the same var in two of its output slots.
     """
     block = op.enclosing_block
     if not isinstance(block, Function):
@@ -129,6 +140,8 @@ def _renames_function_input(op, new_var) -> bool:
     out_var = op.outputs[0]
     if out_var not in block.outputs:
         return False
+    if new_var in block.outputs:
+        return True
     return new_var in block.inputs.values() and new_var.name != out_var.name
 
 
@@ -153,6 +166,9 @@ class simplify_concat(RewritePass):
     ``interleave=True`` concats take part in neither rewrite: they round-robin
     their operands rather than append them, so they are neither associative nor
     indifferent to an empty operand.
+
+    A copy whose output is a *function* output is only bypassed when that does
+    not disturb the model interface; see :func:`_breaks_function_outputs`.
 
     Given:
         %2 = concat(values=(%0, %1), axis=0)   # %1: (0, 16)
@@ -209,9 +225,13 @@ class simplify_concat(RewritePass):
             new_var = new_values[0]
             if new_var.dtype != out_var.dtype:
                 return False
-            if _renames_function_input(op, new_var):
+            if _breaks_function_outputs(op, new_var):
                 return False
         else:
+            # No `_breaks_function_outputs` check here: this var is brand new, so
+            # it is neither a function input nor already an output, and the
+            # rename `replace_block_output_var` performs just moves `op`'s output
+            # name onto its replacement -- one output slot in, one out.
             new_var = mb.concat(values=new_values, axis=axis, interleave=False, before_op=op)
             built_op = new_var.op
 

--- a/stablehlo_coreml/passes/simplify_concat.py
+++ b/stablehlo_coreml/passes/simplify_concat.py
@@ -1,0 +1,229 @@
+"""MIL pass: drop no-op ``concat`` operands and flatten same-axis concat chains.
+
+``concatenate`` lowers one-to-one, so StableHLO built by appending to a list of
+tensors reaches MIL as a left-leaning chain of binary ``concat`` ops, every link
+of which materialises a full copy of everything concatenated so far. A five-link
+chain therefore writes the final tensor more than once over. Padding adds no-ops
+on top of that: an edge of width zero lowers to a ``concat`` with a zero-sized
+operand, and a single-element concatenation to a ``concat`` with one input --
+both plain copies of their input.
+
+coremltools cleans up neither. ``noop_elimination`` does not list ``concat``
+among its ``_SUPPORTED_OPS`` at all, ``const_elimination`` only folds concats
+whose operands are *all* constants, and ``remove_redundant_ops`` just
+deduplicates structurally identical ops. The no-ops consequently survive into
+the final model, which is what this pass is for.
+"""
+
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import Function
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .pattern_utils import RewritePass, normalize_axis, shapes_equal, sole_consumer
+
+
+def _plain_concat_axis(op, rank: int) -> int | None:
+    """``op``'s concat axis, normalised against ``rank``, or ``None``.
+
+    ``None`` whenever the op is not a ``concat`` this pass understands: a
+    non-constant or out-of-range ``axis``, or ``interleave=True`` (which
+    round-robins the operands instead of appending them, so neither of the
+    rewrites below holds).
+    """
+    if op is None or op.op_type != "concat":
+        return None
+
+    interleave = op.inputs.get("interleave")
+    if interleave is not None:
+        # `interleave` is a `const` by its input spec, so an unknown value here
+        # means a graph we do not understand -- give up on it either way.
+        value = getattr(interleave, "val", None)
+        if value is None or bool(value):
+            return None
+
+    axis = getattr(op.inputs.get("axis"), "val", None)
+    if axis is None:
+        return None
+    return normalize_axis(int(axis), rank)
+
+
+def _has_uniform_rank(values, rank: int) -> bool:
+    """True if every value has a known shape of exactly ``rank`` dimensions.
+
+    Rank-0 operands are rejected by construction: ``concat`` promotes scalars to
+    length-1 rows, so its output rank is 1 while the operand rank is 0, and
+    neither splicing them into another concat nor bypassing the op would keep
+    the shapes right.
+    """
+    return all(value.shape is not None and len(value.shape) == rank for value in values)
+
+
+def _inline_operands(value, parent, axis: int, block, rank: int):
+    """The operands to splice in place of ``value``, or ``None`` to keep it as is.
+
+    ``value`` may be replaced by its own operands when it is produced by a
+    ``concat`` on the same axis that nothing else consumes:
+    ``concat(concat(a, b), c) == concat(a, b, c)``. The producer has to sit in
+    the same block, and ``parent`` has to be its only consumer -- otherwise the
+    intermediate result is still needed and the rewrite would only add an op.
+    """
+    child = value.op
+    if _plain_concat_axis(child, rank) != axis:
+        return None
+    if child.enclosing_block is not block:
+        return None
+    # `sole_consumer` also rejects a value that leaves the block as an output.
+    if sole_consumer(value) is not parent:
+        return None
+    # A var consumed twice by the same op is a single entry in `child_ops`, so
+    # count the occurrences rather than trusting `sole_consumer` alone.
+    if sum(1 for operand in parent.values if operand is value) != 1:
+        return None
+    if not _has_uniform_rank(child.values, rank):
+        return None
+    return list(child.values)
+
+
+def _is_empty(value, axis: int) -> bool:
+    """True if ``value`` provably contributes nothing along ``axis``.
+
+    Only a literal ``0`` counts: a symbolic dimension may well be zero at
+    runtime, but it may just as well not be.
+    """
+    dim = value.shape[axis]
+    return not is_symbolic(dim) and int(dim) == 0
+
+
+def _concat_shape(values, axis: int):
+    """The shape ``concat(values, axis=axis)`` infers, or ``None`` if not provable.
+
+    Mirrors ``concat.type_inference``: the non-axis dimensions come from the
+    first operand and the axis dimension is the sum. One symbolic operand makes
+    the sum a fresh symbol, which no comparison can match, so those give up.
+    """
+    shape = list(values[0].shape)
+    total = 0
+    for value in values:
+        dim = value.shape[axis]
+        if is_symbolic(dim):
+            return None
+        total += int(dim)
+    shape[axis] = total
+    return tuple(shape)
+
+
+def _renames_function_input(op, new_var) -> bool:
+    """True if replacing ``op``'s output by ``new_var`` would rename a function input.
+
+    coremltools carries the name of a replaced block output over to its
+    replacement so that the model keeps its output names, and refuses to do that
+    to a function input (``Block.replace_block_output_var`` raises ``ValueError:
+    It is not allowed to modify function inputs name.``, aborting the whole
+    conversion). That happens for e.g. a single-input ``concat`` of an argument
+    returned as the function's result.
+    """
+    block = op.enclosing_block
+    if not isinstance(block, Function):
+        return False
+    out_var = op.outputs[0]
+    if out_var not in block.outputs:
+        return False
+    return new_var in block.inputs.values() and new_var.name != out_var.name
+
+
+@register_pass(namespace="common")
+class simplify_concat(RewritePass):
+    """
+    Remove ``concat`` operands that contribute nothing, and fold a ``concat``
+    chain on one axis into a single n-ary ``concat``.
+
+    A concat is rewritten when, after
+
+    1. replacing every operand that is itself a same-axis ``concat`` in the same
+       block with no other consumer by that concat's own operands, and
+    2. dropping every operand whose size along the concat axis is a literal 0,
+
+    the operand list has changed, or is down to a single operand -- in which
+    case the concat is a copy and its consumers use the operand directly. The
+    rewrite is skipped unless the new operand list provably infers the very same
+    output shape, which also rules out the cases a symbolic dimension makes
+    undecidable (``concat`` mints a fresh symbol for an axis it cannot add up).
+
+    ``interleave=True`` concats take part in neither rewrite: they round-robin
+    their operands rather than append them, so they are neither associative nor
+    indifferent to an empty operand.
+
+    Given:
+        %2 = concat(values=(%0, %1), axis=0)   # %1: (0, 16)
+        %4 = concat(values=(%2, %3), axis=0)
+
+    Result:
+        %4 = concat(values=(%0, %3), axis=0)
+    """
+
+    _REWRITES = "concat op(s)"
+
+    def visit(self, op, block) -> bool:
+        out_var = op.outputs[0]
+        if out_var.shape is None:
+            return False
+        rank = len(out_var.shape)
+
+        axis = _plain_concat_axis(op, rank)
+        if axis is None:
+            return False
+
+        values = list(op.values)
+        if not _has_uniform_rank(values, rank):
+            return False
+
+        expanded = []
+        changed = False
+        for value in values:
+            inlined = _inline_operands(value, op, axis, block, rank)
+            if inlined is None:
+                expanded.append(value)
+            else:
+                expanded += inlined
+                changed = True
+
+        new_values = [value for value in expanded if not _is_empty(value, axis)]
+        if len(new_values) != len(expanded):
+            changed = True
+
+        # Everything was empty: there is no operand left to carry the (equally
+        # empty) result, so leave the op alone.
+        if len(new_values) == 0:
+            return False
+        # A single operand left is a copy, worth removing even if nothing else
+        # about the operand list changed.
+        if not changed and len(new_values) > 1:
+            return False
+
+        if not shapes_equal(_concat_shape(new_values, axis), out_var.shape):
+            return False
+
+        built_op = None
+        if len(new_values) == 1:
+            new_var = new_values[0]
+            if new_var.dtype != out_var.dtype:
+                return False
+            if _renames_function_input(op, new_var):
+                return False
+        else:
+            new_var = mb.concat(values=new_values, axis=axis, interleave=False, before_op=op)
+            built_op = new_var.op
+
+        # `try_...` rather than the unguarded variant: an operand may descend
+        # from a var coremltools refuses to replace (a `constexpr_*` weight,
+        # say), in which case the rewrite is skipped instead of raising.
+        if not block.try_replace_uses_of_var_after_op(
+            anchor_op=op, old_var=out_var, new_var=new_var
+        ):
+            if built_op is not None:
+                built_op.remove_from_block()
+            return False
+
+        op.remove_from_block()
+        return True

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -20,6 +20,7 @@ from . import fuse_rmsnorm as _fuse_rmsnorm  # noqa: F401
 from . import remove_broadcast_tiles as _remove_broadcast_tiles  # noqa: F401
 from . import remove_noop_slice_update as _remove_noop_slice_update  # noqa: F401
 from . import replace_decomposed_softmax as _replace_decomposed_softmax  # noqa: F401
+from . import simplify_concat as _simplify_concat  # noqa: F401
 
 # The passes do not clean up after themselves; the ops they leave behind are
 # removed by coremltools' dead code elimination, interleaved between them (one
@@ -41,6 +42,12 @@ CLEANUP_PASSES: list[str] = [
     # was its sole consumer.
     _DCE,
     "common::remove_noop_slice_update",
+    # Structural cleanup: the no-op `concat`s and the binary `concat` chains
+    # go before `const_elimination`, so that a chain of constant operands is
+    # folded once, into the flattened concat, rather than at every link.
+    "common::simplify_concat",
+    # `simplify_concat` leaves the concats it folded away behind.
+    _DCE,
 ]
 
 # Fusion passes. They run just before `common::fuse_matmul_weight_bias`: by then

--- a/tests/passes/test_simplify_concat.py
+++ b/tests/passes/test_simplify_concat.py
@@ -1,0 +1,404 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import (
+    assert_model_is_valid,
+    get_op_types_in_program,
+)
+
+from tests.passes.helpers import apply_pass, count_ops, ops_of_type, predict
+from tests.utils import get_model_instruction_types, run_and_compare
+
+PASS_NAME = "common::simplify_concat"
+
+
+def _apply(prog):
+    """Apply the pass (plus DCE, which clears the folded-away concats)."""
+    return apply_pass(prog, PASS_NAME)
+
+
+def _concat_operands(prog):
+    """The operand shapes of every remaining concat, in program order."""
+    return [
+        [tuple(value.shape) for value in op.values]
+        for op in ops_of_type(prog, "concat", recurse=True)
+    ]
+
+
+def _empty(rows: int = 0, cols: int = 4):
+    return np.zeros((rows, cols), dtype=np.float32)
+
+
+class TestSimplifyConcat:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_drops_a_zero_sized_operand(self):
+        """One operand left after the drop, so the concat itself is a copy."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            padded = mb.concat(values=[x, _empty()], axis=0)
+            return mb.relu(x=padded)
+
+        assert get_op_types_in_program(prog) == ["concat", "relu"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["relu"]
+        assert prog.functions["main"].outputs[0].shape == (3, 4)
+        assert_model_is_valid(
+            prog, {"x": (3, 4)}, minimum_deployment_target=ct.target.iOS18, backend=("mlprogram", "fp32")
+        )
+
+    def test_drops_a_zero_sized_operand_and_keeps_the_concat(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(x, y):
+            padded = mb.concat(values=[x, _empty(), y], axis=0)
+            return mb.relu(x=padded)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["concat", "relu"]
+        assert _concat_operands(prog) == [[(3, 4), (2, 4)]]
+        assert prog.functions["main"].outputs[0].shape == (5, 4)
+
+    def test_drops_a_zero_sized_operand_on_a_non_zero_axis(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(4, 3))])
+        def prog(x):
+            padded = mb.concat(values=[x, np.zeros((4, 0), dtype=np.float32)], axis=1)
+            return mb.relu(x=padded)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["relu"]
+        assert prog.functions["main"].outputs[0].shape == (4, 3)
+
+    def test_removes_a_single_input_concat(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            copied = mb.concat(values=[x], axis=0)
+            return mb.relu(x=copied)
+
+        assert get_op_types_in_program(prog) == ["concat", "relu"]
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["relu"]
+        assert prog.functions["main"].outputs[0].shape == (3, 4)
+
+    def test_flattens_a_same_axis_chain(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, 4)),
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(3, 4)),
+            mb.TensorSpec(shape=(4, 4)),
+        ])
+        def prog(a, b, c, d):
+            ab = mb.concat(values=[a, b], axis=0)
+            abc = mb.concat(values=[ab, c], axis=0)
+            abcd = mb.concat(values=[abc, d], axis=0)
+            return mb.relu(x=abcd)
+
+        assert count_ops(prog, "concat") == 3
+        _apply(prog)
+        assert _concat_operands(prog) == [[(1, 4), (2, 4), (3, 4), (4, 4)]]
+        assert prog.functions["main"].outputs[0].shape == (10, 4)
+        assert_model_is_valid(
+            prog,
+            {"a": (1, 4), "b": (2, 4), "c": (3, 4), "d": (4, 4)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_flattens_a_chain_whose_child_is_not_the_first_operand(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, 4)),
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(3, 4)),
+        ])
+        def prog(a, b, c):
+            bc = mb.concat(values=[b, c], axis=0)
+            abc = mb.concat(values=[a, bc], axis=0)
+            return mb.relu(x=abc)
+
+        _apply(prog)
+        assert _concat_operands(prog) == [[(1, 4), (2, 4), (3, 4)]]
+
+    def test_flattens_a_chain_on_a_negative_axis(self):
+        """A negative axis names the same dimension, so the chain still folds."""
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(4, 1)),
+            mb.TensorSpec(shape=(4, 2)),
+            mb.TensorSpec(shape=(4, 3)),
+        ])
+        def prog(a, b, c):
+            ab = mb.concat(values=[a, b], axis=-1)
+            abc = mb.concat(values=[ab, c], axis=1)
+            return mb.relu(x=abc)
+
+        _apply(prog)
+        assert _concat_operands(prog) == [[(4, 1), (4, 2), (4, 3)]]
+        assert prog.functions["main"].outputs[0].shape == (4, 6)
+
+    def test_flattens_a_five_deep_chain_into_one_op(self):
+        """The shape of the chains the sphere model builds: one concat per scale."""
+        sizes = [120, 527, 2205, 9216, 37668, 152292]
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(size,)) for size in sizes])
+        def prog(a, b, c, d, e, f):
+            acc = a
+            for scale in (b, c, d, e, f):
+                acc = mb.concat(values=[acc, scale], axis=0)
+            return mb.relu(x=acc)
+
+        assert count_ops(prog, "concat") == 5
+        _apply(prog)
+        assert _concat_operands(prog) == [[(size,) for size in sizes]]
+        assert prog.functions["main"].outputs[0].shape == (sum(sizes),)
+
+    def test_drops_a_zero_sized_operand_of_a_flattened_chain(self):
+        """The empty operand comes in through the splice, and still goes."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(x, y):
+            padded = mb.concat(values=[x, _empty()], axis=0)
+            joined = mb.concat(values=[padded, y], axis=0)
+            return mb.relu(x=joined)
+
+        _apply(prog)
+        assert _concat_operands(prog) == [[(3, 4), (2, 4)]]
+
+    def test_not_flattened_when_the_child_has_another_consumer(self):
+        """The intermediate result is needed anyway; folding would only add an op."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=0)
+            abb = mb.concat(values=[ab, b], axis=0)
+            return mb.add(x=abb, y=mb.concat(values=[ab, b], axis=0))
+
+        before = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == before
+
+    def test_not_flattened_when_the_child_is_a_block_output(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=0)
+            abb = mb.concat(values=[ab, b], axis=0)
+            return ab, abb
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+
+    def test_not_flattened_across_different_axes(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=1)
+            stacked = mb.concat(values=[ab, mb.concat(values=[a, b], axis=1)], axis=0)
+            return mb.relu(x=stacked)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 3
+
+    def test_not_flattened_when_the_child_interleaves(self):
+        """`interleave` round-robins the operands, so the chain is not associative."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=0, interleave=True)
+            abb = mb.concat(values=[ab, b], axis=0)
+            return mb.relu(x=abb)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+
+    def test_not_rewritten_when_the_parent_interleaves(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=0)
+            interleaved = mb.concat(values=[ab, ab], axis=0, interleave=True)
+            return mb.relu(x=interleaved)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+
+    def test_not_rewritten_when_the_same_operand_is_used_twice(self):
+        """`concat(c, c)` keeps `c`: splicing it in would drop one of the copies."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(a, b):
+            ab = mb.concat(values=[a, b], axis=0)
+            doubled = mb.concat(values=[ab, ab], axis=0)
+            return mb.relu(x=doubled)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+        assert prog.functions["main"].outputs[0].shape == (6, 4)
+
+    def test_not_dropped_for_a_symbolic_operand(self):
+        """A symbolic dimension may be 0 at runtime, but it may just as well not be."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(length, 4))])
+        def prog(x, y):
+            joined = mb.concat(values=[x, y], axis=0)
+            return mb.relu(x=joined)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["concat", "relu"]
+        assert _concat_operands(prog) == [[(3, 4), (length, 4)]]
+
+    def test_not_flattened_when_a_symbolic_dim_would_be_renamed(self):
+        """`concat` mints a fresh symbol per op, so the folded shape is unprovable.
+
+        The chain below really is associative, but its output dimension is a
+        symbol that no compile-time comparison can match against the one the
+        rebuilt concat would infer, so the pass leaves it alone.
+        """
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(length, 4)),
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(3, 4)),
+        ])
+        def prog(a, b, c):
+            ab = mb.concat(values=[a, b], axis=0)
+            abc = mb.concat(values=[ab, c], axis=0)
+            return mb.relu(x=abc)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+
+    def test_all_empty_operands_are_left_alone(self):
+        """Nothing is left to carry the (equally empty) result."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 4))])
+        def prog(x):
+            joined = mb.concat(values=[_empty(), _empty()], axis=0)
+            return mb.concat(values=[x, joined], axis=0)
+
+        _apply(prog)
+        assert count_ops(prog, "concat") == 2
+
+    def test_scalar_concat_is_left_alone(self):
+        """`concat` promotes rank-0 operands to length 1, so it is not a copy."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3,))])
+        def prog(x):
+            scalar = mb.reduce_sum(x=x, axes=[0], keep_dims=False)
+            promoted = mb.concat(values=[scalar], axis=0)
+            return mb.relu(x=promoted)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["reduce_sum", "concat", "relu"]
+        assert prog.functions["main"].outputs[0].shape == (1,)
+
+    def test_single_input_concat_of_a_function_input_is_left_alone(self):
+        """coremltools refuses to rename a function input to the output's name."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            return mb.concat(values=[x], axis=0)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["concat"]
+
+    def test_rewritten_inside_a_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            def true_fn():
+                return mb.concat(values=[x, _empty()], axis=0)
+
+            def false_fn():
+                return mb.relu(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert count_ops(prog, "concat", recurse=True) == 1
+        _apply(prog)
+        assert count_ops(prog, "concat", recurse=True) == 0
+
+    def test_not_flattened_when_the_child_is_consumed_from_a_nested_block(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(1,), dtype=types.bool)])
+        def prog(x, pred):
+            ab = mb.concat(values=[x, x], axis=0)
+
+            def true_fn():
+                return mb.concat(values=[ab, x], axis=0)
+
+            def false_fn():
+                return mb.concat(values=[x, ab], axis=0)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert count_ops(prog, "concat", recurse=True) == 3
+
+    def test_is_idempotent(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, 4)),
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(3, 4)),
+        ])
+        def prog(a, b, c):
+            ab = mb.concat(values=[a, b, _empty()], axis=0)
+            abc = mb.concat(values=[ab, c], axis=0)
+            return mb.relu(x=abc)
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        operands_after_first = _concat_operands(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+        assert _concat_operands(prog) == operands_after_first
+
+
+class TestSimplifyConcatNumerics:
+    """The rewritten program computes exactly what the original one did."""
+
+    def test_flattened_chain_matches(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, 4)),
+            mb.TensorSpec(shape=(2, 4)),
+            mb.TensorSpec(shape=(3, 4)),
+        ])
+        def prog(a, b, c):
+            ab = mb.concat(values=[a, b], axis=0)
+            abc = mb.concat(values=[ab, c], axis=0)
+            return mb.relu(x=abc)
+
+        values = {
+            "a": np.random.randn(1, 4).astype(np.float32),
+            "b": np.random.randn(2, 4).astype(np.float32),
+            "c": np.random.randn(3, 4).astype(np.float32),
+        }
+        prev_prog = _apply(prog)
+        assert count_ops(prog, "concat") == 1
+        np.testing.assert_array_equal(predict(prog, **values), predict(prev_prog, **values))
+
+    def test_dropped_empty_operand_matches(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(2, 4))])
+        def prog(x, y):
+            padded = mb.concat(values=[x, _empty(), y], axis=0)
+            return mb.relu(x=padded)
+
+        values = {
+            "x": np.random.randn(3, 4).astype(np.float32),
+            "y": np.random.randn(2, 4).astype(np.float32),
+        }
+        prev_prog = _apply(prog)
+        assert _concat_operands(prog) == [[(3, 4), (2, 4)]]
+        np.testing.assert_array_equal(predict(prog, **values), predict(prev_prog, **values))
+
+
+class TestSimplifyConcatEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    def test_repeated_concatenate_leaves_a_single_concat(self):
+        def f(a, b, c, d):
+            acc = a
+            for part in (b, c, d):
+                acc = jnp.concatenate([acc, part], axis=0)
+            return acc * 2.0
+
+        cml_model = run_and_compare(
+            f,
+            [
+                jax.ShapeDtypeStruct((1, 8), jnp.float32),
+                jax.ShapeDtypeStruct((2, 8), jnp.float32),
+                jax.ShapeDtypeStruct((3, 8), jnp.float32),
+                jax.ShapeDtypeStruct((4, 8), jnp.float32),
+            ],
+        )
+        assert get_model_instruction_types(cml_model).count("concat") == 1

--- a/tests/passes/test_simplify_concat_adversarial.py
+++ b/tests/passes/test_simplify_concat_adversarial.py
@@ -201,7 +201,7 @@ class TestNestedBlocks:
                 grown = mb.concat(values=[acc, x], axis=0)
                 return mb.add(x=i, y=1), mb.concat(values=[grown, _empty()], axis=0)
 
-            i, acc = mb.while_loop(_cond=cond, _body=body, loop_vars=(np.int32(0), x))
+            _, acc = mb.while_loop(_cond=cond, _body=body, loop_vars=(np.int32(0), x))
             return acc
 
         _apply(prog, skip_output_shape_check=True)

--- a/tests/passes/test_simplify_concat_adversarial.py
+++ b/tests/passes/test_simplify_concat_adversarial.py
@@ -5,32 +5,26 @@ graph rather than for the sphere model: concats whose output is a block
 output, nested blocks, loop-carried values, non-float dtypes, concats that
 feed a ``reshape``'s shape vector, and symbolic non-axis dimensions.
 
-The ``xfail(strict=True)`` tests pin down confirmed defects: they start
-failing on purpose (and must have their marker removed) once the pass is
-fixed.
+The first two tests of :class:`TestBlockOutputs` used to be
+``xfail(strict=True)``: they pinned down a defect where bypassing a copy
+whose output is a function output merged two of the function's outputs into
+one. They pin the fix now.
 """
 
 import coremltools as ct
 import numpy as np
-import pytest
 from coremltools.converters.mil.mil import Builder as mb
 from coremltools.converters.mil.mil import get_new_symbol
-from coremltools.converters.mil.mil.passes.pass_pipeline import PassPipelineManager
 from coremltools.converters.mil.testing_utils import get_op_types_in_program
 
 import stablehlo_coreml.passes.utils  # noqa: F401  (registers the pass)
-from tests.passes.helpers import DCE_PASS_NAME, apply_pass, count_ops, predict
+from tests.passes.helpers import apply_pass, count_ops, predict
 
 PASS_NAME = "common::simplify_concat"
 
 
 def _apply(prog, **kwargs):
     return apply_pass(prog, PASS_NAME, **kwargs)
-
-
-def _apply_unchecked(prog):
-    """Apply the pass without coremltools' basic checks (which would already trip)."""
-    PassPipelineManager.apply_pipeline(prog, ct.PassPipeline([PASS_NAME, DCE_PASS_NAME], "adversarial"))
 
 
 def _convert(prog, **kwargs):
@@ -56,16 +50,8 @@ def _empty(rows: int = 0, cols: int = 4):
 class TestBlockOutputs:
     """Concats whose output leaves the function."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "simplify_concat bypasses a single-input concat that is a function output while its "
-            "operand is *also* a function output: Block.replace_block_output_var then renames the "
-            "operand to the concat's name, so the model ends up with two outputs both called 'c' and "
-            "the output 'y' silently disappears."
-        ),
-    )
     def test_copy_of_a_var_that_is_also_returned_directly_keeps_both_outputs(self):
+        """Bypassing the copy would rename `y` to `c` and leave `c` returned twice."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
         def prog(x):
             y = mb.relu(x=x, name="y")
@@ -74,8 +60,9 @@ class TestBlockOutputs:
 
         names_before = _output_names(prog)
         assert names_before == ["y", "c"]
-        _apply_unchecked(prog)
+        _apply(prog)
         assert _output_names(prog) == names_before
+        assert get_op_types_in_program(prog) == ["relu", "concat"]
 
         model = _convert(prog)
         spec_outputs = [feature.name for feature in model.get_spec().description.output]
@@ -83,15 +70,8 @@ class TestBlockOutputs:
         result = model.predict({"x": np.ones((3, 4), dtype=np.float32)})
         assert set(result) == {"y", "c"}
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "two no-op concats of the same var, both returned by the function, collapse into one "
-            "var: the function then has two outputs that are the same Var with one name, and the "
-            "converted model exposes a single output."
-        ),
-    )
     def test_two_copies_of_one_var_stay_two_outputs(self):
+        """Only the first copy may be bypassed; `y` is an output afterwards, so the second stays."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
         def prog(x):
             y = mb.relu(x=x)
@@ -99,7 +79,7 @@ class TestBlockOutputs:
             second = mb.concat(values=[y, _empty()], axis=0, name="second")
             return first, second
 
-        _apply_unchecked(prog)
+        _apply(prog)
         assert _output_names(prog) == ["first", "second"]
         outputs = prog.functions["main"].outputs
         assert outputs[0] is not outputs[1]
@@ -107,6 +87,26 @@ class TestBlockOutputs:
         model = _convert(prog)
         result = model.predict({"x": np.ones((3, 4), dtype=np.float32)})
         assert set(result) == {"first", "second"}
+
+    def test_rebuilt_concat_that_is_an_output_next_to_its_own_operand(self):
+        """The rebuilt-concat path replaces one output slot by a fresh var, never merging two."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            y = mb.relu(x=x, name="y")
+            return y, mb.concat(values=[y, y, _empty()], axis=0, name="c")
+
+        _apply(prog)
+        assert _output_names(prog) == ["y", "c"]
+        outputs = prog.functions["main"].outputs
+        assert outputs[0] is not outputs[1]
+        assert get_op_types_in_program(prog) == ["relu", "concat"]
+        concat = next(op for op in prog.functions["main"].operations if op.op_type == "concat")
+        assert len(concat.values) == 2
+
+        model = _convert(prog)
+        result = model.predict({"x": np.ones((3, 4), dtype=np.float32)})
+        assert set(result) == {"y", "c"}
+        np.testing.assert_array_equal(result["c"], np.ones((6, 4), dtype=np.float32))
 
     def test_copy_returned_next_to_an_unrelated_output_keeps_the_names(self):
         """The rename is harmless when the operand is not itself an output."""

--- a/tests/passes/test_simplify_concat_adversarial.py
+++ b/tests/passes/test_simplify_concat_adversarial.py
@@ -1,0 +1,311 @@
+"""Adversarial tests for ``common::simplify_concat``.
+
+The cases in here go after the paths the pass has to get right for *any*
+graph rather than for the sphere model: concats whose output is a block
+output, nested blocks, loop-carried values, non-float dtypes, concats that
+feed a ``reshape``'s shape vector, and symbolic non-axis dimensions.
+
+The ``xfail(strict=True)`` tests pin down confirmed defects: they start
+failing on purpose (and must have their marker removed) once the pass is
+fixed.
+"""
+
+import coremltools as ct
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol
+from coremltools.converters.mil.mil.passes.pass_pipeline import PassPipelineManager
+from coremltools.converters.mil.testing_utils import get_op_types_in_program
+
+import stablehlo_coreml.passes.utils  # noqa: F401  (registers the pass)
+from tests.passes.helpers import DCE_PASS_NAME, apply_pass, count_ops, predict
+
+PASS_NAME = "common::simplify_concat"
+
+
+def _apply(prog, **kwargs):
+    return apply_pass(prog, PASS_NAME, **kwargs)
+
+
+def _apply_unchecked(prog):
+    """Apply the pass without coremltools' basic checks (which would already trip)."""
+    PassPipelineManager.apply_pipeline(prog, ct.PassPipeline([PASS_NAME, DCE_PASS_NAME], "adversarial"))
+
+
+def _convert(prog, **kwargs):
+    return ct.convert(
+        prog,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+        compute_precision=ct.precision.FLOAT32,
+        pass_pipeline=ct.PassPipeline.DEFAULT,
+        **kwargs,
+    )
+
+
+def _output_names(prog):
+    return [var.name for var in prog.functions["main"].outputs]
+
+
+def _empty(rows: int = 0, cols: int = 4):
+    return np.zeros((rows, cols), dtype=np.float32)
+
+
+class TestBlockOutputs:
+    """Concats whose output leaves the function."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "simplify_concat bypasses a single-input concat that is a function output while its "
+            "operand is *also* a function output: Block.replace_block_output_var then renames the "
+            "operand to the concat's name, so the model ends up with two outputs both called 'c' and "
+            "the output 'y' silently disappears."
+        ),
+    )
+    def test_copy_of_a_var_that_is_also_returned_directly_keeps_both_outputs(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            y = mb.relu(x=x, name="y")
+            c = mb.concat(values=[y], axis=0, name="c")
+            return y, c
+
+        names_before = _output_names(prog)
+        assert names_before == ["y", "c"]
+        _apply_unchecked(prog)
+        assert _output_names(prog) == names_before
+
+        model = _convert(prog)
+        spec_outputs = [feature.name for feature in model.get_spec().description.output]
+        assert spec_outputs == ["y", "c"]
+        result = model.predict({"x": np.ones((3, 4), dtype=np.float32)})
+        assert set(result) == {"y", "c"}
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "two no-op concats of the same var, both returned by the function, collapse into one "
+            "var: the function then has two outputs that are the same Var with one name, and the "
+            "converted model exposes a single output."
+        ),
+    )
+    def test_two_copies_of_one_var_stay_two_outputs(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            y = mb.relu(x=x)
+            first = mb.concat(values=[y], axis=0, name="first")
+            second = mb.concat(values=[y, _empty()], axis=0, name="second")
+            return first, second
+
+        _apply_unchecked(prog)
+        assert _output_names(prog) == ["first", "second"]
+        outputs = prog.functions["main"].outputs
+        assert outputs[0] is not outputs[1]
+
+        model = _convert(prog)
+        result = model.predict({"x": np.ones((3, 4), dtype=np.float32)})
+        assert set(result) == {"first", "second"}
+
+    def test_copy_returned_next_to_an_unrelated_output_keeps_the_names(self):
+        """The rename is harmless when the operand is not itself an output."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            y = mb.relu(x=x)
+            c = mb.concat(values=[y], axis=0, name="c")
+            return c, mb.sigmoid(x=y, name="s")
+
+        _apply(prog)
+        assert _output_names(prog) == ["c", "s"]
+        assert get_op_types_in_program(prog) == ["relu", "sigmoid"]
+
+
+class TestNestedBlocks:
+    """The rewrite inside `cond` / `while_loop` blocks, run end to end."""
+
+    def test_cond_branch_that_becomes_an_outer_var_runs(self):
+        """After the rewrite the true branch returns the outer `x` directly."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(1,))])
+        def prog(x, pred):
+            def true_fn():
+                return mb.concat(values=[x, _empty()], axis=0)
+
+            def false_fn():
+                return mb.sigmoid(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=mb.cast(x=pred, dtype="bool")), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert count_ops(prog, "concat", recurse=True) == 0
+        true_block = next(op for op in prog.functions["main"].operations if op.op_type == "cond").blocks[0]
+        assert true_block.outputs[0] is prog.functions["main"].inputs["x"]
+
+        model = _convert(prog)
+        x = np.random.randn(3, 4).astype(np.float32)
+        for pred, expected in ((1.0, x), (0.0, 1.0 / (1.0 + np.exp(-x)))):
+            result = next(iter(model.predict({"x": x, "pred": np.array([pred], dtype=np.float32)}).values()))
+            np.testing.assert_allclose(result, expected, rtol=1e-6, atol=1e-6)
+
+    def test_cond_branch_returning_a_var_twice_runs(self):
+        """A branch output that collapses onto another output of the same branch."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4)), mb.TensorSpec(shape=(1,))])
+        def prog(x, pred):
+            def true_fn():
+                y = mb.relu(x=x)
+                return y, mb.concat(values=[y], axis=0)
+
+            def false_fn():
+                return mb.sigmoid(x=x), mb.tanh(x=x)
+
+            a, b = mb.cond(pred=mb.squeeze(x=mb.cast(x=pred, dtype="bool")), _true_fn=true_fn, _false_fn=false_fn)
+            return mb.add(x=a, y=b)
+
+        _apply(prog)
+        assert count_ops(prog, "concat", recurse=True) == 0
+
+        model = _convert(prog)
+        x = np.random.randn(3, 4).astype(np.float32)
+        expected = {1.0: 2 * np.maximum(x, 0), 0.0: 1.0 / (1.0 + np.exp(-x)) + np.tanh(x)}
+        for pred, value in expected.items():
+            result = next(iter(model.predict({"x": x, "pred": np.array([pred], dtype=np.float32)}).values()))
+            np.testing.assert_allclose(result, value, rtol=1e-6, atol=1e-6)
+
+    def test_while_body_copy_of_a_loop_var(self):
+        """The body then returns its own block input; the loop stays correct."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(3, 4))])
+        def prog(x):
+            def cond(i, acc):
+                return mb.less(x=i, y=3)
+
+            def body(i, acc):
+                return mb.add(x=i, y=1), mb.concat(values=[acc, _empty()], axis=0)
+
+            i, acc = mb.while_loop(_cond=cond, _body=body, loop_vars=(np.int32(0), x))
+            return mb.add(x=acc, y=mb.cast(x=i, dtype="fp32"))
+
+        _apply(prog)
+        assert count_ops(prog, "concat", recurse=True) == 0
+
+        x = np.random.randn(3, 4).astype(np.float32)
+        np.testing.assert_allclose(predict(prog, x=x), x + 3.0, rtol=1e-6)
+
+    def test_loop_carried_chain_with_a_symbolic_accumulator_is_left_alone(self):
+        """A growing accumulator has a fresh symbol per link; nothing is provable."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 4))])
+        def prog(x):
+            def cond(i, acc):
+                return mb.less(x=i, y=3)
+
+            def body(i, acc):
+                grown = mb.concat(values=[acc, x], axis=0)
+                return mb.add(x=i, y=1), mb.concat(values=[grown, _empty()], axis=0)
+
+            i, acc = mb.while_loop(_cond=cond, _body=body, loop_vars=(np.int32(0), x))
+            return acc
+
+        _apply(prog, skip_output_shape_check=True)
+        assert count_ops(prog, "concat", recurse=True) == 2
+
+
+class TestDtypesAndValues:
+    def test_int32_chain_matches(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3)), mb.TensorSpec(shape=(1, 3))])
+        def prog(a, b):
+            a = mb.cast(x=a, dtype="int32")
+            b = mb.cast(x=b, dtype="int32")
+            ab = mb.concat(values=[a, b], axis=0)
+            abb = mb.concat(values=[ab, b, np.zeros((0, 3), dtype=np.int32)], axis=0)
+            return mb.cast(x=mb.add(x=abb, y=np.int32(1)), dtype="fp32")
+
+        values = {
+            "a": np.random.randint(-5, 5, (2, 3)).astype(np.float32),
+            "b": np.random.randint(-5, 5, (1, 3)).astype(np.float32),
+        }
+        prev_prog = _apply(prog)
+        assert count_ops(prog, "concat") == 1
+        np.testing.assert_array_equal(predict(prog, **values), predict(prev_prog, **values))
+
+    def test_bool_chain_matches(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3)), mb.TensorSpec(shape=(1, 3))])
+        def prog(a, b):
+            a = mb.greater(x=a, y=0.0)
+            b = mb.greater(x=b, y=0.0)
+            ab = mb.concat(values=[a, b], axis=0)
+            abb = mb.concat(values=[ab, b, np.zeros((0, 3), dtype=np.bool_)], axis=0)
+            return mb.cast(x=mb.logical_not(x=abb), dtype="fp32")
+
+        values = {
+            "a": np.random.randn(2, 3).astype(np.float32),
+            "b": np.random.randn(1, 3).astype(np.float32),
+        }
+        prev_prog = _apply(prog)
+        assert count_ops(prog, "concat") == 1
+        np.testing.assert_array_equal(predict(prog, **values), predict(prev_prog, **values))
+
+    def test_child_with_a_repeated_operand_is_spliced(self):
+        """`concat(concat(a, a), b)` -> `concat(a, a, b)`: the duplicate is inside the child."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(2, 3)), mb.TensorSpec(shape=(1, 3))])
+        def prog(a, b):
+            aa = mb.concat(values=[a, a], axis=0)
+            return mb.relu(x=mb.concat(values=[aa, b], axis=0))
+
+        values = {
+            "a": np.random.randn(2, 3).astype(np.float32),
+            "b": np.random.randn(1, 3).astype(np.float32),
+        }
+        prev_prog = _apply(prog)
+        assert count_ops(prog, "concat") == 1
+        concat = next(op for op in prog.functions["main"].operations if op.op_type == "concat")
+        assert [value.name for value in concat.values] == ["a", "a", "b"]
+        np.testing.assert_array_equal(predict(prog, **values), predict(prev_prog, **values))
+
+    def test_shape_vector_concat_keeps_its_symbolic_value(self):
+        """A `reshape` whose shape is a chain of concats over shape pieces still type-infers."""
+        length = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(length, 4))])
+        def prog(x):
+            n = mb.slice_by_index(x=mb.shape(x=x), begin=[0], end=[1])
+            inner = mb.concat(values=[n, np.array([2], dtype=np.int32)], axis=0)
+            shape = mb.concat(values=[inner, np.array([2], dtype=np.int32), np.zeros((0,), dtype=np.int32)], axis=0)
+            return mb.reshape(x=x, shape=shape)
+
+        assert prog.functions["main"].outputs[0].shape == (length, 2, 2)
+        _apply(prog)
+        assert count_ops(prog, "concat") == 1
+        assert prog.functions["main"].outputs[0].shape == (length, 2, 2)
+
+        model = _convert(prog, inputs=[ct.TensorType(name="x", shape=(ct.RangeDim(1, 16), 4))])
+        x = np.random.randn(5, 4).astype(np.float32)
+        result = next(iter(model.predict({"x": x}).values()))
+        np.testing.assert_array_equal(result, x.reshape(5, 2, 2))
+
+
+class TestSymbolicNonAxisDims:
+    """`concat` takes the non-axis dims from its first operand, symbolic or not."""
+
+    def test_empty_first_operand_with_a_symbolic_non_axis_dim_is_kept(self):
+        """Dropping it would turn the output's `(3, s)` into `(3, 4)`."""
+        width = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(0, width)), mb.TensorSpec(shape=(3, 4))])
+        def prog(empty, y):
+            return mb.relu(x=mb.concat(values=[empty, y], axis=0))
+
+        assert prog.functions["main"].outputs[0].shape == (3, width)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["concat", "relu"]
+        assert prog.functions["main"].outputs[0].shape == (3, width)
+
+    def test_empty_second_operand_with_a_symbolic_non_axis_dim_is_dropped(self):
+        width = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(0, width)), mb.TensorSpec(shape=(3, 4))])
+        def prog(empty, y):
+            return mb.relu(x=mb.concat(values=[y, empty], axis=0))
+
+        assert prog.functions["main"].outputs[0].shape == (3, 4)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["relu"]
+        assert prog.functions["main"].outputs[0].shape == (3, 4)


### PR DESCRIPTION
## What

New MIL pass `common::simplify_concat`, in `CLEANUP_PASSES` (before the first `const_elimination`, followed by a `_DCE` entry). Per `concat` op it

1. splices in the operands of any operand that is itself a same-axis, non-interleaving `concat` in the same block with no other consumer (`concat(concat(a, b), c) -> concat(a, b, c)`),
2. drops every operand whose size along the concat axis is a literal 0,
3. bypasses the concat when a single operand is left (it is a copy).

The rewrite only fires when the new operand list provably infers the same output shape (`shapes_equal`, symbolic-aware), so a symbolic axis never gets summed into a fresh symbol. `interleave=True` and rank-0 operands are excluded; nested blocks go through `RewritePass`. A copy whose output is a *function* output is only bypassed when that keeps the model interface intact: not when the operand is a function input (coremltools refuses the rename) and not when the operand is already another function output (the two output slots would collapse onto one `Var` and one output name would silently vanish) — both found by adversarial review and pinned by tests.

Why coremltools does not do this: `noop_elimination` does not list `concat` in `_SUPPORTED_OPS`, `const_elimination` only folds all-constant concats, and `remove_redundant_ops` only deduplicates identical ops.

## Where it comes from

`jnp.concatenate`/`jnp.pad` in a JAX model built by appending to a list lower to left-leaning binary concat chains, every link of which re-copies everything so far; zero-width pads lower to concats with a `(0, n)` operand. On the sphere-detector export (8231 ops): concat 224 -> 164 (18 zero-sized-operand concats, 6 single-input concats, 36 chain links incl. nine 5-deep chains that become one 6-ary concat each), total ops 8231 -> 8033, ~630k fp32 elements of pure copy removed. Outputs bit-identical.

## Measurements (honest version)

Interleaved benchmark on an M-series GPU (`CPU_AND_GPU`, fp32, median of 50 predicts per round):

| | 7 rounds | 15 rounds |
|---|---|---|
| baseline 0.1.6 | 13.9 ms | 13.95 ± 0.47 ms |
| this pass alone | 14.6 ms (noise) | — |
| this + #103 + `conv_pool_rank4` | 13.4 ms | 13.51 ± 0.76 ms |

So on this model the wall-clock effect of this pass alone is below the noise floor; all three cleanup passes together are worth about 3 %. It is a correctness-neutral cleanup of real no-op copies rather than a measurable speed-up here — merge on those merits or close. Full context, incl. the ANE analysis, in #105.

## Tests

`tests/passes/test_simplify_concat.py` (26) + `test_simplify_concat_adversarial.py` (14): positive rewrites on both axes, chains 3- and 5-deep, child-not-first-operand, negative axis; must-not-rewrite for extra consumers, block-output child, mixed axes, interleave, repeated operand, all-empty, rank-0, function-input copy; symbolic-axis and fresh-symbol cases; nested `cond`/`while_loop`; idempotence; predict-equality; one end-to-end JAX test. `tests/passes`: 452 passed, 1 xfailed (pre-existing). `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWnpV2yYCekx4wC2NyanuJ
