### PR TITLE
op_scatter: static collision-free lowering for out-of-bounds drops

### DIFF
--- a/stablehlo_coreml/converter.py
+++ b/stablehlo_coreml/converter.py
@@ -86,6 +86,7 @@ from .function_interface import _FunctionInterface
 from .ops_register import StableHloOpsRegistry, register_composite_op, register_stablehlo_op
 from .padding import pad_with_cast
 from .reductions import compute_reduction, compute_windowed_reduction, match_computation, match_simple_reduce_window
+from .scatter import scatter_column, static_scatter, static_scatter_indices, static_scatter_sizes
 from .sort_utils import match_sort
 from .state import (
     FunctionStateMapping,
@@ -1593,12 +1594,22 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         #     updates must be the shape as `indices.shape[:-1] + data.shape[indices.shape[-1]:]`
         # [sic] via
         #     https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.scatter_gather.scatter_nd
-        if scatter_indices.shape != (1,) and \
-                updates.shape != scatter_indices.shape[:-1] + operand.shape[scatter_indices.shape[-1]:]:
-            raise ValueError("Scatter windows that only partially fill dimensions are not supported!")
-
-        # this can be done pre-emptively because of the constraint on scatter windows
-        scatter_indices = mb.gather(x=scatter_indices, indices=np.argsort(dim_mapping), axis=-1)
+        rest = operand.shape[len(dim_mapping):]
+        if scatter_indices.shape != (1,):
+            batch_rank = scatter_indices_rank - 1
+            if (
+                dim_numbers.index_vector_dim != batch_rank
+                or tuple(dim_numbers.update_window_dims) != tuple(range(batch_rank, batch_rank + len(rest)))
+                or tuple(dim_numbers.inserted_window_dims) != tuple(sorted(dim_mapping))
+                or updates.rank != batch_rank + len(rest)
+            ):
+                raise ValueError("Scatter requires trailing index vectors and canonical full-slice window dimensions")
+            # Distinct MIL Symbols do not prove equal extents, even if HLO inputs
+            # used the same dimension name. op_custom_call skips shape_assertion;
+            # preserving those equality facts is needed to support separate inputs.
+            if any(actual != expected for actual, expected in zip(updates.shape[batch_rank:], rest)):
+                raise ValueError("Scatter windows that only partially fill dimensions or have unproven symbolic extents "
+                                 "are not supported!")
 
         # StableHLO supports arbitrary scatter computations, but MIL has a fixed set
         # We try to match the update computation to a known binary operation
@@ -1607,22 +1618,41 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
         if mil_binary_op is None:
             raise ValueError("Unsupported update mode for scatter operation")
 
-        upper_bound = np.array(operand.shape[:len(dim_mapping)], dtype=np.int32)[(None,) * (scatter_indices_rank - 1)]
+        if any(d == 0 for d in rest):
+            context.add_result(op.results[0], operand)
+            return
+        if scatter_indices.shape == (1,) and is_symbolic(operand.shape[0]):
+            raise ValueError("Scatter partial-window operand front dimension must be static")
+
+        sizes = static_scatter_sizes(operand.shape, scatter_indices.shape, len(dim_mapping))
+        if scatter_indices.shape != (1,) and sizes is not None:
+            size, rows = sizes
+            if size == 0:
+                context.add_result(op.results[0], operand)
+                return
+            indices = static_scatter_indices(scatter_indices, operand.shape[:len(dim_mapping)], rows, tuple(dim_mapping))
+            result = static_scatter(operand, indices, updates, mode, size, rows)
+            context.add_result(op.results[0], result)
+            return
+
+        permutation = np.argsort(dim_mapping)
+        if not np.array_equal(permutation, np.arange(len(dim_mapping))):
+            scatter_indices = mb.concat(values=[scatter_column(scatter_indices, n) for n in permutation], axis=-1)
+
+        front = operand.shape[:len(dim_mapping)]
+        if any(is_symbolic(d) for d in front):
+            upper_bound = mb.slice_by_index(x=mb.shape(x=operand), begin=(0,), end=(len(dim_mapping),))
+        else:
+            upper_bound = np.array(front, dtype=np.int32)[(None,) * (scatter_indices_rank - 1)]
         valid = mb.logical_and(
             x=mb.greater_equal(x=scatter_indices, y=0),
             y=mb.less(x=scatter_indices, y=upper_bound)
         )
 
-        def along(n):
-            return mb.slice_by_index(
-                x=valid, begin=(0,) * (scatter_indices_rank - 1) + (n,),
-                end=scatter_indices.shape[:-1] + (n + 1,)
-            )
-
         # unrolling O(scatter_indices.rank)
-        reduction = along(0)
+        reduction = scatter_column(valid, 0)
         for i in range(1, scatter_indices.shape[-1]):
-            reduction = mb.logical_and(x=reduction, y=along(i))
+            reduction = mb.logical_and(x=reduction, y=scatter_column(valid, i))
         reduction = mb.squeeze(x=reduction, axes=(scatter_indices_rank - 1,))
 
         # Special handling for rank-0 reduction (single index update).
@@ -1692,6 +1722,9 @@ class StableHloConverter(metaclass=StableHloOpsRegistry):
             )
         else:
             where = mb.non_zero(x=reduction)
