### PR TITLE
passes: conv_pool_rank4 keeps the rank-4 layout across conv/pool chains (draft)

### DIFF
--- a/stablehlo_coreml/passes/conv_pool_rank4.py
+++ b/stablehlo_coreml/passes/conv_pool_rank4.py
@@ -1,0 +1,452 @@
+"""MIL pass: keep the rank-4 layout across ``conv``/``max_pool`` chains.
+
+``conv`` and the pooling ops are the only ops in MIL that insist on a rank-4
+(NCHW) operand. A JAX model that convolves a plain ``(H, W)`` image therefore
+comes out of the converter with every convolution wrapped in a pair of
+reshapes::
+
+    (H, W) -> reshape -> (1, 1, H, W) -> conv -> (1, 1, H', W') -> reshape -> (H', W')
+
+Those reshapes are *rank-only*: they add and drop size-1 dimensions and leave
+the element order alone. Core ML still executes them as full copies -- tens of
+microseconds each once the tensor reaches a few megabytes -- and an image
+pyramid ends up with hundreds of them.
+
+Two rewrites take them out of the chains. Both decide on shapes alone, and
+neither fires unless it removes at least one reshape and copies no more elements
+than it saves, so neither can make a graph worse:
+
+**Share the lift.** A convolution's operand is usually a *slice* of a larger
+buffer, and the same buffer is sliced several times over (the four shifted 2x2
+windows of a stride-2 pyramid level, say). Each slice gets its own reshape.
+Slicing commutes with a rank lift, so the lift is hoisted above the slices and
+shared: *n* reshapes of the slices become one reshape of their source, and the
+slices run at the lifted rank.
+
+**Close the round trip.** Where a chain leaves rank 4 only to re-enter it a few
+shape-preserving ops later (``conv -> reshape -> reverse -> reshape -> conv``),
+those ops are re-emitted at the outer rank -- ``reverse`` only needs its axes
+remapped -- and the two reshapes collapse into one, or into none when they are
+exact inverses.
+
+Anything that cannot be proven is skipped: symbolic dimensions, non-constant
+slice bounds, and intermediates with a second consumer.
+"""
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .pattern_utils import RewritePass, const_int_list, normalize_axis, sole_consumer
+
+# The slice ops a rank lift can be hoisted above.
+_SLICE_OPS = frozenset({"slice_by_index", "slice_by_size"})
+
+# Shape-preserving ops that can be re-emitted at any rank with the same non-1
+# dimensions. Elementwise unary ops qualify by definition, and their remaining
+# operands (``cast``'s dtype, ``clip``'s bounds, ...) are rank-independent
+# scalars. ``reverse`` qualifies once its ``axes`` are remapped, which
+# :func:`_rebuild` does. Binary ops are deliberately left out: their second
+# operand would need a rank change of its own, which is a new op unless it
+# happens to broadcast.
+_RANK_AGNOSTIC_OPS = frozenset({
+    "abs", "acos", "asin", "atan", "atanh", "cast", "ceil", "clip", "cos", "cosh",
+    "elu", "erf", "exp", "exp2", "floor", "identity", "inverse", "leaky_relu",
+    "log", "logical_not", "relu", "relu6", "reverse", "round", "rsqrt", "sigmoid",
+    "sign", "sin", "sinh", "softplus", "sqrt", "square", "tan", "tanh", "threshold",
+})
+
+# Upper bound on the number of ops the backward walks step over. The converter
+# emits at most a handful; the bound just keeps the search finite.
+_MAX_CHAIN = 8
+
+
+def static_shape(var) -> tuple[int, ...] | None:
+    """``var``'s shape as a tuple of ints, or ``None`` if any dimension is symbolic."""
+    if var is None:
+        return None
+    shape = var.shape
+    if shape is None:
+        return None
+    if any(is_symbolic(dim) for dim in shape):
+        return None
+    return tuple(int(dim) for dim in shape)
+
+
+def core_dims(shape) -> tuple[int, ...]:
+    """``shape`` without its size-1 dimensions.
+
+    Two shapes with the same core hold the same elements in the same order, so a
+    reshape between them is rank-only: a relabelling, not a permutation.
+    """
+    return tuple(dim for dim in shape if dim != 1)
+
+
+def num_elements(shape) -> int:
+    """How many elements a tensor of ``shape`` holds."""
+    return int(np.prod(shape, dtype=np.int64)) if len(shape) > 0 else 1
+
+
+def rank_only_reshape(op) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    """``(in_shape, out_shape)`` if ``op`` is a reshape that only adds/drops 1s."""
+    if op.op_type != "reshape":
+        return None
+    in_shape = static_shape(op.inputs.get("x"))
+    out_shape = static_shape(op.outputs[0])
+    if in_shape is None or out_shape is None:
+        return None
+    if core_dims(in_shape) != core_dims(out_shape):
+        return None
+    return in_shape, out_shape
+
+
+def map_axes(axes, from_shape, to_shape) -> list[int] | None:
+    """Rewrite ``axes`` of ``from_shape`` for the equivalent ``to_shape`` layout.
+
+    The two shapes share a core (see :func:`core_dims`), so the *i*-th non-1
+    dimension of one is the *i*-th non-1 dimension of the other. Axes addressing
+    a size-1 dimension are dropped: there is nothing to reverse along them, and
+    the two layouts need not agree on where their 1s sit. ``None`` when an axis
+    is out of range.
+    """
+    from_core = [i for i, dim in enumerate(from_shape) if dim != 1]
+    to_core = [i for i, dim in enumerate(to_shape) if dim != 1]
+    mapped = set()
+    for axis in axes:
+        axis = normalize_axis(axis, len(from_shape))
+        if axis is None:
+            return None
+        if from_shape[axis] == 1:
+            continue
+        mapped.add(to_core[from_core.index(axis)])
+    return sorted(mapped)
+
+
+def _const_flags(var, length) -> list[bool] | None:
+    """A boolean mask operand as a list of ``length`` bools (absent means all-False)."""
+    if var is None:
+        return [False] * length
+    val = getattr(var, "val", None)
+    if val is None:
+        return None
+    flags = np.asarray(val).reshape(-1)
+    if flags.size != length:
+        return None
+    return [bool(flag) for flag in flags]
+
+
+def _slice_params(op) -> dict | None:
+    """The compile-time constant operands of a slice op, or ``None``.
+
+    ``None`` means the slice cannot be re-expressed at a higher rank: some
+    operand is not a constant, or a ``squeeze_mask`` bit drops an axis -- which
+    would make the output rank differ from ``begin``'s length, and with it the
+    correspondence between the two layouts.
+    """
+    x_shape = static_shape(op.inputs.get("x"))
+    out_shape = static_shape(op.outputs[0])
+    if x_shape is None or out_shape is None:
+        return None
+    rank = len(x_shape)
+
+    def indices(name):
+        values = const_int_list(op.inputs.get(name))
+        return values if values is not None and len(values) == rank else None
+
+    begin = indices("begin")
+    if begin is None:
+        return None
+
+    if op.op_type == "slice_by_size":
+        size = indices("size")
+        if size is None:
+            return None
+        return {"begin": begin, "size": size, "out_shape": out_shape}
+
+    end = indices("end")
+    stride = [1] * rank if op.inputs.get("stride") is None else indices("stride")
+    if end is None or stride is None:
+        return None
+    masks = {
+        name: _const_flags(op.inputs.get(name), rank)
+        for name in ("begin_mask", "end_mask", "squeeze_mask")
+    }
+    if any(mask is None for mask in masks.values()) or any(masks["squeeze_mask"]):
+        return None
+    return {"begin": begin, "end": end, "stride": stride, "out_shape": out_shape, **masks}
+
+
+def _lifted_slice(op, params, lift, source, before_op):
+    """Re-emit slice ``op`` against ``source``, which carries ``lift`` extra leading 1s.
+
+    Each prepended axis has extent 1 in ``source``, so ``[0:1:1]`` on it keeps
+    the whole (single) index while the original axes keep their bounds.
+
+    ``stride`` and the masks are only passed on when they differ from their
+    defaults. Spelling out an all-``False`` mask costs a ``const`` op that
+    ``const_deduplication`` does not fold away, which would trade the reshapes
+    this pass removes for as many constants.
+    """
+    ones, zeros, falses = [1] * lift, [0] * lift, [False] * lift
+    if op.op_type == "slice_by_size":
+        return mb.slice_by_size(
+            x=source,
+            begin=zeros + params["begin"],
+            size=ones + params["size"],
+            before_op=before_op,
+        )
+
+    optional = {}
+    if any(stride != 1 for stride in params["stride"]):
+        optional["stride"] = ones + params["stride"]
+    for name in ("begin_mask", "end_mask"):
+        if any(params[name]):
+            optional[name] = falses + params[name]
+    return mb.slice_by_index(
+        x=source,
+        begin=zeros + params["begin"],
+        end=ones + params["end"],
+        before_op=before_op,
+        **optional,
+    )
+
+
+def _leading_lift(op) -> int | None:
+    """How many size-1 dimensions ``op`` prepends, if that is all it does."""
+    shapes = rank_only_reshape(op)
+    if shapes is None:
+        return None
+    in_shape, out_shape = shapes
+    lift = len(out_shape) - len(in_shape)
+    if lift <= 0 or out_shape != (1,) * lift + in_shape:
+        return None
+    return lift
+
+
+def _first_in_block(block, ops):
+    """The op of ``ops`` that comes first in ``block``'s operation order."""
+    wanted = {id(op) for op in ops}
+    for candidate in block.operations:
+        if id(candidate) in wanted:
+            return candidate
+    return None
+
+
+def _lift_group(reshape_op, block):
+    """All ``slice -> reshape(lift)`` pairs that share ``reshape_op``'s source.
+
+    Returns ``(source, lift, members)``, the members being
+    ``(slice_op, params, reshape_op)`` triples, or ``None`` when the pattern does
+    not apply. Every sibling is checked on its own; one that cannot be lifted
+    simply does not join the group.
+    """
+    lift = _leading_lift(reshape_op)
+    if lift is None:
+        return None
+    slice_op = reshape_op.inputs["x"].op
+    if slice_op is None or slice_op.op_type not in _SLICE_OPS:
+        return None
+    source = slice_op.inputs["x"]
+    source_shape = static_shape(source)
+    if source_shape is None:
+        return None
+    # Reshaping a constant would materialise a second copy of it as a weight,
+    # and the slices of a constant are folded away by `const_elimination` anyway.
+    if getattr(source, "val", None) is not None:
+        return None
+
+    members = []
+    for sibling in source.child_ops:
+        if sibling.op_type not in _SLICE_OPS or sibling.enclosing_block is not block:
+            continue
+        # The slice must feed nothing but its lift; otherwise the rank-2
+        # spelling has to be computed anyway and hoisting buys nothing.
+        consumer = sole_consumer(sibling.outputs[0])
+        if consumer is None or consumer.enclosing_block is not block:
+            continue
+        if _leading_lift(consumer) != lift or consumer.outputs[0] in block.outputs:
+            continue
+        params = _slice_params(sibling)
+        if params is None:
+            continue
+        members.append((sibling, params, consumer))
+
+    # `reshape_op` not being a member means its own slice has another consumer.
+    # Leave the group to be found from a member's reshape, so that a rewrite is
+    # only ever reported for an op that it actually removes.
+    if not any(member is reshape_op for _, _, member in members):
+        return None
+    if len(members) < 2:
+        return None
+    # One reshape of the source replaces one reshape per member: fewer ops, and
+    # fewer copied elements as long as the slices together are not smaller than
+    # what the source lift has to copy.
+    copied = sum(num_elements(params["out_shape"]) for _, params, _ in members)
+    if copied < num_elements(source_shape):
+        return None
+    return source, lift, members
+
+
+def _peel_reshapes(var, consumer, block):
+    """Walk back over a run of single-consumer rank-only reshapes above ``var``.
+
+    ``var`` is the input of the rank-only reshape ``consumer``. Returns the
+    var that feeds the outermost such reshape, so that a whole stack collapses
+    in one go rather than one reshape per run of the pass.
+    """
+    for _ in range(_MAX_CHAIN):
+        if sole_consumer(var) is not consumer:
+            return var
+        producer = var.op
+        if producer is None or producer.enclosing_block is not block:
+            return var
+        if rank_only_reshape(producer) is None:
+            return var
+        var, consumer = producer.inputs["x"], producer
+    return var
+
+
+def _match_round_trip(reshape_op, block):
+    """``(source, chain, layout, target)`` for a reshape re-entering a rank it just left.
+
+    Walks back from ``reshape_op`` over shape-preserving, rank-agnostic ops until
+    it reaches another rank-only reshape with the same core. ``source`` is what
+    feeds that reshape, ``chain`` the ops in between (innermost first), ``layout``
+    the shape they run at today and ``target`` the shape they will run at.
+
+    Every intermediate must have a single consumer: the old chain has to become
+    dead, or the rebuilt one is pure addition. ``reverse`` axes are remapped here
+    as well, so that a chain which cannot be rebuilt is rejected before any op is
+    emitted.
+    """
+    shapes = rank_only_reshape(reshape_op)
+    if shapes is None or reshape_op.outputs[0] in block.outputs:
+        return None
+    layout, target = shapes
+
+    chain = []
+    var, consumer = reshape_op.inputs["x"], reshape_op
+    for _ in range(_MAX_CHAIN):
+        if sole_consumer(var) is not consumer:
+            return None
+        producer = var.op
+        if producer is None or producer.enclosing_block is not block:
+            return None
+        if rank_only_reshape(producer) is not None:
+            source = _peel_reshapes(producer.inputs["x"], producer, block)
+            return source, chain, layout, target
+        if producer.op_type not in _RANK_AGNOSTIC_OPS:
+            return None
+        if static_shape(producer.inputs.get("x")) != layout:
+            return None
+        if producer.op_type == "reverse" and _remapped_axes(producer, layout, target) is None:
+            return None
+        chain.append(producer)
+        var, consumer = producer.inputs["x"], producer
+    return None
+
+
+def _remapped_axes(op, layout, target) -> list[int] | None:
+    """``op``'s ``reverse`` axes expressed in the ``target`` layout, or ``None``."""
+    axes = op.inputs.get("axes")
+    axes = list(range(len(layout))) if axes is None else const_int_list(axes)
+    if axes is None:
+        return None
+    return map_axes(axes, layout, target)
+
+
+def _rebuild(op, x, layout, target, before_op):
+    """Re-emit ``op`` on ``x``, which holds ``layout``'s elements shaped as ``target``."""
+    if op.op_type != "reverse":
+        return getattr(mb, op.op_type)(**{**dict(op.inputs), "x": x}, before_op=before_op)
+    axes = _remapped_axes(op, layout, target)
+    # Reversing nothing but size-1 axes is the identity; drop the op entirely.
+    if len(axes) == 0:
+        return x
+    return mb.reverse(x=x, axes=axes, before_op=before_op)
+
+
+@register_pass(namespace="common")
+class conv_pool_rank4(RewritePass):
+    """
+    Keep the rank-4 layout across ``conv``/``max_pool`` chains, so that the
+    rank-only reshapes surrounding them are shared or cancelled.
+
+    Two rewrites are tried, in this order, on every rank-only reshape (one that
+    only adds or drops size-1 dimensions):
+
+    1. **Share the lift.** The reshape only prepends 1s, and its input is a slice
+       whose sole consumer it is. Every sibling slice of the same source that is
+       lifted the same way joins a group; the source is then lifted once and the
+       slices run at the higher rank instead. The group needs at least two
+       members (so it loses at least one reshape) and its slices must together
+       copy no fewer elements than the source lift does.
+
+    2. **Close the round trip.** The ops feeding the reshape are shape-preserving
+       and rank-agnostic (elementwise unary ops, and ``reverse`` with remapped
+       axes), and the chain starts at another rank-only reshape with the same
+       core. The chain is re-emitted at the outer shape, leaving one reshape
+       where there were two -- or none, when the two are exact inverses. Every
+       intermediate must have a single consumer.
+
+    Everything is decided from static shapes and constant operands; symbolic
+    dimensions and computed slice bounds are skipped.
+
+    Given:
+        %1 = slice_by_index(x=%0, begin=[0, 0], end=[517, 293])   # %0: (518, 294)
+        %2 = reshape(x=%1, shape=[1, 1, 517, 293])
+        %3 = max_pool(x=%2, ...)
+        %4 = slice_by_index(x=%0, begin=[1, 0], end=[518, 293])
+        %5 = reshape(x=%4, shape=[1, 1, 517, 293])
+        %6 = max_pool(x=%5, ...)
+
+    Result:
+        %l = reshape(x=%0, shape=[1, 1, 518, 294])
+        %2 = slice_by_index(x=%l, begin=[0, 0, 0, 0], end=[1, 1, 517, 293])
+        %3 = max_pool(x=%2, ...)
+        %5 = slice_by_index(x=%l, begin=[0, 0, 1, 0], end=[1, 1, 518, 293])
+        %6 = max_pool(x=%5, ...)
+    """
+
+    _REWRITES = "rank-only reshape(s)"
+
+    def visit(self, op, block) -> bool:
+        return self._share_lift(op, block) or self._close_round_trip(op, block)
+
+    def _share_lift(self, op, block) -> bool:
+        group = _lift_group(op, block)
+        if group is None:
+            return False
+        source, lift, members = group
+
+        lifted_source = mb.reshape(
+            x=source,
+            shape=[1] * lift + list(static_shape(source)),
+            before_op=_first_in_block(block, [slice_op for slice_op, _, _ in members]),
+        )
+        for slice_op, params, reshape_op in members:
+            lifted = _lifted_slice(slice_op, params, lift, lifted_source, before_op=slice_op)
+            block.replace_uses_of_var_after_op(
+                anchor_op=reshape_op, old_var=reshape_op.outputs[0], new_var=lifted
+            )
+            reshape_op.remove_from_block()
+        return True
+
+    def _close_round_trip(self, op, block) -> bool:
+        match = _match_round_trip(op, block)
+        if match is None:
+            return False
+        source, chain, layout, target = match
+
+        current = source
+        if static_shape(source) != target:
+            current = mb.reshape(x=source, shape=list(target), before_op=op)
+        # `chain` runs innermost-first; rebuild it in execution order.
+        for chain_op in reversed(chain):
+            current = _rebuild(chain_op, current, layout, target, before_op=op)
+        block.replace_uses_of_var_after_op(
+            anchor_op=op, old_var=op.outputs[0], new_var=current
+        )
+        op.remove_from_block()
+        return True

