### PR TITLE
build_pass_pipeline: protect int32 data from int16 narrowing

### DIFF
--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -6,8 +6,11 @@ pipeline with the passes inserted at the right places.
 """
 
 import copy
+from functools import partial
 
 import coremltools as ct
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
 
 # Importing the pass modules registers them in coremltools' PASS_REGISTRY.
 from . import broadcast_select_operands as _broadcast_select_operands  # noqa: F401
@@ -131,6 +134,75 @@ def _insert_passes(
         pipeline.insert_pass(index=index + offset, pass_name=pass_name)
 
 
+def _int16_cast_is_safe(op) -> bool:
+    """Conservatively protect int32 data from upstream narrowing.
+
+    coremltools 9.0 common::add_int16_cast narrows dynamic DATA as well as
+    indices. Only constants (range-checked by that pass) and indices with a
+    statically bounded addressing domain are eligible; never dynamic int32 x.
+    """
+    if op.op_type == 'topk':
+        # output_indices_dtype is a string, so the input dtype loop misses it.
+        extent = op.x.shape[int(op.axis.val)]
+        if is_symbolic(extent) or extent > 32767:
+            return False
+    inputs = [(name, var) for name, value in op.inputs.items()
+              for var in (value if isinstance(value, (tuple, list)) else (value,))]
+    dynamic_indices = any(name == 'indices' and var.dtype == types.int32 and var.val is None
+                          for name, var in inputs)
+    if dynamic_indices and any(
+        var.dtype == types.int32 and var.rank > 0 and var.op is not None
+        and var.op.op_type == 'const' and var.val.size and (var.val >= 0).all()
+        for _, var in inputs
+    ):
+        # A nonnegative constant tensor can select uint16 for subsequent dynamic
+        # indices too. Before guard_negative_gather_indices, -1 must stay signed.
+        return False
+    for name, value in op.inputs.items():
+        for var in value if isinstance(value, (tuple, list)) else (value,):
+            if var.dtype != types.int32 or (var.op is not None and var.op.op_type == 'const'):
+                continue
+            if name != 'indices':
+                return False
+            if op.op_type in ('gather', 'gather_along_axis'):
+                if op.axis.val is None:
+                    return False
+                dims = (op.x.shape[int(op.axis.val)],)
+            elif op.op_type == 'gather_nd':
+                k = op.indices.shape[-1]
+                if is_symbolic(k):
+                    return False
+                batch = getattr(op, 'batch_dims', 0)
+                batch = batch.val if hasattr(batch, 'val') else batch
+                if batch is None:
+                    return False
+                dims = op.x.shape[int(batch):int(batch) + k]
+            else:
+                return False
+            if any(is_symbolic(d) or d > 32767 for d in dims):
+                return False
+    return True
+
+
+class _PassPipeline(ct.PassPipeline):
+    def remove_pass(self, index):
+        name = self.passes[index]
+        super().remove_pass(index)
+        if name not in self.passes:
+            self.get_all_options().pop(name, None)
+
+    def remove_passes(self, passes_names):
+        # coremltools 9.0 ct.convert(FLOAT32) removes the cast passes, but its
+        # PassPipeline.remove_passes leaves orphan options that fail validate().
+        super().remove_passes(passes_names)
+        for name in passes_names:
+            self.get_all_options().pop(name, None)
+
+
+def _with_int16_safety(op, caller):
+    return caller(op) and _int16_cast_is_safe(op)
+
+
 def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
     """Return a new pipeline: ``base`` with the stablehlo-coreml passes inserted.
 