+            # The add_int16_cast op_selector from #107 (build_pass_pipeline) protects
+            # this index-data gather. Without that fix, upstream add_int16_cast
+            # can narrow valid coordinates >= 32768.
             scatter_indices = mb.gather_nd(x=scatter_indices, indices=where)
             updates = mb.gather_nd(x=updates, indices=where)
             result = mb.scatter_nd(data=operand, indices=scatter_indices, updates=updates, mode=mode)

--- a/stablehlo_coreml/scatter.py
+++ b/stablehlo_coreml/scatter.py
@@ -1,0 +1,68 @@
+"""Static OOB-drop lowering for scatter over complete trailing slices."""
+from math import prod
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .utils import clamp_index
+
+
+def static_scatter_sizes(operand_shape, indices_shape, indexed_rank):
+    """Return (flattened front, update rows), or None for symbolic routing dimensions.
+
+    Use Python integers so the eligibility check itself cannot overflow. Trailing
+    slice dimensions need not be static: only the routing domain must be known.
+    """
+    front = operand_shape[:indexed_rank]
+    batch = indices_shape[:-1]
+    if any(is_symbolic(d) for d in (*front, *batch)):
+        return None
+    size, rows = prod(int(d) for d in front), prod(int(d) for d in batch)
+    if size + rows > np.iinfo(np.int32).max:
+        raise ValueError("scatter operand front too large for int32 indexing")
+    return size, rows
+
+
+def scatter_column(x, column, squeeze=False):
+    """Slice one last-axis column, retaining arbitrary static or symbolic batches."""
+    return mb.slice_by_index(
+        x=x, begin=(0,) * (x.rank - 1) + (column,),
+        end=(0,) * (x.rank - 1) + (column + 1,),
+        end_mask=(True,) * (x.rank - 1) + (False,),
+        squeeze_mask=(False,) * (x.rank - 1) + (squeeze,),
+    )
+
+
+def static_scatter_indices(indices, front, rows, dim_mapping):
+    """Linearize original indices, assigning each OOB row a unique slot.
+
+    Slice columns directly: add_int16_cast can narrow gather's int32 DATA and
+    corrupt large index values before bounds checking, even for identity gathers.
+    """
+    indices = mb.reshape(x=indices, shape=(rows, len(front)))
+    valid, linear = None, None
+    for axis, extent in enumerate(front):
+        column = dim_mapping.index(axis)
+        component = scatter_column(indices, column, squeeze=True)
+        in_bounds = mb.logical_and(
+            x=mb.greater_equal(x=component, y=0), y=mb.less(x=component, y=extent),
+        )
+        valid = in_bounds if valid is None else mb.logical_and(x=valid, y=in_bounds)
+        # Clamp BEFORE multiplying: even INT_MIN/INT_MAX must not overflow the
+        # flattened index expression, including values in the discarded branch.
+        component = clamp_index(component, extent, 1)
+        linear = component if linear is None else mb.add(x=mb.mul(x=linear, y=extent), y=component)
+    dummy = np.arange(prod(front), prod(front) + rows, dtype=np.int32)
+    return mb.select(cond=valid, a=linear, b=dummy)
+
+
+def static_scatter(operand, indices, updates, mode, size, rows):
+    """Use the updates themselves as discarded padding; retain operand once."""
+    data = mb.reshape(x=operand, shape=(size, -1))
+    updates = mb.reshape(x=updates, shape=(rows, -1))
+    data = mb.concat(values=(data, updates), axis=0)
+    result = mb.scatter(data=data, indices=indices, updates=updates, axis=0, mode=mode)
+    result = mb.slice_by_size(x=result, begin=(0, 0), size=(size, -1))
+    shape = mb.shape(x=operand) if any(is_symbolic(d) for d in operand.shape) else operand.shape
+    return mb.reshape(x=result, shape=shape)