--- a/stablehlo_coreml/passes/conv_pool_rank4.py
+++ b/stablehlo_coreml/passes/conv_pool_rank4.py
@@ -112,15 +112,17 @@ def map_axes(axes, from_shape, to_shape) -> list[int] | None:
     """
     from_core = [i for i, dim in enumerate(from_shape) if dim != 1]
     to_core = [i for i, dim in enumerate(to_shape) if dim != 1]
-    mapped = set()
+    mapped = []
     for axis in axes:
         axis = normalize_axis(axis, len(from_shape))
         if axis is None:
             return None
         if from_shape[axis] == 1:
             continue
-        mapped.add(to_core[from_core.index(axis)])
-    return sorted(mapped)
+        # MIL value inference applies each reverse axis in sequence, so repeated
+        # axes cancel in pairs. Preserve repetitions, including negative aliases.
+        mapped.append(to_core[from_core.index(axis)])
+    return mapped
 
 
 def _const_flags(var, length) -> list[bool] | None:

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -11,6 +11,7 @@ import coremltools as ct
 
 # Importing the pass modules registers them in coremltools' PASS_REGISTRY.
 from . import broadcast_select_operands as _broadcast_select_operands  # noqa: F401
+from . import conv_pool_rank4 as _conv_pool_rank4  # noqa: F401
 from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
 from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
 from . import fuse_gelu_tanh as _fuse_gelu_tanh  # noqa: F401
@@ -60,6 +61,11 @@ FUSION_PASSES: list[str] = [
     "common::fuse_gelu_erfc",
     _DCE,
     "common::fuse_gelu_tanh",
+    _DCE,
+    # Last of the group. It reads the shape of every operand it touches, so it
+    # wants the folded constants and settled shapes this slot has, and the
+    # fusions above are free to keep matching the rank-2 spellings it replaces.
+    "common::conv_pool_rank4",
     _DCE,
 ]
 

--- a/tests/passes/test_conv_pool_rank4.py
+++ b/tests/passes/test_conv_pool_rank4.py
@@ -1,0 +1,509 @@
+import coremltools as ct
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import assert_model_is_valid, get_op_types_in_program
+
+# Importing the package registers the passes with coremltools' PASS_REGISTRY.
+import stablehlo_coreml  # noqa: F401
+from tests.passes.helpers import apply_pass, count_ops, predict
+
+PASS_NAME = "common::conv_pool_rank4"
+
+# A 2x2 averaging kernel, so that a rank-4 conv is available as a chain end.
+KERNEL = np.full((1, 1, 2, 2), 0.25, dtype=np.float32)
+
+
+def _apply(prog):
+    """Run the pass (plus DCE) and return the program as it was before."""
+    return apply_pass(prog, PASS_NAME, skip_output_shape_check=True)
+
+
+def _count_reshapes(prog, recurse: bool = True) -> int:
+    return count_ops(prog, "reshape", recurse=recurse)
+
+
+def _assert_same_prediction(prog, prev_prog, **inputs):
+    """The rewritten program computes exactly what the original one did."""
+    np.testing.assert_array_equal(predict(prog, **inputs), predict(prev_prog, **inputs))
+
+
+class TestShareTheLift:
+    """Hoisting a rank lift above the slices that feed it."""
+
+    def test_two_pooled_slices_share_one_lift(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            top = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            bottom = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+            pooled_top = mb.max_pool(
+                x=mb.reshape(x=top, shape=[1, 1, 7, 5]),
+                kernel_sizes=[2, 2], strides=[2, 2], pad_type="valid",
+            )
+            pooled_bottom = mb.max_pool(
+                x=mb.reshape(x=bottom, shape=[1, 1, 7, 5]),
+                kernel_sizes=[2, 2], strides=[2, 2], pad_type="valid",
+            )
+            return mb.add(x=pooled_top, y=pooled_bottom)
+
+        assert _count_reshapes(prog) == 2
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == [
+            "reshape", "slice_by_index", "slice_by_index", "max_pool", "max_pool", "add"
+        ]
+        # The lift now sits on the source, and the slices carry the extra axes.
+        lift = prog.functions["main"].find_ops(op_type="reshape")[0]
+        assert lift.outputs[0].shape == (1, 1, 8, 6)
+        assert lift.inputs["x"] is prog.functions["main"].inputs["x"]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(8, 6).astype(np.float32))
+
+    def test_slice_by_size_group(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(6, 5))])
+        def prog(x):
+            left = mb.slice_by_size(x=x, begin=[0, 0], size=[5, 4])
+            right = mb.slice_by_size(x=x, begin=[1, 1], size=[5, 4])
+            a = mb.conv(x=mb.reshape(x=left, shape=[1, 1, 5, 4]), weight=KERNEL, pad_type="valid")
+            b = mb.conv(x=mb.reshape(x=right, shape=[1, 1, 5, 4]), weight=KERNEL, pad_type="valid")
+            return mb.add(x=a, y=b)
+
+        prev_prog = _apply(prog)
+        assert _count_reshapes(prog) == 1
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(6, 5).astype(np.float32))
+
+    def test_four_slices_leave_one_reshape(self):
+        """The shape the sphere model emits: four shifted windows per pyramid level."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(9, 7))])
+        def prog(x):
+            pooled = []
+            for row, col in ((0, 0), (0, 1), (1, 0), (1, 1)):
+                window = mb.slice_by_index(x=x, begin=[row, col], end=[row + 8, col + 6])
+                pooled.append(mb.max_pool(
+                    x=mb.reshape(x=window, shape=[1, 1, 8, 6]),
+                    kernel_sizes=[2, 2], strides=[2, 2], pad_type="valid",
+                ))
+            return mb.add(x=mb.add(x=pooled[0], y=pooled[1]), y=mb.add(x=pooled[2], y=pooled[3]))
+
+        assert _count_reshapes(prog) == 4
+        prev_prog = _apply(prog)
+        assert _count_reshapes(prog) == 1
+        assert count_ops(prog, "slice_by_index") == 4
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(9, 7).astype(np.float32))
+
+    def test_strided_slice_keeps_its_stride_and_masks(self):
+        """`begin_mask[0]` and `end_mask[1]` below override `begin`/`end`, and must
+        keep doing so once two more axes are prepended."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            even_rows = mb.slice_by_index(
+                x=x, begin=[5, 0], end=[8, 3], stride=[2, 1],
+                begin_mask=[True, False], end_mask=[False, True],
+            )
+            odd_rows = mb.slice_by_index(x=x, begin=[1, 0], end=[8, 6], stride=[2, 1])
+            return mb.add(
+                x=mb.reshape(x=even_rows, shape=[1, 1, 4, 6]),
+                y=mb.reshape(x=odd_rows, shape=[1, 1, 4, 6]),
+            )
+
+        prev_prog = _apply(prog)
+        assert _count_reshapes(prog) == 1
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(8, 6).astype(np.float32))
+
+    def test_not_rewritten_for_a_lone_slice(self):
+        """One slice would trade its reshape for a reshape of the (larger) source."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            window = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            return mb.max_pool(
+                x=mb.reshape(x=window, shape=[1, 1, 7, 5]),
+                kernel_sizes=[2, 2], strides=[2, 2], pad_type="valid",
+            )
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["slice_by_index", "reshape", "max_pool"]
+
+    def test_not_rewritten_when_the_slices_are_smaller_than_the_source(self):
+        """Two tiny windows of a big buffer: lifting the source copies more, not less."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(64, 64))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[4, 4])
+            b = mb.slice_by_index(x=x, begin=[4, 4], end=[8, 8])
+            return mb.add(
+                x=mb.reshape(x=a, shape=[1, 1, 4, 4]),
+                y=mb.reshape(x=b, shape=[1, 1, 4, 4]),
+            )
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_when_a_slice_has_a_second_consumer(self):
+        """The rank-2 slice is needed anyway, so hoisting only adds an op."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+            lifted_a = mb.reshape(x=a, shape=[1, 1, 7, 5])
+            lifted_b = mb.reshape(x=b, shape=[1, 1, 7, 5])
+            return mb.add(x=lifted_a, y=lifted_b), mb.abs(x=a), mb.abs(x=b)
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_a_slice_with_a_second_consumer_drops_out_of_the_group(self):
+        """The other three still share a lift; the shared one keeps its own reshape."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(9, 7))])
+        def prog(x):
+            windows = [
+                mb.slice_by_index(x=x, begin=[row, col], end=[row + 8, col + 6])
+                for row, col in ((0, 0), (0, 1), (1, 0), (1, 1))
+            ]
+            lifted = [mb.reshape(x=window, shape=[1, 1, 8, 6]) for window in windows]
+            total = lifted[0]
+            for other in lifted[1:]:
+                total = mb.add(x=total, y=other)
+            return total, mb.abs(x=windows[3])
+
+        prev_prog = _apply(prog)
+        # Three reshapes replaced by one, plus the one the shared slice keeps.
+        assert _count_reshapes(prog) == 2
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(9, 7).astype(np.float32))
+
+    def test_not_rewritten_for_symbolic_dims(self):
+        rows = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(rows, 6))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[4, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[5, 6])
+            return mb.add(
+                x=mb.reshape(x=a, shape=[1, 1, 4, 5]),
+                y=mb.reshape(x=b, shape=[1, 1, 4, 5]),
+            )
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_when_the_reshape_is_not_a_pure_rank_lift(self):
+        """(7, 5) -> (1, 5, 7) reorders elements; it is not a rank-only reshape."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+            return mb.add(
+                x=mb.reshape(x=a, shape=[1, 5, 7]),
+                y=mb.reshape(x=b, shape=[1, 5, 7]),
+            )
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_when_the_lift_is_not_leading(self):
+        """A trailing 1 does not commute with a slice the way a leading one does."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+            return mb.add(
+                x=mb.reshape(x=a, shape=[7, 5, 1]),
+                y=mb.reshape(x=b, shape=[7, 5, 1]),
+            )
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_for_mismatched_lifts(self):
+        """Two slices lifted by different amounts cannot share one source lift."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(8, 6))])
+        def prog(x):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+            return mb.reshape(x=a, shape=[1, 1, 7, 5]), mb.reshape(x=b, shape=[1, 7, 5])
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_for_a_constant_source(self):
+        """Lifting a constant would materialise a second copy of it as a weight."""
+        source = np.random.rand(8, 6).astype(np.float32)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 7, 5))])
+        def prog(x):
+            a = mb.slice_by_index(x=source, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=source, begin=[1, 1], end=[8, 6])
+            lifted = mb.add(
+                x=mb.reshape(x=a, shape=[1, 1, 7, 5]),
+                y=mb.reshape(x=b, shape=[1, 1, 7, 5]),
+            )
+            return mb.add(x=lifted, y=x)
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_rewritten_inside_a_nested_block(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(8, 6)), mb.TensorSpec(shape=(1,), dtype=types.bool)
+        ])
+        def prog(x, pred):
+            def true_fn():
+                a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+                b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+                return mb.add(
+                    x=mb.reshape(x=a, shape=[1, 1, 7, 5]),
+                    y=mb.reshape(x=b, shape=[1, 1, 7, 5]),
+                )
+
+            def false_fn():
+                lone = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+                return mb.reshape(x=lone, shape=[1, 1, 7, 5])
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert _count_reshapes(prog) == 3
+        _apply(prog)
+        # The two slices of the taken branch share a lift; the lone one in the
+        # other branch is not a group and keeps its reshape.
+        assert _count_reshapes(prog) == 2
+        assert_model_is_valid(
+            prog,
+            {"x": (8, 6), "pred": (1,)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+    def test_not_rewritten_when_the_slice_is_outside_the_block(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(8, 6)), mb.TensorSpec(shape=(1,), dtype=types.bool)
+        ])
+        def prog(x, pred):
+            a = mb.slice_by_index(x=x, begin=[0, 0], end=[7, 5])
+            b = mb.slice_by_index(x=x, begin=[1, 1], end=[8, 6])
+
+            def true_fn():
+                return mb.add(
+                    x=mb.reshape(x=a, shape=[1, 1, 7, 5]),
+                    y=mb.reshape(x=b, shape=[1, 1, 7, 5]),
+                )
+
+            def false_fn():
+                return mb.reshape(x=a, shape=[1, 1, 7, 5])
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 3
+
+
+class TestCloseTheRoundTrip:
+    """Collapsing a rank round trip made across shape-preserving ops."""
+
+    def test_reverse_between_two_convolutions(self):
+        """conv -> reshape -> reverse -> reshape -> conv, the sphere model's Sobel pair."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 6, 4))])
+        def prog(x):
+            first = mb.conv(x=x, weight=KERNEL, pad_type="same")
+            flat = mb.reshape(x=first, shape=[6, 4])
+            flipped = mb.reverse(x=flat, axes=[0, 1])
+            lifted = mb.reshape(x=flipped, shape=[1, 1, 6, 4])
+            return mb.conv(x=lifted, weight=KERNEL, pad_type="same")
+
+        assert _count_reshapes(prog) == 2
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["conv", "reverse", "conv"]
+        # The reverse now runs on the rank-4 layout, with its axes shifted by 2.
+        reverse = prog.functions["main"].find_ops(op_type="reverse")[0]
+        assert list(reverse.inputs["axes"].val) == [2, 3]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 1, 6, 4).astype(np.float32))
+
+    def test_round_trip_between_unequal_layouts_leaves_one_reshape(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            flipped = mb.reverse(x=flat, axes=[1])
+            trailing = mb.reshape(x=flipped, shape=[5, 4, 1])
+            return mb.add(x=trailing, y=np.float32(1.0))
+
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["reshape", "reverse", "add"]
+        reverse = prog.functions["main"].find_ops(op_type="reverse")[0]
+        assert list(reverse.inputs["axes"].val) == [1]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 1, 5, 4).astype(np.float32))
+
+    def test_unary_chain_is_rebuilt_at_the_outer_rank(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            chained = mb.sqrt(x=mb.abs(x=mb.exp(x=flat)))
+            lifted = mb.reshape(x=chained, shape=[1, 1, 5, 4])
+            return mb.add(x=lifted, y=np.float32(1.0))
+
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["exp", "abs", "sqrt", "add"]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 1, 5, 4).astype(np.float32))
+
+    def test_exact_inverse_pair_disappears(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            return mb.add(x=mb.reshape(x=flat, shape=[1, 1, 5, 4]), y=np.float32(1.0))
+
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 1, 5, 4).astype(np.float32))
+
+    def test_reversing_only_a_size_one_axis_drops_the_reverse(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4, 1])
+            flipped = mb.reverse(x=flat, axes=[2])
+            return mb.add(x=mb.reshape(x=flipped, shape=[1, 5, 4]), y=np.float32(1.0))
+
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["add"]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 5, 4).astype(np.float32))
+
+    def test_stacked_reshapes_collapse_in_one_run(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=mb.reshape(x=x, shape=[1, 5, 4]), shape=[5, 4])
+            return mb.add(x=mb.reshape(x=flat, shape=[5, 4, 1]), y=np.float32(1.0))
+
+        prev_prog = _apply(prog)
+        assert get_op_types_in_program(prog) == ["reshape", "add"]
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(1, 1, 5, 4).astype(np.float32))
+
+    def test_not_rewritten_when_the_chain_op_has_a_second_consumer(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            flipped = mb.reverse(x=flat, axes=[0])
+            return mb.reshape(x=flipped, shape=[1, 1, 5, 4]), mb.abs(x=flipped)
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_across_a_binary_op(self):
+        """`mul`'s second operand would need a rank change of its own."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4)), mb.TensorSpec(shape=(5, 4))])
+        def prog(x, y):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            return mb.reshape(x=mb.mul(x=flat, y=y), shape=[1, 1, 5, 4])
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_across_a_shape_changing_op(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            reduced = mb.reduce_sum(x=flat, axes=[1], keep_dims=True)
+            return mb.reshape(x=reduced, shape=[1, 1, 5, 1])
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_when_the_reshape_is_a_block_output(self):
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            return mb.reshape(x=mb.abs(x=flat), shape=[1, 1, 5, 4])
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_for_symbolic_dims(self):
+        rows = get_new_symbol()
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, rows, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[-1, 4])
+            return mb.add(x=mb.reshape(x=mb.abs(x=flat), shape=[1, 1, -1, 4]), y=np.float32(1.0))
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_not_rewritten_when_the_reshape_permutes_elements(self):
+        """(5, 4) -> (4, 5) has a different core, so the two are not the same layout."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=x, shape=[5, 4])
+            return mb.add(x=mb.reshape(x=mb.abs(x=flat), shape=[1, 1, 4, 5]), y=np.float32(1.0))
+
+        _apply(prog)
+        assert _count_reshapes(prog) == 2
+
+    def test_rewritten_inside_a_nested_block(self):
+        @mb.program(input_specs=[
+            mb.TensorSpec(shape=(1, 1, 5, 4)), mb.TensorSpec(shape=(1,), dtype=types.bool)
+        ])
+        def prog(x, pred):
+            def true_fn():
+                flat = mb.reshape(x=x, shape=[5, 4])
+                lifted = mb.reshape(x=mb.abs(x=flat), shape=[1, 1, 5, 4])
+                return mb.add(x=lifted, y=np.float32(1.0))
+
+            def false_fn():
+                return mb.identity(x=x)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        assert _count_reshapes(prog) == 2
+        _apply(prog)
+        assert _count_reshapes(prog) == 0
+        assert_model_is_valid(
+            prog,
+            {"x": (1, 1, 5, 4), "pred": (1,)},
+            minimum_deployment_target=ct.target.iOS18,
+            backend=("mlprogram", "fp32"),
+        )
+
+
+class TestConvPoolRank4Invariants:
+    @pytest.mark.parametrize("build", ["lift", "round_trip"])
+    def test_is_idempotent(self, build):
+        if build == "lift":
+            @mb.program(input_specs=[mb.TensorSpec(shape=(9, 7))])
+            def prog(x):
+                windows = [
+                    mb.slice_by_index(x=x, begin=[row, col], end=[row + 8, col + 6])
+                    for row, col in ((0, 0), (0, 1), (1, 0), (1, 1))
+                ]
+                lifted = [mb.reshape(x=window, shape=[1, 1, 8, 6]) for window in windows]
+                total = lifted[0]
+                for other in lifted[1:]:
+                    total = mb.add(x=total, y=other)
+                return total
+        else:
+            @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 6, 4))])
+            def prog(x):
+                first = mb.conv(x=x, weight=KERNEL, pad_type="same")
+                flat = mb.reshape(x=first, shape=[6, 4])
+                lifted = mb.reshape(x=mb.reverse(x=flat, axes=[0, 1]), shape=[1, 1, 6, 4])
+                return mb.conv(x=lifted, weight=KERNEL, pad_type="same")
+
+        _apply(prog)
+        ops_after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ops_after_first
+
+    def test_pyramid_level_keeps_its_numerics(self):
+        """A whole level of the sphere model: four windows, pooled, then combined."""
+        @mb.program(input_specs=[mb.TensorSpec(shape=(9, 7))])
+        def prog(x):
+            pooled = []
+            for row, col in ((0, 0), (0, 1), (1, 0), (1, 1)):
+                window = mb.slice_by_index(x=x, begin=[row, col], end=[row + 8, col + 6])
+                pooled.append(mb.max_pool(
+                    x=mb.reshape(x=window, shape=[1, 1, 8, 6]),
+                    kernel_sizes=[2, 2], strides=[2, 2], pad_type="valid",
+                ))
+            combined = mb.mul(
+                x=mb.maximum(x=mb.add(x=pooled[0], y=pooled[1]), y=np.float32(0.0)),
+                y=mb.maximum(x=mb.add(x=pooled[2], y=pooled[3]), y=np.float32(0.0)),
+            )
+            flat = mb.reshape(x=combined, shape=[4, 3])
+            return mb.reverse(x=flat, axes=[0])
+
+        assert _count_reshapes(prog) == 5
+        prev_prog = _apply(prog)
+        assert _count_reshapes(prog) == 2
+        _assert_same_prediction(prog, prev_prog, x=np.random.rand(9, 7).astype(np.float32))

--- a/tests/passes/test_conv_pool_rank4.py
+++ b/tests/passes/test_conv_pool_rank4.py
@@ -296,6 +296,27 @@ class TestShareTheLift:
 class TestCloseTheRoundTrip:
     """Collapsing a rank round trip made across shape-preserving ops."""
 
+    @pytest.mark.parametrize("axes", [[0, 0], [0, -2]])
+    @pytest.mark.parametrize("constant_source", [False, True])
+    def test_reverse_preserves_repeated_axes(self, axes, constant_source):
+        values = np.arange(20, dtype=np.float32).reshape(1, 1, 5, 4)
+
+        @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 5, 4))])
+        def prog(x):
+            flat = mb.reshape(x=values if constant_source else x, shape=[5, 4])
+            flipped = mb.reverse(x=flat, axes=axes)
+            lifted = mb.reshape(x=flipped, shape=[1, 1, 5, 4])
+            return mb.add(x=x, y=lifted)
+
+        # MIL value inference applies each axis in sequence; two reversals of
+        # the same dimension must remain the identity after remapping.
+        prev_prog = _apply(prog)
+        if constant_source:
+            np.testing.assert_array_equal(prog.functions["main"].outputs[0].op.y.val, values)
+        reverse = prog.functions["main"].find_ops(op_type="reverse")[0]
+        assert list(reverse.axes.val) == [2, 2]
+        _assert_same_prediction(prog, prev_prog, x=values)
+
     def test_reverse_between_two_convolutions(self):
         """conv -> reshape -> reverse -> reshape -> conv, the sphere model's Sobel pair."""
         @mb.program(input_specs=[mb.TensorSpec(shape=(1, 1, 6, 4))])