@@ -139,10 +211,18 @@ def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
     no-op for those passes.
     """
     # `ct.PassPipeline.DEFAULT` already hands out a fresh object on every access.
-    pipeline = ct.PassPipeline.DEFAULT if base is None else copy.deepcopy(base)
+    base = ct.PassPipeline.DEFAULT if base is None else copy.deepcopy(base)
+    pipeline = _PassPipeline(list(base.passes), base.pipeline_name)
+    pipeline.set_options_by_another_pipeline(base)
 
     _insert_passes(pipeline, CLEANUP_PASSES, _CLEANUP_ANCHOR, fallback_index=0)
     _insert_passes(pipeline, FUSION_PASSES, _FUSION_ANCHOR, fallback_index=None)
     _insert_passes(pipeline, LATE_FUSION_PASSES, _LATE_FUSION_ANCHOR, fallback_index=None, after=True)
+
+    if 'common::add_int16_cast' in pipeline.passes:
+        caller = next((option.option_val for option in pipeline.get_options('common::add_int16_cast') or []
+                       if option.option_name == 'op_selector'), None)
+        selector = _int16_cast_is_safe if caller is None else partial(_with_int16_safety, caller=caller)
+        pipeline.set_options('common::add_int16_cast', {'op_selector': selector})
 
     return pipeline

--- a/tests/passes/test_int16_cast_safety.py
+++ b/tests/passes/test_int16_cast_safety.py
@@ -1,0 +1,179 @@
+"""Pipeline regressions for upstream int32 data/index narrowing."""
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+
+from stablehlo_coreml import build_pass_pipeline
+from stablehlo_coreml.passes.utils import _int16_cast_is_safe
+from tests.utils import run_and_compare_specific_input
+
+
+def _convert(program, fp32=False):
+    pipeline = build_pass_pipeline()
+    pipeline.remove_passes(['common::add_fp16_cast'])
+    return ct.convert(program, source='milinternal', minimum_deployment_target=ct.target.iOS18,
+                      compute_precision=ct.precision.FLOAT32 if fp32 else None, compute_units=ct.ComputeUnit.CPU_ONLY,
+                      pass_pipeline=pipeline)
+
+
+def test_large_jax_take():
+    table = np.arange(80000, dtype=np.int32).reshape(40000, 2)
+    run_and_compare_specific_input(lambda x, i: jnp.take(x, i, axis=0, mode='clip'),
+                                   (table, np.array([35000, 3], np.int32)), max_complexity=100000, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize('kind', ['gather_nd', 'squeeze', 'topk'])
+def test_int32_data_preserved(kind):
+    shape = {'gather_nd': (40000, 2), 'squeeze': (1, 4), 'topk': (4,)}[kind]
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=shape, dtype=types.int32)], opset_version=ct.target.iOS18)
+    def program(x):
+        if kind == 'gather_nd':
+            return mb.gather_nd(x=x, indices=np.array([[35000], [3]], np.int32))
+        if kind == 'squeeze':
+            return mb.squeeze(x=x, axes=[0])
+        return mb.topk(x=x, k=2)[0]
+
+    data = (np.arange(80000, dtype=np.int32).reshape(shape) if kind == 'gather_nd'
+            else np.array([40000, -40000, 35000, 2], np.int32).reshape(shape))
+    expected = {'gather_nd': lambda: data[[35000, 3]], 'squeeze': lambda: data[0],
+                'topk': lambda: np.array([40000, 35000], np.int32)}[kind]()
+    model = _convert(program)
+    np.testing.assert_array_equal(next(iter(model.predict({'x': data}).values())), expected)
+    assert not any(op.op_type == 'cast' and op.dtype.val in ('int16', 'uint16') and op.x.dtype == types.int32
+                   and op.x.val is None for op in model._mil_program.functions['main'].operations)
+
+
+def test_jax_topk_int32():
+    model = run_and_compare_specific_input(lambda x: jax.lax.top_k(x, 2),
+                                           (np.array([40000, -40000, 35000, 2], np.int32),), atol=0, rtol=0)
+    assert any(op.op_type == 'topk' for op in model._mil_program.functions['main'].operations)
+
+
+def test_safe_small_gather_still_narrows():
+    # Negative constant entries select signed int16 rather than uint16. Dynamic
+    # indices also permit a surviving int16 cast to be inspected after folding.
+    @mb.program(input_specs=[mb.TensorSpec(shape=(2,), dtype=types.int32)], opset_version=ct.target.iOS18)
+    def program(indices):
+        return mb.gather(x=np.array([-3, 2, 7], np.int32), indices=indices, axis=0)
+
+    model = _convert(program)
+    np.testing.assert_array_equal(next(iter(model.predict({'indices': np.array([0, 2], np.int32)}).values())), [-3, 7])
+    assert any(op.op_type == 'cast' and op.dtype.val == 'int16' for op in model._mil_program.functions['main'].operations)
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=(3,))], opset_version=ct.target.iOS18)
+    def const_indexed(x):
+        return mb.gather(x=x, indices=np.array([0, 2], np.int32), axis=0)
+
+    model = _convert(const_indexed)
+    gather = next(op for op in model._mil_program.functions['main'].operations if op.op_type == 'gather')
+    # Constant cast folds to a constant, so inspect the actual narrowed dtype.
+    assert gather.indices.dtype in (types.int16, types.uint16)
+    np.testing.assert_array_equal(next(iter(model.predict({'x': np.array([1., 2., 3.], np.float32)}).values())), [1., 3.])
+
+
+def test_explicit_fp32_conversion_removes_cast_options():
+    @mb.program(input_specs=[mb.TensorSpec(shape=(2,))])
+    def program(x):
+        return mb.add(x=x, y=1.)
+    model = _convert(program, fp32=True)
+    np.testing.assert_array_equal(next(iter(model.predict({'x': np.array([1., 2.], np.float32)}).values())), [2., 3.])
+
+
+@pytest.mark.parametrize('kind', ['gather', 'gather_along_axis', 'gather_nd'])
+@pytest.mark.parametrize('size,safe', [(32767, True), (32768, False), (None, False)])
+def test_dynamic_index_domain(kind, size, safe):
+    extent = get_new_symbol() if size is None else size
+    index_shape = (2, 1) if kind == 'gather_nd' else (2,)
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=(extent,)), mb.TensorSpec(shape=index_shape, dtype=types.int32)],
+                opset_version=ct.target.iOS18)
+    def program(x, indices):
+        if kind == 'gather_nd':
+            return mb.gather_nd(x=x, indices=indices)
+        return getattr(mb, kind)(x=x, indices=indices, axis=0)
+
+    op = next(op for op in program.functions['main'].operations if op.op_type == kind)
+    assert _int16_cast_is_safe(op) is safe
+
+
+@pytest.mark.parametrize('shape,safe', [((1, 80000), False), ((80000, 3), True)])
+def test_batched_gather_nd_domain(shape, safe):
+    @mb.program(input_specs=[mb.TensorSpec(shape=shape),
+                            mb.TensorSpec(shape=(shape[0], 1, 1), dtype=types.int32)], opset_version=ct.target.iOS18)
+    def program(x, indices):
+        return mb.gather_nd(x=x, indices=indices, batch_dims=1)
+
+    op = next(op for op in program.functions['main'].operations if op.op_type == 'gather_nd')
+    assert _int16_cast_is_safe(op) is safe
+    model = _convert(program)
+    x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    index = 2 if safe else 70000
+    actual = next(iter(model.predict({'x': x, 'indices': np.full((shape[0], 1, 1), index, np.int32)}).values()))
+    np.testing.assert_array_equal(actual, x[:, index:index + 1])
+
+
+def test_batched_gather_axis_is_absolute():
+    @mb.program(input_specs=[mb.TensorSpec(shape=(1, 80000)), mb.TensorSpec(shape=(1, 1), dtype=types.int32)],
+                opset_version=ct.target.iOS18)
+    def program(x, indices):
+        return mb.gather(x=x, indices=indices, axis=-1, batch_dims=1)
+    op = next(op for op in program.functions['main'].operations if op.op_type == 'gather')
+    assert not _int16_cast_is_safe(op)
+
+
+def test_nonnegative_table_preserves_negative_indices():
+    @mb.program(input_specs=[mb.TensorSpec(shape=(1,), dtype=types.int32)], opset_version=ct.target.iOS18)
+    def program(indices):
+        return mb.gather(x=np.array([3, 2, 7], np.int32), indices=indices, axis=0)
+    model = _convert(program)
+    np.testing.assert_array_equal(next(iter(model.predict({'indices': np.array([-1], np.int32)}).values())), [7])
+
+
+@pytest.mark.parametrize('size', [80000, None])
+def test_large_float_topk_keeps_int32_indices(size):
+    extent = get_new_symbol() if size is None else size
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=(extent,))], opset_version=ct.target.iOS18)
+    def program(x):
+        return mb.topk(x=x, k=1, output_indices_dtype='int32')
+    op = next(op for op in program.functions['main'].operations if op.op_type == 'topk')
+    assert not _int16_cast_is_safe(op)
+    if size is not None:
+        model = _convert(program)
+        topk = next(op for op in model._mil_program.functions['main'].operations if op.op_type == 'topk')
+        assert topk.output_indices_dtype.val == 'int32'
+        x = np.zeros(size, np.float32)
+        x[70000] = 1
+        out = list(model.predict({'x': x}).values())
+        assert any(np.array_equal(v, [70000]) for v in out)
+
+
+def test_caller_selector_still_disables_casts():
+    base = ct.PassPipeline.DEFAULT
+    base.remove_passes(['common::add_fp16_cast'])
+    base.set_options('common::add_int16_cast', {'op_selector': lambda op: False})
+
+    @mb.program(input_specs=[mb.TensorSpec(shape=(3,)), mb.TensorSpec(shape=(1,), dtype=types.int32)],
+                opset_version=ct.target.iOS18)
+    def program(x, indices):
+        return mb.gather(x=x, indices=indices, axis=0)
+    model = ct.convert(program, source='milinternal', minimum_deployment_target=ct.target.iOS18,
+                       compute_units=ct.ComputeUnit.CPU_ONLY, pass_pipeline=build_pass_pipeline(base))
+    assert not any(op.op_type == 'cast' and op.dtype.val in ('int16', 'uint16')
+                   for op in model._mil_program.functions['main'].operations)
+
+
+def test_remove_cast_pass_by_index_cleans_last_options():
+    pipeline = build_pass_pipeline()
+    name = 'common::add_int16_cast'
+    while name in pipeline.passes:
+        pipeline.remove_pass(pipeline.passes.index(name))
+        if name in pipeline.passes:
+            assert pipeline.get_options(name)
+    assert pipeline.get_options(name) is None
+    pipeline.validate()


### PR DESCRIPTION
## What

Set an `op_selector` on upstream `common::add_int16_cast` in `build_pass_pipeline()`. Only allow an operation when every int32 input is either a constant (range-checked by coremltools itself), or a gather index with a statically bounded addressing domain: the selected axis for `gather`/`gather_along_axis`, or dimensions `x.shape[batch_dims:batch_dims+k]` for `gather_nd`, must be ≤32767. Gather axis values remain absolute (including negative axes); batch dimensions do not offset them. Never allow nonconstant int32 data (`x`) to be narrowed for these gathers, `squeeze`, or `topk`.

Reject dynamic-index casts when a nonnegative int32 constant tensor could select uint16 and destroy negative indices before wrapping. Also bound the selected axis of float `topk` to protect its string `output_indices_dtype` parameter, including symbolic extents. Compose a caller selector with the safety predicate (`caller(op) and safe(op)`).

Keep safe 16-bit conversions, including small constant-indexed gathers. The selector applies to both existing occurrences of the pass; it neither adds the upstream pass nor changes the duplicate entries. Caller pipelines are copied as before.

A small `PassPipeline` subclass also clears options when passes are removed. This is needed because coremltools 9.0's explicit fp32 conversion removes the cast passes but leaves their options behind, causing pipeline validation to reject the otherwise valid selector configuration. It uses the public options accessor and supports removal by name and by index, dropping options only after the last indexed occurrence is removed. Explicit fp32 conversion and both removal APIs are covered.

## Why

coremltools 9.0's DEFAULT pipeline contains `common::add_int16_cast`, which narrows every eligible nonconstant int32 input, including **data**, without proving the values fit. Its constant range check and limited gather-index dimension check do not protect dynamic int32 data. `op_selector` is supported by this pass; the FP16 pass's `skip_ops_by_type` option is not.

The reviewer reproduced a real correctness failure on main: taking rows `[35000, 3]` from an int32 `(40000, 2)` table through the converter returned row 9464 after narrowing an intermediate index-data gather. Scatter fallback, reductions, and arbitrary int32 squeeze/topk data are exposed to the same upstream behavior. This PR fixes pipeline policy independently of the static-scatter PR; it does not change converter lowering or claim a performance improvement. Use `build_pass_pipeline()` to obtain the protection; direct use of unmodified `ct.PassPipeline.DEFAULT` remains upstream behavior.

## Tests

- `tests/passes/test_int16_cast_safety.py` + `tests/passes/test_pass_pipeline.py`: **56 passed**. Large int32 JAX take (fails on `main`: row 9464 instead of 35000), MIL gather_nd, squeeze carrying ±40000, MIL and JAX topk, positive controls for surviving int16 casts and folded narrow constant indices, gather-family dynamic domain boundaries (32767/32768/symbolic), explicit fp32 conversion with options cleanup, unsafe and safe batched gather_nd domains, a valid negative index into `[3,2,7]`, float topk output-index dtype at extent 80000 and symbolic extent, caller-selector vetoes, and indexed pass removal.
- Full suite (`pytest tests/ --ignore=tests/pytorch`, JAX/JAXlib 0.9.1, coremltools 9.0, Flax 0.12.5, macOS 26 / M4): **658 passed, 2 failed, 1 xfailed**. The two failures are pre-existing on `main` in the same environment (`test_flax_multi_head_attention_is_causal`, `test_flax_multi_head_attention_grouped_query`: Flax 0.12.5 lacks the arguments those tests pass).
- Review round: an independent review found the selector ignored `gather_nd`'s `batch_dims` (index 70000 in a `(1, 80000)` table returned 4464), that a non-negative const table flips the pass to `uint16` so a dynamic index of −1 returned the wrong element (the first `add_int16_cast` occurrence runs before `guard_negative_gather_indices`), that `topk`'s string `output_indices_dtype` was rewritten to `uint16` for large extents, that a caller-supplied `op_selector` was overwritten, and that `remove_pass(index)` left the option behind. All five are fixed and covered by the tests above; the first two were confirmed with real predictions before and after the fix.
- `ruff check .`: **All checks passed!**

Implemented with OpenAI Codex (gpt-6-astra) under Claude Code orchestration and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
