### PR TITLE
Bump torchax nightly and cap torch below 2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,13 +70,14 @@ parallel = true
 
 extra-dependencies = [
     "pytest",
-    "torch>=2.12.0",
-    "torchvision",
+    # TorchAX still imports aten.qr, which PyTorch 2.14 removed.
+    "torch>=2.13.0,<2.14.0",
+    "torchvision>=0.28.0,<0.29.0",
     # torchax 0.0.13 imports removed PyTorch 2.13 named-tensor overloads
     # (aten.prod.dim_Dimname) at module import. google/torchax#102 is on
     # 0.0.14.dev* nightlies (no stable 0.0.14 yet). Pin the post-fix nightly
     # exactly so hatch/pip will install the pre-release without --pre.
-    "torchax==0.0.14.dev20260820",
+    "torchax==0.0.14.dev20260903",
     "flax>=0.12.9", # torchax wants flax to be installed; 0.12.9 needed for jax 0.11
     "transformers>=5.12.0",
 ]


### PR DESCRIPTION
## Problem

The `test-pytorch` matrix is failing on `main`. It is not a code regression — `torch` resolved to the newly released **2.14.0**, which removes the `aten.qr` operator that `torchax` still references in its autocast policy table. `torchax` therefore raises at *import* time, so `tests/pytorch/` errors during collection and no test runs:

```
torchax/amp.py:199: in <module>
    torch.ops.aten.qr.default: CastPolicy.FP32,
E   AttributeError: '_OpNamespace' 'aten' object has no attribute 'qr'
```

This only showed up on the 3.13 leg locally, because the 3.12 environment had a cached torch 2.13.

## Why not a stable torchax

There is currently no `torchax` release that works with torch 2.14:

- Latest **stable** is `0.0.13` (2026-06-17). It references `aten.prod.dim_Dimname`, removed back in torch **2.13**, so it is already incompatible with our floor — verified: `AttributeError: The underlying op of 'aten.prod' has no overload name 'dim_Dimname'`.
- Latest **nightly** `0.0.14.dev20260903` still references `aten.qr`, so it does not work with 2.14 either.

So the nightly pin has to stay for now, and torch has to be capped.

## Change

- Bump the `torchax` nightly pin `0.0.14.dev20260820` → `0.0.14.dev20260903`.
- Cap `torch` to the 2.13 line and pin the matching `torchvision` 0.28 line.

This is the newest combination that actually imports and passes. The cap can be dropped once an upstream `torchax` build stops referencing `aten.qr`.

## Verification

Both matrix entries were run from freshly recreated environments (`hatch env remove` first, so resolution was not served from cache):

```
hatch run +py=3.12 test-pytorch:pytest -vv tests/pytorch/   # 15 passed
hatch run +py=3.13 test-pytorch:pytest -vv tests/pytorch/   # 15 passed
hatch run lint:check                                        # All checks passed!
```

Resolved versions: `torch=2.13.0`, `torchvision=0.28.0`, `torchax=0.0.14.dev20260903`.