--- a/tests/test_scatter_static.py
+++ b/tests/test_scatter_static.py
@@ -1,0 +1,297 @@
+"""Static scatter semantics, routing safety, and dynamic fallback coverage."""
+from math import prod
+
+import coremltools as ct
+import jax
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic, k_used_symbols
+from jax._src.interpreters import mlir as jax_mlir
+from jax._src.lib.mlir import ir
+
+from stablehlo_coreml.converter import convert
+from stablehlo_coreml.scatter import static_scatter_indices, static_scatter_sizes
+from tests.utils import run_and_compare_hlo_module, run_and_compare_specific_input, run_and_compare_symbolic
+
+MODES = ('update', 'add', 'sub', 'mul', 'div', 'min', 'max')
+
+
+@pytest.fixture(autouse=True)
+def _restore_symbol_registry():
+    # Expected conversion failures bypass ct.convert's normal symbol cleanup.
+    before = k_used_symbols.copy()
+    yield
+    k_used_symbols.clear()
+    k_used_symbols.update(before)
+
+
+def _module(shape, index_shape, mode='add', dtype='f32', mapping=None):
+    k = index_shape[-1]
+    mapping = tuple(range(k)) if mapping is None else mapping
+    rest = tuple(shape[i] for i in range(len(shape)) if i not in mapping)
+    update_shape = (*index_shape[:-1], *rest)
+    def tensor(s, t):
+        return 'tensor<' + 'x'.join((*map(str, s), t)) + '>'
+    data_t, index_t, update_t = tensor(shape, dtype), tensor(index_shape, 'i32'), tensor(update_shape, dtype)
+    window = list(range(len(index_shape) - 1, len(update_shape)))
+    scalar = tensor((), dtype)
+    if mode == 'update':
+        body = f'stablehlo.return %b : {scalar}'
+    else:
+        op = {'min': 'minimum', 'max': 'maximum', 'sub': 'subtract', 'mul': 'multiply', 'div': 'divide'}.get(mode, mode)
+        body = f'%r = stablehlo.{op} %a, %b : {scalar}\n stablehlo.return %r : {scalar}'
+    return ir.Module.parse(f'''module {{
+      func.func @main(%data: {data_t}, %indices: {index_t}, %updates: {update_t}) -> {data_t} {{
+        %out = "stablehlo.scatter"(%data, %indices, %updates) ({{
+          ^bb0(%a: {scalar}, %b: {scalar}):
+            {body}
+        }}) {{indices_are_sorted = false, unique_indices = false,
+              scatter_dimension_numbers = #stablehlo.scatter<
+                update_window_dims = {window}, inserted_window_dims = {sorted(mapping)},
+                scatter_dims_to_operand_dims = {list(mapping)}, index_vector_dim = {len(index_shape)-1}>
+        }} : ({data_t}, {index_t}, {update_t}) -> {data_t}
+        return %out : {data_t}
+      }}
+    }}''', context=jax_mlir.make_ir_context())
+
+
+def _walk(block):
+    for op in block.operations:
+        yield op
+        for child in op.blocks:
+            yield from _walk(child)
+
+
+def _audit(model):
+    ops = list(_walk(model._mil_program.functions['main']))
+    assert all(op.op_type not in ('non_zero', 'gather', 'gather_nd', 'gather_along_axis') for op in ops)
+    assert all(not is_symbolic(d) for op in ops for v in op.outputs for d in v.shape)
+    return ops
+
+
+@pytest.mark.parametrize('mode', MODES)
+@pytest.mark.parametrize('dtype', [np.float32, np.int32])
+@pytest.mark.parametrize('shape,mapping,index_batch', [
+    ((4,), (0,), (6,)),
+    ((3, 4), (0,), (2, 3)),
+    ((3, 4), (1, 0), (6,)),
+    ((3, 4, 2), (0,), (6,)),
+    ((3, 4, 2), (1, 0), (2, 3)),
+])
+def test_modes_and_full_slices(mode, dtype, shape, mapping, index_batch):
+    """Nonzero operand, duplicates, and arbitrary OOB int32 values.
+
+    Duplicate overwrite values are equal; no conflicting-overwrite order is
+    required. Values are exactly representable in all tested arithmetic modes.
+    """
+    k = len(mapping)
+    indices = np.zeros((prod(index_batch), k), dtype=np.int32)
+    indices[:2] = np.arange(k)
+    indices[2] = 1 + np.arange(k)
+    indices[3] = -1
+    indices[4] = np.iinfo(np.int32).max
+    indices[5] = np.iinfo(np.int32).min
+    indices = indices.reshape((*index_batch, k))
+    rest = shape[k:]
+    data = np.full(shape, 16, dtype=dtype)
+    updates = np.full((*index_batch, *rest), 2, dtype=dtype)
+    updates.reshape((-1, *rest))[2] = 32
+    expected = data.copy()
+    for row, value in zip(indices.reshape(-1, k), updates.reshape((-1, *rest))):
+        dest = tuple(row[mapping.index(axis)] for axis in range(k))
+        if not all(0 <= d < shape[i] for i, d in enumerate(dest)):
+            continue
+        old = expected[dest]
+        expected[dest] = {
+            'update': value, 'add': old + value,
+            'sub': old - value, 'mul': old * value,
+            'div': old / value, 'min': np.minimum(old, value),
+            'max': np.maximum(old, value),
+        }[mode]
+    model = run_and_compare_hlo_module(
+        _module(shape, indices.shape, mode, 'f32' if dtype == np.float32 else 'i32', mapping),
+        (data, indices, updates), expected, atol=0, rtol=0,
+    )
+    ops = _audit(model)
+    assert any(op.op_type == 'scatter' and op.mode.val == mode for op in ops)
+
+
+@pytest.mark.parametrize('indices', [np.array([[1]], np.int32), np.array([[-1], [5], [9]], np.int32)])
+def test_single_row_and_all_oob(indices):
+    data = np.full(4, 16, np.float32)
+    updates = np.full(indices.shape[0], 2, np.float32)
+    expected = data.copy()
+    if indices[0, 0] == 1:
+        expected[1] = 18
+    model = run_and_compare_hlo_module(_module(data.shape, indices.shape), (data, indices, updates), expected)
+    _audit(model)
+
+
+def test_bool_cast_and_empty():
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((), (0,), (0,))
+        return jax.lax.scatter(data, indices, updates, dims, mode='drop')
+    data = np.array([True, False, True, False])
+    for indices in [np.array([[1], [1], [-1], [10]], np.int32), np.empty((0, 1), np.int32)]:
+        model = run_and_compare_specific_input(fn, (data, indices, np.ones(len(indices), bool)))
+        _audit(model)
+
+
+def test_unique_dummy_routing():
+    @mb.program(input_specs=[mb.TensorSpec(shape=(5, 2), dtype=types.int32)])
+    def program(indices):
+        return static_scatter_indices(indices, (3, 4), 5, (0, 1))
+    model = ct.convert(program, source='milinternal', compute_units=ct.ComputeUnit.CPU_ONLY,
+                       minimum_deployment_target=ct.target.iOS18, compute_precision=ct.precision.FLOAT32)
+    indices = np.array([[2, 3], [-1, 0], [0, 4], [2**31-1, 0], [0, -2**31]], np.int32)
+    actual = next(iter(model.predict({'indices': indices}).values()))
+    np.testing.assert_array_equal(actual, [11, 13, 14, 15, 16])
+
+
+def test_size_guard_without_allocations():
+    limit = np.iinfo(np.int32).max
+    assert static_scatter_sizes((limit - 2,), (2, 1), 1) == (limit - 2, 2)
+    for shape, indices, k in [((limit - 1,), (2, 1), 1), ((2**40, 2**40), (2, 2), 2)]:
+        with pytest.raises(ValueError, match="scatter operand front too large for int32 indexing"):
+            static_scatter_sizes(shape, indices, k)
+    symbol = get_new_symbol()
+    assert static_scatter_sizes((4,), (symbol, 1), 1) is None
+    assert static_scatter_sizes((symbol,), (2, 1), 1) is None
+    assert static_scatter_sizes((4, symbol), (2, 1), 1) == (4, 2)
+    assert static_scatter_sizes((0, 4), (2, 1), 1) == (0, 2)
+
+
+def test_large_valid_index_not_narrowed_to_int16():
+    data = np.full((40000, 2), 16, np.float32)
+    indices = np.array([[35000], [35000], [-2**31], [2**31 - 1]], np.int32)
+    updates = np.full((4, 2), 2, np.float32)
+    expected = data.copy()
+    expected[35000] += 4
+    model = run_and_compare_hlo_module(_module(data.shape, indices.shape), (data, indices, updates), expected, atol=0, rtol=0)
+    _audit(model)
+
+
+@pytest.mark.parametrize('symbolic_front', [False, True])
+def test_symbolic_fallback(symbolic_front):
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((), (0,), (0,))
+        return jax.lax.scatter_add(data, indices, updates, dims, mode='drop')
+    n, = jax.export.symbolic_shape('n')
+    specs = [jax.ShapeDtypeStruct((n if symbolic_front else 4,), np.float32),
+             jax.ShapeDtypeStruct((2 if symbolic_front else n, 1), np.int32),
+             jax.ShapeDtypeStruct((2 if symbolic_front else n,), np.float32)]
+    inputs = []
+    for size in [2, 5]:
+        rows = 2 if symbolic_front else size
+        indices = np.arange(rows, dtype=np.int32)[:, None] - 1
+        inputs.append((np.full(size if symbolic_front else 4, 16, np.float32), indices, np.full(rows, 2, np.float32)))
+    run_and_compare_symbolic(fn, specs, inputs)
+
+
+def test_noncontiguous_mapping_still_rejected():
+    module = _module((3, 4), (2, 1), mapping=(1,))
+    with pytest.raises(ValueError, match='contiguous'):
+        convert(module, minimum_deployment_target=ct.target.iOS18)
+
+
+def test_captured_indices_in_sibling_blocks():
+    def fn(data, indices, flag):
+        dims = jax.lax.ScatterDimensionNumbers((), (0,), (0,))
+
+        def branch(scale):
+            return jax.lax.scatter_add(data, indices, jax.numpy.full((3,), scale), dims, mode='drop')
+
+        return jax.lax.cond(flag, lambda: branch(2.), lambda: branch(4.))
+
+    for flag in [True, False]:
+        model = run_and_compare_specific_input(
+            fn, (np.full(4, 16, np.float32), np.array([[1], [1], [-1]], np.int32), np.array(flag)),
+        )
+        _audit(model)
+
+
+@pytest.mark.parametrize('aliased', [False, True])
+def test_symbolic_trailing_full_slice(aliased):
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((1,), (0,), (0,))
+        return jax.lax.scatter_add(data, indices, data if aliased else updates, dims, mode='drop')
+
+    n, = jax.export.symbolic_shape('n')
+    specs = [jax.ShapeDtypeStruct((4, n), np.float32), jax.ShapeDtypeStruct((4, 1), np.int32),
+             jax.ShapeDtypeStruct((4, n), np.float32)]
+    inputs = [(np.full((4, width), 16, np.float32), np.array([[1], [-1], [1], [9]], np.int32),
+               np.full((4, width), 2, np.float32)) for width in [2, 5]]
+    if aliased:
+        run_and_compare_symbolic(fn, specs, inputs)
+    else:
+        module = ir.Module.parse(jax.export.export(jax.jit(fn))(*specs).mlir_module(), context=jax_mlir.make_ir_context())
+        with pytest.raises(ValueError, match='unproven symbolic extents'):
+            convert(module, minimum_deployment_target=ct.target.iOS18)
+
+
+
+def test_zero_trailing_window_returns_operand():
+    program = convert(_module((4, 0), (3, 1)), minimum_deployment_target=ct.target.iOS18)
+    main = program.functions['main']
+    assert main.outputs[0] is next(iter(main.inputs.values()))
+    assert not any(op.op_type in ('scatter', 'scatter_nd') for op in _walk(main))
+
+
+@pytest.mark.parametrize('indices', [np.array([1, 2], np.int32), np.array([-1, 2], np.int32)])
+def test_rank_one_index_vector(indices):
+    data = np.full((3, 4, 2), 16, np.float32)
+    updates = np.array([2, 3], np.float32)
+    expected = data.copy()
+    if indices[0] >= 0:
+        expected[1, 2] += updates
+    model = run_and_compare_hlo_module(_module(data.shape, indices.shape), (data, indices, updates), expected)
+    _audit(model)
+
+
+def test_symbolic_partial_window_rejected_clearly():
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((0,), (), (0,))
+        return jax.lax.scatter_add(data, indices, updates, dims, mode='drop')
+
+    n, = jax.export.symbolic_shape('n', constraints=('n >= 2',))
+    exported = jax.export.export(jax.jit(fn))(
+        jax.ShapeDtypeStruct((n,), np.float32), jax.ShapeDtypeStruct((1,), np.int32),
+        jax.ShapeDtypeStruct((2,), np.float32),
+    )
+    module = ir.Module.parse(exported.mlir_module(), context=jax_mlir.make_ir_context())
+    with pytest.raises(ValueError, match='partial-window operand front dimension must be static'):
+        convert(module, minimum_deployment_target=ct.target.iOS18)
+
+
+def test_extra_nontrailing_window_axes_rejected():
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((0, 2), (), (0,))
+        return jax.lax.scatter_add(data, indices, updates, dims, mode='drop')
+    specs = [jax.ShapeDtypeStruct((4, 2), np.float32), jax.ShapeDtypeStruct((2, 1), np.int32),
+             jax.ShapeDtypeStruct((2, 2, 1), np.float32)]
+    module = ir.Module.parse(jax.export.export(jax.jit(fn))(*specs).mlir_module(), context=jax_mlir.make_ir_context())
+    with pytest.raises(ValueError, match='canonical full-slice'):
+        convert(module, minimum_deployment_target=ct.target.iOS18)
+
+
+def test_nontrailing_index_vector_rejected():
+    # Square indices keep input/update shapes valid while changing index_vector_dim.
+    text = str(_module((3, 4), (2, 2))).replace('index_vector_dim = 1', 'index_vector_dim = 0')
+    assert 'index_vector_dim = 0' in text
+    module = ir.Module.parse(text, context=jax_mlir.make_ir_context())
+    with pytest.raises(ValueError, match='trailing index vectors'):
+        convert(module, minimum_deployment_target=ct.target.iOS18)
+
+
+def test_symbolic_partial_trailing_extent_rejected():
+    def fn(data, indices, updates):
+        dims = jax.lax.ScatterDimensionNumbers((1,), (0,), (0,))
+        return jax.lax.scatter_add(data, indices, updates, dims, mode='drop')
+    n, = jax.export.symbolic_shape('n', constraints=('n >= 2',))
+    specs = [jax.ShapeDtypeStruct((4, n), np.float32), jax.ShapeDtypeStruct((2, 1), np.int32),
+             jax.ShapeDtypeStruct((2, n - 1), np.float32)]
+    module = ir.Module.parse(jax.export.export(jax.jit(fn))(*specs).mlir_module(), context=jax_mlir.make_ir_context())
+    with pytest.raises(ValueError, match='unproven symbolic extents'):
+        convert(module, minimum_deployment_target=ct.target.iOS18)