### PR DESCRIPTION
**Draft: not adversarially reviewed yet, and the speed-up is not measurable on its own.** Pushed so the code is visible next to the measurements in #105.

## What

New MIL pass `common::conv_pool_rank4` (last in `FUSION_PASSES`, followed by `_DCE`). `conv` and the pooling ops are the only MIL ops that require rank 4, so a JAX model convolving a plain `(H, W)` image comes out of the converter with every conv/pool wrapped in a `reshape -> (1,1,H,W)` / `reshape -> (H',W')` pair; an image pyramid has hundreds of them. Two rewrites, both from static shapes only and each only when it removes a reshape without copying more elements than it saves:

1. **Share the lift.** A `slice -> reshape[prepend 1s]` whose slice is sole-consumed joins a group with every sibling slice of the same source lifted the same way; the source is lifted once and the slices are re-emitted at the lifted rank (`begin/end/stride/masks` prefixed). Needs ≥2 members.
2. **Close the round trip.** From a rank-only reshape, walk back over shape-preserving rank-agnostic ops (elementwise unary, `reverse` with remapped axes) to another rank-only reshape with the same non-1 core; rebuild the chain at the outer shape, leaving one reshape or none.

Skips symbolic dims, non-constant slice bounds, `squeeze_mask`, constant sources, block outputs, multi-consumer intermediates.