### PR DESCRIPTION
## What

Replace the general static-size scatter lowering's `non_zero`/`gather_nd` filtering with a flattened `scatter(axis=0)`. Valid indices address the original operand; invalid update row `j` addresses a unique appended dummy row. The reshaped updates themselves supply the padding, so no zero-fill tensor or folded zero weights are needed. Slice away the dummy tail and restore the operand shape. Clamp each coordinate before linearization so arbitrary out-of-bounds int32 indices cannot overflow the address calculation.

Support the existing contiguous leading dimension mappings (including permutations), multidimensional index batches, full trailing-slice windows, bool auto-casting, and all existing update modes: update/set, add, sub, mul, div, min, max. Preserve the scalar-index partial-window path and unsupported-form errors. Fall back to dynamic filtering for symbolic index-row counts or indexed operand dimensions; raise a clear error if the real-plus-dummy row count exceeds int32. Rely on the default pipeline's `remove_redundant_ops` to share routing; the converter cache is removed, and all 13 full-model sphere scatters still share one routing tensor after optimization.

Static-path index data never passes through `gather`, `gather_nd`, or `gather_along_axis`: each operand axis slices its mapped column directly from the original index tensor. This is necessary because coremltools' `common::add_int16_cast`, already present in coremltools' own DEFAULT pipeline, can narrow gather **data** to int16 before bounds checking (for example INT_MIN becomes zero). The converter does not introduce this pass.

The dynamic fallback permutes columns with slices and concat, skipping identity permutations. Its remaining index-data `gather_nd` is protected by the `add_int16_cast` `op_selector` from #107 (merge that first); without it, valid index values ≥ 32768 are exposed to the upstream narrowing (casting through fp32 would not be an exact remedy above 2^24 either). Also handled: rank-one multi-axis index vectors `(k,)`, statically empty trailing windows (return the operand), and symbolic-front partial windows (clear error instead of a crash inside `mb.minimum`).

Outside the preserved `(1,)` partial-window path, explicitly require a trailing index-vector axis, trailing update-window axes with one per remaining operand dimension, inserted window dimensions equal to the sorted mapping, and the exact update rank before checking trailing extents. Unsupported layouts raise instead of being flattened into a different scatter. Trailing extents must be equal integers or the same MIL Symbol. **Known limitation:** separate symbolic `updates` inputs are conservatively rejected, even when the HLO used the same dimension name; the converter currently discards `shape_assertion` equality facts. Aliased full windows remain supported, and partial `(n-1)` windows are rejected.

The operand is included once and valid updates are not regrouped. The scatter buffer grows by the size of `updates` (O(inputs)); dummy initial values do not affect retained outputs, including for sub/div. This is not a universal memory or latency win for every scatter workload.