On the sphere-detector export: reshape 953 -> 872, total ops 8231 -> 7969 (-75 from shared lifts, -6 from round trips), 25.5M -> 21.6M elements copied by reshapes; outputs bit-identical.

## Measurements

7 interleaved rounds on an M-series GPU (`CPU_AND_GPU`, fp32): baseline 13.9 ms, this pass 14.1 ms — noise. All three cleanup passes (#102, #103, this) together: 13.51 ± 0.76 ms vs 13.95 ± 0.47 ms over 15 rounds, ~3 %. A micro-benchmark showed rank-only reshapes cost 30–55 µs only on multi-MB tensors and nothing at the 0.6–1.2 MB this model uses, which is why Core ML's cost estimate (7.9 % for these reshapes) does not translate into time here. Models with larger feature maps would benefit more.

## Tests

`tests/passes/test_conv_pool_rank4.py`: 31 tests (both rewrites incl. `slice_by_size`, strided slices with load-bearing masks, the 4-window pyramid level, `reverse` between convs with axes remapped to `[2, 3]`, exact-inverse pairs; must-not-rewrite for lone slice, smaller slices, extra consumer, symbolic dims, non-rank-only reshape, trailing lift, mismatched lifts, constant source, binary op in chain, shape-changing op, block output, cross-block slice; nested `cond`; idempotence; predict-equality). `tests/passes`: 443 passed, 1 xfailed. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWnpV2yYCekx4wC2NyanuJ