The static path writes two operand-sized copies per scatter (`concat` in, `slice` out), on top of the scatter itself. That traffic is cheap for this model's approximately 0.6 MB operands, but not free for very large operands with few updates; the dynamic path touched only update rows plus one operand write. The shared-dummy and identity-value alternatives were measured and rejected at approximately one second per predict from GPU atomic serialization; unique dummy slots are intentional.

## Why

This implements [suggestion 1 in #105](https://github.com/kasper0406/stablehlo-coreml/issues/105) without introducing symbolic intermediate shapes. Unique dummy slots matter: routing invalid updates to one shared dummy destination took approximately one second per sphere predict in the investigation. A collision-sharded alternative was also tested and rejected: binning latency increased monotonically with K=4, 8, 16. Neither variant is included here. Static shapes remove one obstacle to future ANE work; this PR does not claim an ANE speedup or an ANE-compatible full graph.

## Measurements

Workload: the [sphere-detector](https://github.com/kentslaney/sphere-detector) export (8.2k MIL ops, fp32, `CPU_AND_GPU`, one 518×294 depth map) on an Apple M4 Mac mini, macOS 26.6, coremltools 9.1.dev1, jax 0.10.2. Each comparison set is loaded together and run as 15 cyclically interleaved rounds × 50 synchronous predicts after warm-up; values are the median of round medians ± sample SD of the round medians, baseline in every set.

Packages built from this branch (`pr_static` = full model, `pr_binned` = the binning prefix that contains all the scatters), converted from the same saved HLO as the `main` packages; `static2` is the earlier prototype from the investigation:

| Set | `main` lowering | this branch | prototype (`static2`) |
|---|---:|---:|---:|
| Full model, sphere scene | 10.959 ± 0.241 ms | **10.298 ± 0.097 ms** (−6.0%) | 10.334 ± 0.061 ms |
| Full model, noise scene | 11.580 ± 0.757 ms | **9.266 ± 0.489 ms** (−20%) | 9.356 ± 0.449 ms |
| Binning prefix, sphere scene | 7.171 ± 0.251 ms | 7.008 ± 0.041 ms | — |
| Binning prefix, noise scene | 3.984 ± 0.322 ms | 3.439 ± 0.284 ms | — |

Across all runs in the investigation (three revisions of this lowering, each measured against a fresh `main` baseline in the same session) the sphere-scene full-model gain is 3–7% and the noise-scene gain 15–20%; the noise number is not the production claim. The scatter stage costs ~3 ms more on the sphere scene than on noise with *either* lowering (thousands of pixels vote for the same few cells); that cost is Core ML's GPU scatter behaviour, not dynamic shapes, and a collision-sharded variant (K = 4/8/16 layers, then reduce) was measured and rejected because it got monotonically slower with K.

Op counts: `main` 8,209 total / 3,720 nonconstant with 16 symbolic-output ops and one `non_zero`; this branch **8,339 / 3,771** with none (no `fill` either — the updates serve as padding). The binning prefix goes from 521 / 217 with 18 symbolic-output ops to 675 / 278 with zero. All 13 full-model scatters share one routing tensor after `remove_redundant_ops`. The routing also embeds one `rows`-sized int32 constant (the dummy-slot `arange`, 0.6 MB here). These are graph counts, not kernel counts. This review round changes validation only: re-exported sphere model protobufs (deterministic serialization) and weights match a phase-7 reference export, histograms and CPU bytes are unchanged; the hash audit is in `results/phase8-export-equivalence.json`, so these #108 validation changes do not require a sphere GPU rerun.

**GPU numerics.** The `main` lowering is already non-deterministic on GPU: consecutive predicts of the same model on the same input differ by up to ~1e-2 in the output coordinates (scatter-add atomic accumulation order), so a bitwise GPU gate is unsatisfiable even for `main`. GPU validation therefore calibrated a per-output envelope from 40 alternating predicts of two `main` instances, checked 5 held-out `main` predicts against it, and then compared 5 predicts of each branch package on each of 12 inputs: finite/NaN/inf/validity masks unchanged everywhere; 22/24 package×input cases inside the `main` envelope, the other two (`pr_binned`, two random inputs) exceeding it by one ULP on a single accumulator output (e.g. 3.8e-6 vs 1.9e-6) — the same behaviour two byte-identical copies of the `main` package show against each other. CPU outputs are byte-identical.

## Tests

Review round: the independent review found missing rank/layout checks and unjustified symbolic equality; explicit dimension-number validation and conservative extent equality now reject both miscompilations.

- New `tests/test_scatter_static.py`: **89 passed**. Added must-reject regressions for extra/nontrailing window dimensions, a nontrailing index-vector axis, distinct symbolic full-window inputs, and symbolic `(n-1)` partial windows; the aliased symbolic case still passes. All seven modes with duplicate destinations and nonzero operands; fp32/int32; rank 1/2/3, permuted mappings, multidimensional index batches and full-slice windows; mixed/OOB/extreme int32 indices, all-OOB, single index, bool and empty updates; static-shape audits; unique dummy routing; int32 overflow guard without giant allocations; sibling-block correctness; symbolic N/front fallback and symbolic trailing slices; unsupported noncontiguous mapping; no gather-family operations in post-pipeline static-scatter tests; a 40,000-row operand with valid index 35,000.
- Full suite (`pytest tests/ --ignore=tests/pytorch`, JAX/JAXlib 0.9.1, coremltools 9.0, Flax 0.12.5, macOS 26 / M4): **723 passed, 2 failed, 1 xfailed**. The two failures are pre-existing on `main` in the same environment (`test_flax_multi_head_attention_is_causal`, `test_flax_multi_head_attention_grouped_query`; Flax 0.12.5 lacks the arguments those tests pass). Note for anyone re-running: a sandboxed Core ML runtime that cannot write its E5RT cache silently takes a different execution path that *does not* apply the int16 narrowing — the INT_MIN/INT_MAX cases only fail on a real runtime, which is where the first version of this branch was caught.
- `ruff check .`: **All checks passed!**
- Sphere-detector exports built from this branch (JAX/JAXlib 0.10.2, coremltools 9.1.dev1, CPU_ONLY): **12/12 full-model and 12/12 binning-prefix inputs byte-identical** to the `main` lowering.

Implemented with OpenAI Codex (gpt-6-astra) under Claude Code orchestration and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
