### PR TITLE
passes: add the opt-in avoid_ane_dma_notch ANE workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,73 @@ hlo_module = ir.Module.parse(jax_exported.mlir_module(), context=context)
 
 For the JAX example to work, you will additionally need to install `absl-py` and `flatbuffers` as dependencies.
 
+## Apple Neural Engine: avoiding the 1 MiB DMA notch
+
+The Apple Neural Engine has an erratum in its kernel-DMA prefetch ring
+([writeup](https://eiln.github.io/posts/ane-dma.html)): whenever the fp16 weight
+payload a single core has to stream is an integer multiple of 1 MiB, DRAM
+throughput collapses from ~40-60 GB/s to ~17-25 GB/s. The payload of a
+weight-streaming op is
+
+```
+ceil(N / 16) * D * prod(kernel) * 2 bytes
+```
+
+with `N` the output units (output channels / weight rows), `D` the contracting
+(input-channel) dimension and 16 the number of ANE cores — so an innocuous
+2048x4096 fp16 projection lands on exactly 1 MiB per core.
+
+`common::avoid_ane_dma_notch` rewrites the affected `conv`, `linear` and `matmul`
+ops into partial products over chunks of the contracting dimension whose payloads
+are *not* near a multiple of 1 MiB, and sums the partials. Enable it with:
+
+```python
+pass_pipeline=build_pass_pipeline(avoid_ane_dma_notch=True)
+```
+
+Measured on a Mac mini M4 (fp16 1x1 `conv` forced onto the ANE, single token,
+medians of 3 rounds x 200 predicts):
+
+| Weight (Cout x Cin) | Per core  | Unsplit | Split          |
+| ------------------- | --------- | ------- | -------------- |
+| 2048 x 4096         | 1 MiB     | 840 us  | 430 us (2-way) |
+| 4096 x 4096         | 2 MiB     | 1142 us | 697 us (4-way) |
+| 2048 x 8192         | 2 MiB     | 1350 us | 698 us (4-way) |
+| 4096 x 14336        | 7 MiB     | 3522 us | 1989 us (2-way)|
+| 2016 x 4096         | 0.98 MiB  | 426 us  | 426 us (control) |
+
+The split column reports the chunk count each measurement used. The pass picks
+the *fewest* chunks that take every partial out of the notch, which for a 2 MiB
+payload is three near-equal chunks of ~0.67 MiB rather than the four equal
+0.5 MiB chunks measured above. The two are not equally far from a multiple of
+1 MiB (0.33 MiB against 0.5 MiB), but both are far outside the 16 KiB window
+and both stay inside the very first lap of the prefetch ring, where the stall
+cannot happen at all — and they measure the same: across three separate runs
+the 3-way split the pass emits took 684-730 us on 4096 x 4096 and 685-730 us on
+2048 x 8192, against 685-698 us and 695-753 us for the hand-written 4-way one,
+with every slice, partial and add staying on the ANE.
+
+On a whole model the effect compounds. A synthetic Llama-3.2-1B-shaped decode
+step (16 layers, dim 2048, MLP 8192, 1.95 GB of fp16 weights, every projection
+a 1x1 NCHW convolution, single token, everything on the ANE) goes from 76.1 ms
+to 31.6 ms per step — 13.1 to 31.6 tokens/s, a 2.4x speedup, at an effective
+weight-streaming rate of 25.6 against 61.5 GB/s. The pass split the 48 MLP
+projections (2 MiB per core) and correctly left the attention projections
+(0.5 and 0.125 MiB per core) alone.
+
+It is opt-in because it is an ANE-only win: on the GPU there is no notch to
+avoid in the first place (2048 x 4096 runs in 158 us against 156 us for the
+control shape), so the extra slices and adds are pure overhead there, and the
+CPU shows no notch either. It also adds ops — a slice per partial and an add
+per extra partial, so a k-way split costs k slices and k-1 adds — and changes
+fp16 rounding a little, because the accumulation is regrouped into partial
+sums.
+
+Only plain fp16 `const` weights with static shapes are split — `constexpr_*`
+(palettized/quantized) weights stream different bytes than this model counts,
+and grouped convolutions have a per-group contracting dimension the model does
+not describe.
+
 ## Stateful models
 
 Core ML can keep tensors across model invocations as *state* instead of passing

--- a/stablehlo_coreml/passes/avoid_ane_dma_notch.py
+++ b/stablehlo_coreml/passes/avoid_ane_dma_notch.py
@@ -1,0 +1,382 @@
+"""MIL pass: split weight-streaming ops whose per-core weight payload is a multiple of 1 MiB.
+
+The Apple Neural Engine has an RTL erratum in the kernel-DMA prefetch ring
+(described in https://eiln.github.io/posts/ane-dma.html): the prefetcher walks a
+ring of ``0x4000`` 64-byte lines, i.e. exactly 1 MiB, and whenever the number of
+weight bytes a core has to stream is an integer multiple of that ring size, the
+DMA engine stalls at the wrap-around. Measured DRAM throughput collapses from
+~40-60 GB/s to ~17-25 GB/s, and the effect is 1 MiB-periodic: it recurs at every
+multiple of 1 MiB, and recovers linearly over a window of 256 DMA lines (16 KiB)
+on either side of the notch.
+
+The payload model
+-----------------
+The ANE distributes the output units (the output channels of a ``conv``, the
+rows of a ``linear``/``matmul`` weight) over its 16 cores, and each core streams
+the *whole* contracting dimension for the units it owns::
+
+    payload_bytes = ceil(N / NUM_CORES) * D * prod(kernel) * itemsize
+
+with ``N`` the number of output units, ``D`` the contracting (input-channel)
+dimension and ``itemsize == 2`` (the ANE only runs fp16). That is the quantity
+the erratum is periodic in, which is why the notch shows up at shapes that look
+harmless: a 2048x4096 fp16 1x1 convolution is ``ceil(2048/16) * 4096 * 2``
+= exactly 1 MiB per core.
+
+The workaround
+--------------
+A convolution (and a matrix product) is linear in its contracting dimension, so
+
+    y = W @ x  ==  W[:, :d] @ x[:d] + W[:, d:] @ x[d:]
+
+Splitting an affected op into ``k`` partial products whose per-core payloads are
+*not* near a multiple of 1 MiB, and summing the partials, restores full
+bandwidth. Measured on a Mac mini M4 (fp16 1x1 ``conv``, single token, medians of
+3 rounds x 200 predicts):
+
+===================  ==========  ==========  =====================
+Weight (Cout x Cin)  Per core    Unsplit     Split
+===================  ==========  ==========  =====================
+2048 x 4096          1 MiB       840 us      430 us (2-way)
+4096 x 4096          2 MiB       1142 us     697 us (4-way)
+2048 x 8192          2 MiB       1350 us     698 us (4-way)
+4096 x 14336         7 MiB       3522 us     1989 us (2-way)
+2016 x 4096          0.98 MiB    426 us      426 us (control)
+===================  ==========  ==========  =====================
+
+The split column records the chunk count each row was measured with. This pass
+picks the *fewest* chunks that clear the notch, so for a 2 MiB payload it emits
+three near-equal chunks of ~0.67 MiB where the rows above used four equal ones
+of 0.5 MiB. The two chunk sizes are not equally far from a multiple of 1 MiB
+(0.33 MiB against 0.5 MiB), but both are far outside the 16 KiB window and both
+stay inside the very first lap of the ring, where ``hits_notch`` says the stall
+cannot happen -- and they measure the same: over three separate runs the 3-way
+split took 684-730 us on 4096x4096 and 685-730 us on 2048x8192, against
+685-698 us and 695-753 us for the hand-written 4-way one.
+
+Why this pass is opt-in
+-----------------------
+The erratum is an ANE one. On the GPU there is no notch to avoid in the first
+place (2048x4096 runs in 158 us against 156 us for the control shape), so the
+extra slices and adds are pure overhead there, and the CPU shows no notch
+either. The rewrite also adds ops (one slice
+per partial and one add per extra partial, i.e. k slices and k-1 adds for a
+k-way split) and changes fp16 rounding a little, because the accumulation is
+now split into partial sums. So it only runs when the caller
+asks for it with ``build_pass_pipeline(avoid_ane_dma_notch=True)``.
+
+Scope
+-----
+Only leaf ops whose weight is a plain fp16 ``const`` with a static shape are
+touched -- a ``constexpr_*`` (palettized/quantized) weight has a payload this
+model does not describe, and a runtime weight has no compile-time size at all.
+Grouped convolutions are skipped: their contracting dimension is per-group, so
+the payload model above does not apply.
+"""
+
+import logging
+
+import numpy as np
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import types
+from coremltools.converters.mil.mil.passes.pass_registry import register_pass
+from coremltools.converters.mil.mil.types.symbolic import is_symbolic
+
+from .pattern_utils import RewritePass
+
+logger = logging.getLogger(__name__)
+
+# Number of ANE cores the output units are spread over. The erratum is about
+# what *one* core streams, so this is what turns a weight size into a payload.
+NUM_CORES = 16
+
+# Size of the kernel-DMA prefetch ring: 0x4000 lines of 64 bytes. Payloads that
+# are an integer multiple of this wrap the ring exactly and hit the stall.
+NOTCH_BYTES = 1 << 20  # 1 MiB
+
+# Half-width of the measured V-notch: 256 DMA lines (one VM page worth of
+# lines) on either side of a multiple of `NOTCH_BYTES`. Throughput recovers
+# linearly across it, so a payload this far away is already out of trouble.
+WINDOW_BYTES = 256 * 64  # 16 KiB
+
+# Largest number of partial products the pass is willing to emit. Every extra
+# partial costs a slice and an add; the blog's affected models all need <= 4.
+MAX_SPLITS = 8
+
+# The ANE runs fp16 only, so that is the only weight element size that has a
+# payload in the sense above.
+ITEMSIZE_BYTES = 2
+
+# Ops the pass knows how to split, mapped to the input name holding the weight.
+_WEIGHT_INPUT = {"conv": "weight", "linear": "weight", "matmul": "y"}
+
+
+def per_core_payload_bytes(out_units: int, contracting: int, kernel_elems: int) -> int:
+    """Bytes of fp16 weight a single ANE core streams for such an op.
+
+    ``out_units`` (``N``) is spread over :data:`NUM_CORES`; each core streams the
+    full contracting dimension (``contracting * kernel_elems`` values) for every
+    unit it owns.
+    """
+    units_per_core = -(-out_units // NUM_CORES)
+    return units_per_core * contracting * kernel_elems * ITEMSIZE_BYTES
+
+
+def hits_notch(payload_bytes: int) -> bool:
+    """Whether a per-core payload of ``payload_bytes`` falls in a DMA notch.
+
+    True when the payload is within :data:`WINDOW_BYTES` of a multiple of
+    :data:`NOTCH_BYTES`. Payloads below the first notch are never affected: the
+    ring has to wrap at least once for the stall to happen, so a transfer that
+    stays inside the very first lap is fine however close to 0 it is.
+    """
+    if payload_bytes < NOTCH_BYTES - WINDOW_BYTES:
+        return False
+    remainder = payload_bytes % NOTCH_BYTES
+    distance = min(remainder, NOTCH_BYTES - remainder)
+    return distance < WINDOW_BYTES
+
+
+def chunk_sizes(contracting: int, splits: int) -> list[int]:
+    """Split ``contracting`` into ``splits`` near-equal parts, biggest first."""
+    base, remainder = divmod(contracting, splits)
+    return [base + 1] * remainder + [base] * (splits - remainder)
+
+
+def choose_chunks(out_units: int, contracting: int, kernel_elems: int) -> list[int] | None:
+    """Chunk sizes along the contracting axis that take every partial out of the notch.
+
+    Returns the split with the fewest chunks that works (fewer chunks means
+    fewer slices and adds), or ``None`` when no split up to :data:`MAX_SPLITS`
+    does -- in which case the caller leaves the op alone.
+
+    The chunks need not divide ``contracting`` evenly, which is where this
+    differs from the hand-written splits in the blog post: for a 2 MiB payload
+    it picks 3 near-equal chunks of ~0.67 MiB, where the post (splitting only
+    into equal powers of two) used 4 chunks of 0.5 MiB. The 0.67 MiB chunk is
+    closer to a multiple of 1 MiB than the 0.5 MiB one is (0.33 MiB against
+    0.5 MiB), but both stay inside the first lap of the ring, where
+    :func:`hits_notch` says the stall cannot occur, and both measure the same on
+    the ANE; three chunks cost one slice and one add less.
+    """
+    for splits in range(2, min(MAX_SPLITS, contracting) + 1):
+        sizes = chunk_sizes(contracting, splits)
+        if all(
+            not hits_notch(per_core_payload_bytes(out_units, size, kernel_elems))
+            for size in sizes
+        ):
+            return sizes
+    return None
+
+
+def _const_fp16_weight(var) -> np.ndarray | None:
+    """``var``'s value if it is a plain fp16 ``const`` with a static shape.
+
+    ``constexpr_*`` weights (palettized, quantized, sparse) are deliberately
+    rejected: they are decompressed by the hardware, so the bytes that reach the
+    DMA engine are not the ones this pass can count.
+    """
+    if var is None or var.dtype != types.fp16:
+        return None
+    op = getattr(var, "op", None)
+    if op is None or op.op_type != "const":
+        return None
+    if var.shape is None or any(is_symbolic(dim) for dim in var.shape):
+        return None
+    val = var.val
+    if val is None:
+        return None
+    return np.asarray(val)
+
+
+def _static_dim(shape, axis: int) -> int | None:
+    """``shape[axis]`` as an int, or ``None`` if unknown or symbolic."""
+    if shape is None or axis >= len(shape):
+        return None
+    dim = shape[axis]
+    if is_symbolic(dim):
+        return None
+    return int(dim)
+
+
+def _match(op):
+    """Describe how to split ``op``, or return ``None``.
+
+    The result is ``(weight, x_axis, weight_axis, out_units, kernel_elems)``:
+    the constant weight array, the contracting axis of ``x``, the axis of the
+    weight holding the same dimension, the number of output units ``N``, and the
+    number of weight elements per (output unit, input channel) pair.
+    """
+    weight_input = _WEIGHT_INPUT.get(op.op_type)
+    if weight_input is None:
+        return None
+
+    weight = _const_fp16_weight(op.inputs.get(weight_input))
+    if weight is None:
+        return None
+
+    x = op.inputs["x"]
+    if x.shape is None:
+        return None
+
+    if op.op_type == "conv":
+        # [C_out, C_in / groups, *kernel]; x is [N, C_in, *spatial].
+        groups = op.inputs["groups"].val
+        if groups is None or int(groups) != 1:
+            # With groups > 1 a core only streams its own group's slice of the
+            # weight, and the contracting dimension is per-group: a different
+            # payload model, and splitting C_in would cross group boundaries.
+            return None
+        if weight.ndim < 3 or x.rank != weight.ndim:
+            return None
+        out_units = int(weight.shape[0])
+        kernel_elems = int(np.prod(weight.shape[2:]))
+        x_axis, weight_axis = 1, 1
+    elif op.op_type == "linear":
+        # [N, D]; x is [..., D].
+        if weight.ndim != 2:
+            return None
+        out_units = int(weight.shape[0])
+        kernel_elems = 1
+        x_axis, weight_axis = x.rank - 1, 1
+    else:  # matmul
+        if op.inputs["transpose_x"].val:
+            # Then the contracting axis of x is not its last one; rare enough
+            # that v1 skips it rather than guessing.
+            return None
+        if weight.ndim != 2:
+            return None
+        transpose_y = bool(op.inputs["transpose_y"].val)
+        # y is [N, D] when transposed, [D, N] otherwise.
+        out_units = int(weight.shape[0] if transpose_y else weight.shape[1])
+        kernel_elems = 1
+        x_axis, weight_axis = x.rank - 1, 1 if transpose_y else 0
+
+    if x_axis < 0:
+        return None
+    if _static_dim(x.shape, x_axis) != int(weight.shape[weight_axis]):
+        # Either the contracting dimension of x is symbolic/unknown, or it does
+        # not line up with the weight (a broadcasting matmul, say).
+        return None
+
+    return weight, x_axis, weight_axis, out_units, kernel_elems
+
+
+def _slice_along(x, axis: int, begin: int, end: int, before_op):
+    """``x[..., begin:end, ...]`` along ``axis``, leaving every other axis whole.
+
+    Spelled with ``slice_by_index`` and begin/end masks rather than
+    ``slice_by_size``: this is the form that stays on the ANE, and the masks keep
+    the other axes symbolic-safe (their sizes are never mentioned).
+    """
+    rank = x.rank
+    begin_indices, end_indices = [0] * rank, [0] * rank
+    begin_indices[axis], end_indices[axis] = begin, end
+    # Every other axis is covered by its mask, so its size is never spelled out
+    # and may stay symbolic.
+    begin_mask, end_mask = [True] * rank, [True] * rank
+    begin_mask[axis] = end_mask[axis] = False
+    return mb.slice_by_index(
+        x=x,
+        begin=begin_indices,
+        end=end_indices,
+        begin_mask=begin_mask,
+        end_mask=end_mask,
+        before_op=before_op,
+    )
+
+
+def _partial(op, x_chunk, weight_chunk, weight_input: str, keep_bias: bool):
+    """Rebuild ``op`` on one chunk, keeping every other attribute as it was."""
+    kwargs = dict(op.inputs)
+    kwargs["x"] = x_chunk
+    kwargs[weight_input] = weight_chunk
+    if not keep_bias:
+        # The bias is a constant added to the result, not part of the product,
+        # so exactly one partial may carry it.
+        kwargs.pop("bias", None)
+    return getattr(mb, op.op_type)(**kwargs, before_op=op)
+
+
+@register_pass(namespace="common")
+class avoid_ane_dma_notch(RewritePass):
+    """
+    Split ``conv``/``linear``/``matmul`` ops whose per-core fp16 weight payload is
+    a multiple of 1 MiB into partial products that are not, and sum them.
+
+    Works around the Apple Neural Engine kernel-DMA prefetch erratum
+    (https://eiln.github.io/posts/ane-dma.html), which throttles DRAM weight
+    streaming from ~40-60 GB/s to ~17-25 GB/s whenever a core has to stream an
+    exact multiple of the 1 MiB prefetch ring. See the module docstring for the
+    payload model and the measured numbers.
+
+    Only plain fp16 ``const`` weights with static shapes are split, and only
+    along the contracting (input-channel) dimension, where the op is linear.
+    The op is left alone when no split into at most ``MAX_SPLITS`` chunks takes
+    every chunk out of the notch.
+
+    Given (``x`` is ``[1, 4096, 1, 1]``, so each of the 16 cores streams exactly
+    1 MiB of the ``[2048, 4096, 1, 1]`` weight):
+        %y = conv(x=%x, weight=%w)
+
+    Result:
+        %x0 = slice_by_index(x=%x, begin=[0, 0, 0, 0], end=[0, 2048, 0, 0], ...)
+        %x1 = slice_by_index(x=%x, begin=[0, 2048, 0, 0], end=[0, 4096, 0, 0], ...)
+        %y0 = conv(x=%x0, weight=%w[:, :2048])
+        %y1 = conv(x=%x1, weight=%w[:, 2048:])
+        %y  = add(x=%y0, y=%y1)
+
+    This pass is opt-in: it helps on the ANE only, and costs a slice per partial
+    and an add per extra partial everywhere else. Enable it with
+    ``build_pass_pipeline(avoid_ane_dma_notch=True)``.
+    """
+
+    _REWRITES = "weight-streaming op(s)"
+
+    def visit(self, op, block) -> bool:
+        match = _match(op)
+        if match is None:
+            return False
+        weight, x_axis, weight_axis, out_units, kernel_elems = match
+
+        contracting = int(weight.shape[weight_axis])
+        payload = per_core_payload_bytes(out_units, contracting, kernel_elems)
+        if not hits_notch(payload):
+            return False
+
+        sizes = choose_chunks(out_units, contracting, kernel_elems)
+        if sizes is None:
+            logger.debug(
+                "%s: %s has a %d byte per-core payload in the DMA notch, but no split "
+                "into at most %d chunks avoids it; leaving it alone",
+                type(self).__name__, op.name, payload, MAX_SPLITS,
+            )
+            return False
+
+        weight_input = _WEIGHT_INPUT[op.op_type]
+        partials = []
+        offset = 0
+        for index, size in enumerate(sizes):
+            chunk = [slice(None)] * weight.ndim
+            chunk[weight_axis] = slice(offset, offset + size)
+            partials.append(
+                _partial(
+                    op,
+                    _slice_along(op.inputs["x"], x_axis, offset, offset + size, before_op=op),
+                    np.ascontiguousarray(weight[tuple(chunk)]),
+                    weight_input,
+                    keep_bias=index == 0,
+                )
+            )
+            offset += size
+
+        # Sequentially, so that the partials are consumed in the order they are
+        # produced; only the last add takes over the name of the op it replaces.
+        total = partials[0]
+        last = len(partials) - 1
+        for index, partial in enumerate(partials[1:], start=1):
+            named = {"name": op.outputs[0].name} if index == last else {}
+            total = mb.add(x=total, y=partial, before_op=op, **named)
+
+        block.replace_uses_of_var_after_op(anchor_op=op, old_var=op.outputs[0], new_var=total)
+        return True

--- a/stablehlo_coreml/passes/utils.py
+++ b/stablehlo_coreml/passes/utils.py
@@ -10,6 +10,7 @@ import copy
 import coremltools as ct
 
 # Importing the pass modules registers them in coremltools' PASS_REGISTRY.
+from . import avoid_ane_dma_notch as _avoid_ane_dma_notch  # noqa: F401
 from . import broadcast_select_operands as _broadcast_select_operands  # noqa: F401
 from . import fuse_attention_to_sdpa as _fuse_attention_to_sdpa  # noqa: F401
 from . import fuse_gelu_erfc as _fuse_gelu_erfc  # noqa: F401
@@ -82,12 +83,29 @@ LATE_FUSION_PASSES: list[str] = [
     _DCE,
 ]
 
+# Apple Neural Engine workarounds. Opt-in (see `build_pass_pipeline`): the DMA
+# notch they avoid only exists on the ANE, and the extra slices/adds are a small
+# loss on the GPU and the CPU.
+#
+# The group runs late, after `common::add_fp16_cast` and the `const_elimination`
+# that follows it: `avoid_ane_dma_notch` only matches plain fp16 `const` weights,
+# which is what the graph holds at that point, and its payload model is about the
+# fp16 bytes that actually reach the hardware.
+ANE_PASSES: list[str] = [
+    "common::avoid_ane_dma_notch",
+    _DCE,
+]
+
 # The pass the CLEANUP group is inserted before (fallback: the front of the pipeline).
 _CLEANUP_ANCHOR = "common::const_elimination"
 # The pass the FUSION group is inserted before (fallback: the end of the pipeline).
 _FUSION_ANCHOR = "common::fuse_matmul_weight_bias"
 # The pass the LATE_FUSION group is inserted after (fallback: the end of the pipeline).
 _LATE_FUSION_ANCHOR = "common::fuse_reduce_mean"
+# The pass the ANE group is inserted before (fallback: the end of the pipeline).
+# By then the weights are fp16 constants, and the split ops still get to run
+# through the trailing `fuse_transpose_matmul` / DCE / `topological_reorder`.
+_ANE_ANCHOR = "common::merge_affine_dequantize_with_consecutive_ops"
 
 
 def _contains_group(passes: list[str], group: list[str]) -> bool:
@@ -131,12 +149,23 @@ def _insert_passes(
         pipeline.insert_pass(index=index + offset, pass_name=pass_name)
 
 
-def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
+def build_pass_pipeline(
+    base: ct.PassPipeline | None = None,
+    *,
+    avoid_ane_dma_notch: bool = False,
+) -> ct.PassPipeline:
     """Return a new pipeline: ``base`` with the stablehlo-coreml passes inserted.
 
     ``base`` defaults to ``ct.PassPipeline.DEFAULT``. The input pipeline is never
     mutated, and inserting into a pipeline that already contains our passes is a
     no-op for those passes.
+
+    ``avoid_ane_dma_notch`` additionally inserts :data:`ANE_PASSES`, which splits
+    weight-streaming ops whose per-core fp16 weight payload is a multiple of 1 MiB
+    (see :mod:`stablehlo_coreml.passes.avoid_ane_dma_notch`). Only turn it on for
+    models that run on the Apple Neural Engine: the erratum it works around does
+    not exist on the GPU or the CPU, where the extra slices and adds are a small
+    loss.
     """
     # `ct.PassPipeline.DEFAULT` already hands out a fresh object on every access.
     pipeline = ct.PassPipeline.DEFAULT if base is None else copy.deepcopy(base)
@@ -144,5 +173,7 @@ def build_pass_pipeline(base: ct.PassPipeline | None = None) -> ct.PassPipeline:
     _insert_passes(pipeline, CLEANUP_PASSES, _CLEANUP_ANCHOR, fallback_index=0)
     _insert_passes(pipeline, FUSION_PASSES, _FUSION_ANCHOR, fallback_index=None)
     _insert_passes(pipeline, LATE_FUSION_PASSES, _LATE_FUSION_ANCHOR, fallback_index=None, after=True)
+    if avoid_ane_dma_notch:
+        _insert_passes(pipeline, ANE_PASSES, _ANE_ANCHOR, fallback_index=None)
 
     return pipeline

--- a/tests/passes/test_avoid_ane_dma_notch.py
+++ b/tests/passes/test_avoid_ane_dma_notch.py
@@ -1,0 +1,680 @@
+import coremltools as ct
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coremltools.converters.mil.mil import Builder as mb
+from coremltools.converters.mil.mil import get_new_symbol, types
+from coremltools.converters.mil.testing_utils import get_op_types_in_program
+
+from stablehlo_coreml import build_pass_pipeline, convert
+from stablehlo_coreml.passes.avoid_ane_dma_notch import (
+    MAX_SPLITS,
+    NOTCH_BYTES,
+    NUM_CORES,
+    WINDOW_BYTES,
+    choose_chunks,
+    chunk_sizes,
+    hits_notch,
+    per_core_payload_bytes,
+)
+from tests.passes.helpers import apply_pass, count_ops, ops_of_type, predict
+from tests.utils import export_hlo_module, get_model_instruction_types
+
+PASS_NAME = "common::avoid_ane_dma_notch"
+
+KIB = 1 << 10
+MIB = 1 << 20
+
+# The shape the erratum was measured on: a 1x1 convolution with 2048 output and
+# 4096 input channels streams ceil(2048/16) * 4096 * 2 == exactly 1 MiB per core.
+NOTCH_OUT, NOTCH_IN = 2048, 4096
+# Same number of cores' worth of work, one line-window below the notch: 126
+# units per core instead of 128, i.e. 1 MiB - 16 KiB, right at the edge of the
+# window where throughput has recovered.
+CONTROL_OUT = 2016
+
+# Tolerance for comparing a converted program's fp16 output against an fp32
+# reference. Every numeric test below runs a 4096-term reduction at the notch
+# shape, whose outputs have magnitude ~5, where one fp16 ulp is 0.004. Measured
+# over 12 seeds of each configuration on macOS 26.6 / coremltools 9.0, Core ML's
+# CPU fp16 kernels land at most 0.074 (split program) and 0.097 (unsplit) from
+# fp32; the regrouping this pass does is worth ~1 ulp of that, the rest is the
+# kernels' own accumulation order. Anything the pass could get structurally
+# wrong -- a slice with the wrong bounds, a dropped or repeated partial, a bias
+# applied twice -- moves an output by a good fraction of its own magnitude, far
+# past this.
+FP16_REDUCTION_ATOL = 0.25
+
+
+def _weight(*shape, dtype=np.float16):
+    """A weight constant of the given shape. The values never matter structurally."""
+    return np.zeros(shape, dtype=dtype)
+
+
+def _apply(prog):
+    apply_pass(prog, PASS_NAME)
+
+
+def _conv_prog(weight, x_shape, *, bias=None, **conv_kwargs):
+    @mb.program(
+        input_specs=[mb.TensorSpec(shape=x_shape, dtype=types.fp16)],
+        opset_version=ct.target.iOS18,
+    )
+    def prog(x):
+        kwargs = dict(conv_kwargs)
+        if bias is not None:
+            kwargs["bias"] = bias
+        return mb.conv(x=x, weight=weight, **kwargs)
+
+    return prog
+
+
+class TestPayloadModel:
+    """The arithmetic the pass decides on, without any MIL around it."""
+
+    def test_the_measured_notch_shape_is_exactly_one_mib_per_core(self):
+        assert per_core_payload_bytes(NOTCH_OUT, NOTCH_IN, 1) == MIB
+
+    def test_the_control_shape_sits_at_the_edge_of_the_window(self):
+        payload = per_core_payload_bytes(CONTROL_OUT, NOTCH_IN, 1)
+        assert payload == MIB - WINDOW_BYTES
+        assert not hits_notch(payload)
+
+    def test_output_units_are_rounded_up_to_whole_cores(self):
+        """A core that owns one extra unit streams the whole contracting dim for it."""
+        assert per_core_payload_bytes(NUM_CORES + 1, 1024, 1) == 2 * 1024 * 2
+
+    def test_kernel_elements_count_towards_the_payload(self):
+        assert per_core_payload_bytes(16, 512, 32 * 32) == MIB
+
+    @pytest.mark.parametrize("multiple", [1, 2, 6, 7])
+    def test_exact_multiples_of_the_ring_size_hit_the_notch(self, multiple):
+        assert hits_notch(multiple * NOTCH_BYTES)
+
+    @pytest.mark.parametrize("offset", [-WINDOW_BYTES + 64, -64, 64, WINDOW_BYTES - 64])
+    def test_payloads_inside_the_window_hit_the_notch(self, offset):
+        assert hits_notch(2 * NOTCH_BYTES + offset)
+
+    @pytest.mark.parametrize("offset", [-WINDOW_BYTES, WINDOW_BYTES, 3 * WINDOW_BYTES])
+    def test_payloads_outside_the_window_do_not(self, offset):
+        assert not hits_notch(2 * NOTCH_BYTES + offset)
+
+    @pytest.mark.parametrize("payload", [0, 64 * KIB, MIB - WINDOW_BYTES - 64])
+    def test_payloads_below_the_first_notch_never_hit_it(self, payload):
+        """The ring has to wrap at least once before the prefetcher stalls."""
+        assert not hits_notch(payload)
+
+    def test_chunk_sizes_are_equal_when_they_divide(self):
+        assert chunk_sizes(4096, 4) == [1024] * 4
+
+    def test_chunk_sizes_spread_the_remainder_over_the_first_chunks(self):
+        assert chunk_sizes(4096, 3) == [1366, 1365, 1365]
+        assert sum(chunk_sizes(4099, 8)) == 4099
+
+    @pytest.mark.parametrize(
+        "laps, expected_chunks",
+        [
+            pytest.param(2, 3, id="2MiB"),
+            pytest.param(3, 2, id="3MiB"),
+            pytest.param(5, 2, id="5MiB"),
+            pytest.param(6, 4, id="6MiB"),
+            pytest.param(7, 2, id="7MiB"),
+        ],
+    )
+    def test_split_counts_for_the_payloads_seen_in_real_models(self, laps, expected_chunks):
+        """The affected projections listed in the blog post, as payload laps.
+
+        The post splits 2 MiB four ways (4 x 0.5 MiB) because it only considered
+        splits that divide the contracting dimension evenly; three near-equal
+        chunks of ~0.67 MiB clear the notch just as well and cost one partial
+        less, so that is what this pass picks.
+        """
+        # 1024 input channels per lap, so that `laps` laps is `laps` MiB per core.
+        contracting, kernel = 1024 * laps, 512
+        assert per_core_payload_bytes(NUM_CORES, contracting, kernel) == laps * MIB
+        chunks = choose_chunks(NUM_CORES, contracting, kernel)
+        assert len(chunks) == expected_chunks
+        assert sum(chunks) == contracting
+        assert all(
+            not hits_notch(per_core_payload_bytes(NUM_CORES, chunk, kernel)) for chunk in chunks
+        )
+
+    def test_the_two_mib_chunks_clear_the_notch_without_being_equidistant(self):
+        """Why three near-equal chunks are as safe as the blog's four equal ones.
+
+        Not because they are equally far from a multiple of 1 MiB -- they are
+        not, 0.33 MiB against 0.5 MiB -- but because both land inside the very
+        first lap of the prefetch ring, below the first notch altogether.
+        """
+        out_units = 4096  # 4096 x 4096, the 2 MiB per core shape
+        assert per_core_payload_bytes(out_units, NOTCH_IN, 1) == 2 * MIB
+
+        chunks = choose_chunks(out_units, NOTCH_IN, 1)
+        assert chunks == [1366, 1365, 1365]
+        payloads = [per_core_payload_bytes(out_units, chunk, 1) for chunk in chunks]
+        blog_payload = per_core_payload_bytes(out_units, NOTCH_IN // 4, 1)
+        assert blog_payload == MIB // 2
+
+        def distance_to_a_multiple(payload):
+            remainder = payload % NOTCH_BYTES
+            return min(remainder, NOTCH_BYTES - remainder)
+
+        # Closer to 1 MiB than the blog's 0.5 MiB chunks, and still clear: below
+        # the first notch, so `hits_notch` says the ring never wraps.
+        assert all(distance_to_a_multiple(p) < distance_to_a_multiple(blog_payload)
+                   for p in payloads)
+        assert all(p < NOTCH_BYTES - WINDOW_BYTES for p in payloads)
+        assert not any(hits_notch(p) for p in payloads)
+
+    def test_no_split_is_reported_when_every_chunk_count_stays_in_the_notch(self):
+        """A contracting dimension of 1 cannot be split at all."""
+        assert choose_chunks(NUM_CORES * MIB // 2, 1, 1) is None
+
+    def test_splits_never_exceed_the_bound(self):
+        chunks = choose_chunks(NUM_CORES, 1024 * 6, 512)
+        assert 2 <= len(chunks) <= MAX_SPLITS
+
+
+class TestAvoidAneDmaNotch:
+    """Unit tests on hand-built MIL programs."""
+
+    def test_conv_1x1_in_the_notch_is_split(self):
+        prog = _conv_prog(_weight(NOTCH_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1))
+        _apply(prog)
+        assert get_op_types_in_program(prog) == [
+            "slice_by_index", "conv", "slice_by_index", "conv", "add",
+        ]
+
+        convs = ops_of_type(prog, "conv")
+        assert [conv.weight.shape for conv in convs] == [
+            (NOTCH_OUT, NOTCH_IN // 2, 1, 1),
+            (NOTCH_OUT, NOTCH_IN // 2, 1, 1),
+        ]
+        assert [conv.x.shape for conv in convs] == [
+            (1, NOTCH_IN // 2, 1, 1),
+            (1, NOTCH_IN // 2, 1, 1),
+        ]
+
+    def test_the_partials_slice_consecutive_chunks_of_the_weight(self):
+        weight = np.arange(NOTCH_OUT * NOTCH_IN, dtype=np.float16).reshape(
+            NOTCH_OUT, NOTCH_IN, 1, 1
+        )
+        prog = _conv_prog(weight, (1, NOTCH_IN, 1, 1))
+        _apply(prog)
+
+        first, second = ops_of_type(prog, "conv")
+        np.testing.assert_array_equal(first.weight.val, weight[:, : NOTCH_IN // 2])
+        np.testing.assert_array_equal(second.weight.val, weight[:, NOTCH_IN // 2:])
+
+    def test_the_slices_cover_the_contracting_axis_and_nothing_else(self):
+        prog = _conv_prog(_weight(NOTCH_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1))
+        _apply(prog)
+
+        first, second = ops_of_type(prog, "slice_by_index")
+        assert list(first.begin.val) == [0, 0, 0, 0]
+        assert list(first.end.val) == [0, NOTCH_IN // 2, 0, 0]
+        assert list(second.begin.val) == [0, NOTCH_IN // 2, 0, 0]
+        assert list(second.end.val) == [0, NOTCH_IN, 0, 0]
+        # Every axis but the contracting one is left to the masks, so that a
+        # symbolic size never has to be spelled out.
+        for op in (first, second):
+            assert list(op.begin_mask.val) == [True, False, True, True]
+            assert list(op.end_mask.val) == [True, False, True, True]
+
+    def test_control_shape_is_left_alone(self):
+        prog = _conv_prog(_weight(CONTROL_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1))
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["conv"]
+
+    def test_payload_just_inside_the_window_is_split(self):
+        """1 MiB - 8 KiB per core: still on the slope of the V, so still split."""
+        contracting = NOTCH_IN - 32
+        assert per_core_payload_bytes(NOTCH_OUT, contracting, 1) == MIB - 8 * KIB
+
+        prog = _conv_prog(_weight(NOTCH_OUT, contracting, 1, 1), (1, contracting, 1, 1))
+        _apply(prog)
+        assert count_ops(prog, "conv") == 2
+
+    def test_bias_is_applied_once(self):
+        bias = np.arange(NOTCH_OUT, dtype=np.float16)
+        prog = _conv_prog(_weight(NOTCH_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1), bias=bias)
+        _apply(prog)
+
+        first, second = ops_of_type(prog, "conv")
+        np.testing.assert_array_equal(first.bias.val, bias)
+        assert second.bias is None
+
+    def test_conv_attributes_are_preserved(self):
+        # 3x3 over 512 Ki input channels is 9 MiB per core, a notch multiple.
+        # A single output channel keeps the constant itself at 9 MiB, where a
+        # [2048, 4096, 3, 3] weight with the same per-core payload would be
+        # 144 MiB and the pass would then copy it twice.
+        contracting = 512 * KIB
+        assert per_core_payload_bytes(1, contracting, 9) == 9 * MIB
+        prog = _conv_prog(
+            _weight(1, contracting, 3, 3),
+            (1, contracting, 8, 8),
+            strides=[2, 2],
+            pad_type="custom",
+            pad=[1, 2, 3, 4],
+            dilations=[2, 3],
+        )
+        _apply(prog)
+
+        for conv in ops_of_type(prog, "conv"):
+            assert list(conv.strides.val) == [2, 2]
+            assert conv.pad_type.val == "custom"
+            assert list(conv.pad.val) == [1, 2, 3, 4]
+            assert list(conv.dilations.val) == [2, 3]
+            assert conv.groups.val == 1
+        assert count_ops(prog, "conv") == 2
+
+    def test_symbolic_batch_is_split(self):
+        batch = get_new_symbol()
+        prog = _conv_prog(_weight(NOTCH_OUT, NOTCH_IN, 1, 1), (batch, NOTCH_IN, 1, 1))
+        _apply(prog)
+        assert count_ops(prog, "conv") == 2
+        assert prog.functions["main"].outputs[0].shape == (batch, NOTCH_OUT, 1, 1)
+
+    def test_two_mib_payload_needs_more_than_two_chunks(self):
+        """Halving a 2 MiB payload lands on 1 MiB, which is the notch again."""
+        weight = _weight(1, 1024, 32, 32)  # 2 MiB per core, on a single core
+        prog = _conv_prog(weight, (1, 1024, 32, 32))
+        assert per_core_payload_bytes(1, 1024, 32 * 32) == 2 * MIB
+        _apply(prog)
+        assert count_ops(prog, "conv") == 3
+        assert count_ops(prog, "add") == 2
+        assert [conv.weight.shape[1] for conv in ops_of_type(prog, "conv")] == [342, 341, 341]
+
+    @pytest.mark.parametrize(
+        "weight_shape, x_shape, splits",
+        [
+            pytest.param((NOTCH_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1), 2, id="2-way"),
+            pytest.param((1, 1024, 32, 32), (1, 1024, 32, 32), 3, id="3-way"),
+        ],
+    )
+    def test_a_k_way_split_costs_k_slices_and_k_minus_one_adds(
+        self, weight_shape, x_shape, splits
+    ):
+        """Every partial gets its own slice, the first one included."""
+        prog = _conv_prog(_weight(*weight_shape), x_shape)
+        _apply(prog)
+        assert count_ops(prog, "conv") == splits
+        assert count_ops(prog, "slice_by_index") == splits
+        assert count_ops(prog, "add") == splits - 1
+
+    def test_grouped_conv_is_skipped(self):
+        prog = _conv_prog(
+            _weight(NOTCH_OUT, NOTCH_IN // 2, 1, 1), (1, NOTCH_IN, 1, 1), groups=2
+        )
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["conv"]
+
+    def test_fp32_weight_is_skipped(self):
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(1, NOTCH_IN, 1, 1), dtype=types.fp32)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            return mb.conv(x=x, weight=_weight(NOTCH_OUT, NOTCH_IN, 1, 1, dtype=np.float32))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["conv"]
+
+    def test_runtime_weight_is_skipped(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1, NOTCH_IN, 1, 1), dtype=types.fp16),
+                mb.TensorSpec(shape=(NOTCH_OUT, NOTCH_IN, 1, 1), dtype=types.fp16),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, weight):
+            return mb.conv(x=x, weight=weight)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["conv"]
+
+    def test_constexpr_weight_is_skipped(self):
+        """A palettized weight is decompressed on the fly; its DMA payload is not
+        the number of fp16 elements the pass would count."""
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(1, NOTCH_IN, 1, 1), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            weight = mb.constexpr_blockwise_shift_scale(
+                data=np.zeros((NOTCH_OUT, NOTCH_IN, 1, 1), dtype=np.int8),
+                scale=np.ones((NOTCH_OUT, 1, 1, 1), dtype=np.float16),
+            )
+            return mb.conv(x=x, weight=weight)
+
+        _apply(prog)
+        assert count_ops(prog, "conv") == 1
+        assert count_ops(prog, "slice_by_index") == 0
+
+    def test_weight_with_other_consumers_is_still_split(self):
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(1, NOTCH_IN, 1, 1), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            weight = mb.const(val=_weight(NOTCH_OUT, NOTCH_IN, 1, 1))
+            return mb.conv(x=x, weight=weight), mb.mul(x=weight, y=np.float16(2.0))
+
+        _apply(prog)
+        assert count_ops(prog, "conv") == 2
+        # The shared constant stays: the `mul` still reads it.
+        assert count_ops(prog, "mul") == 1
+
+    @pytest.mark.parametrize("with_bias", [True, False], ids=["with_bias", "without_bias"])
+    def test_linear_is_split(self, with_bias):
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(3, NOTCH_IN), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            kwargs = {"bias": np.arange(NOTCH_OUT, dtype=np.float16)} if with_bias else {}
+            return mb.linear(x=x, weight=_weight(NOTCH_OUT, NOTCH_IN), **kwargs)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == [
+            "slice_by_index", "linear", "slice_by_index", "linear", "add",
+        ]
+        first, second = ops_of_type(prog, "linear")
+        assert first.weight.shape == (NOTCH_OUT, NOTCH_IN // 2)
+        # `linear` always materialises a bias (zeros when the caller gave none),
+        # so "applied once" means the real one sits on the first partial only.
+        zeros = np.zeros(NOTCH_OUT, dtype=np.float16)
+        expected = np.arange(NOTCH_OUT, dtype=np.float16) if with_bias else zeros
+        np.testing.assert_array_equal(first.bias.val, expected)
+        np.testing.assert_array_equal(second.bias.val, zeros)
+
+    @pytest.mark.parametrize("transpose_y", [True, False])
+    def test_matmul_is_split(self, transpose_y):
+        weight_shape = (NOTCH_OUT, NOTCH_IN) if transpose_y else (NOTCH_IN, NOTCH_OUT)
+        weight = np.arange(NOTCH_OUT * NOTCH_IN, dtype=np.float16).reshape(weight_shape)
+
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(3, NOTCH_IN), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            return mb.matmul(x=x, y=weight, transpose_y=transpose_y)
+
+        _apply(prog)
+        assert count_ops(prog, "matmul") == 2
+
+        half = NOTCH_IN // 2
+        first, second = ops_of_type(prog, "matmul")
+        assert bool(first.transpose_y.val) == transpose_y
+        if transpose_y:
+            np.testing.assert_array_equal(first.y.val, weight[:, :half])
+            np.testing.assert_array_equal(second.y.val, weight[:, half:])
+        else:
+            np.testing.assert_array_equal(first.y.val, weight[:half])
+            np.testing.assert_array_equal(second.y.val, weight[half:])
+
+    def test_matmul_with_transposed_x_is_skipped(self):
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(NOTCH_IN, 3), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            return mb.matmul(
+                x=x, y=_weight(NOTCH_OUT, NOTCH_IN), transpose_x=True, transpose_y=True
+            )
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["matmul"]
+
+    def test_matmul_with_a_batched_weight_is_skipped(self):
+        """A rank-3 constant `y` is a batch of products, not one weight matrix."""
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(2, 3, NOTCH_IN), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            return mb.matmul(x=x, y=_weight(2, NOTCH_IN, NOTCH_OUT))
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["matmul"]
+
+    def test_matmul_with_a_constant_x_is_skipped(self):
+        """Only the `y` operand is treated as the streamed weight."""
+        @mb.program(
+            input_specs=[mb.TensorSpec(shape=(NOTCH_IN, 3), dtype=types.fp16)],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x):
+            return mb.matmul(x=_weight(NOTCH_OUT, NOTCH_IN), y=x)
+
+        _apply(prog)
+        assert get_op_types_in_program(prog) == ["matmul"]
+
+    def test_split_inside_a_nested_block(self):
+        @mb.program(
+            input_specs=[
+                mb.TensorSpec(shape=(1, NOTCH_IN, 1, 1), dtype=types.fp16),
+                mb.TensorSpec(shape=(1,), dtype=types.bool),
+            ],
+            opset_version=ct.target.iOS18,
+        )
+        def prog(x, pred):
+            def true_fn():
+                return mb.conv(x=x, weight=_weight(NOTCH_OUT, NOTCH_IN, 1, 1))
+
+            def false_fn():
+                return mb.conv(x=x, weight=_weight(NOTCH_OUT, NOTCH_IN, 1, 1) + 1)
+
+            return mb.cond(pred=mb.squeeze(x=pred), _true_fn=true_fn, _false_fn=false_fn)
+
+        _apply(prog)
+        assert count_ops(prog, "conv", recurse=True) == 4
+        assert count_ops(prog, "add", recurse=True) == 2
+
+    def test_is_idempotent(self):
+        prog = _conv_prog(_weight(NOTCH_OUT, NOTCH_IN, 1, 1), (1, NOTCH_IN, 1, 1))
+        _apply(prog)
+        after_first = get_op_types_in_program(prog)
+        _apply(prog)
+        assert get_op_types_in_program(prog) == after_first
+
+
+class TestAvoidAneDmaNotchNumerics:
+    """The split has to compute the same thing, to within fp16 accuracy.
+
+    The comparison is against an fp32 numpy reference rather than against the
+    unsplit program. Both programs run Core ML's CPU fp16 kernels, and the
+    order those kernels accumulate a 4096-term reduction in costs far more
+    accuracy than the regrouping this pass does: measured on macOS 26.6 /
+    coremltools 9.0, regrouping the reduction into two partials that are each
+    accumulated in fp32, rounded to fp16 and added moves the result by ~1 ulp,
+    while the two programs land 0.04-0.10 apart -- and with
+    ``transpose_y=False`` it is the *unsplit* result that is the further of the
+    two from fp32. So a split-vs-unsplit bound would be a bound on the CPU
+    kernels, which a Core ML update can change without any defect here.
+    Bounding each program against fp32 is a real accuracy bound instead.
+    """
+
+    def _check(self, build, x, reference, op_type, partials=2):
+        """Both the unsplit and the split program have to match ``reference``."""
+        np.testing.assert_allclose(predict(build(), x=x), reference, atol=FP16_REDUCTION_ATOL, rtol=0)
+
+        prog = build()
+        _apply(prog)
+        assert count_ops(prog, op_type) == partials
+        np.testing.assert_allclose(predict(prog, x=x), reference, atol=FP16_REDUCTION_ATOL, rtol=0)
+
+    def test_conv_partials_sum_to_the_fp32_reference(self):
+        rng = np.random.default_rng(0)
+        weight = (rng.standard_normal((NOTCH_OUT, NOTCH_IN, 1, 1)) * 0.02).astype(np.float16)
+        bias = (rng.standard_normal(NOTCH_OUT) * 0.1).astype(np.float16)
+        x = rng.standard_normal((1, NOTCH_IN, 1, 1)).astype(np.float16)
+
+        reference = (
+            weight[:, :, 0, 0].astype(np.float32) @ x[0, :, 0, 0].astype(np.float32)
+            + bias.astype(np.float32)
+        ).reshape(1, NOTCH_OUT, 1, 1)
+
+        self._check(lambda: _conv_prog(weight, x.shape, bias=bias), x, reference, "conv")
+
+    @pytest.mark.parametrize("transpose_y", [True, False])
+    def test_matmul_partials_sum_to_the_fp32_reference(self, transpose_y):
+        """``transpose_y=False`` is the layout whose unsplit CPU kernel is the looser one."""
+        rng = np.random.default_rng(1)
+        shape = (NOTCH_OUT, NOTCH_IN) if transpose_y else (NOTCH_IN, NOTCH_OUT)
+        weight = (rng.standard_normal(shape) * 0.02).astype(np.float16)
+        x = rng.standard_normal((3, NOTCH_IN)).astype(np.float16)
+
+        def build():
+            @mb.program(
+                input_specs=[mb.TensorSpec(shape=x.shape, dtype=types.fp16)],
+                opset_version=ct.target.iOS18,
+            )
+            def prog(x):
+                return mb.matmul(x=x, y=weight, transpose_y=transpose_y)
+
+            return prog
+
+        weight32 = weight.astype(np.float32)
+        reference = x.astype(np.float32) @ (weight32.T if transpose_y else weight32)
+        self._check(build, x, reference, "matmul")
+
+    def test_linear_partials_sum_to_the_fp32_reference(self):
+        """``linear`` carries a bias that exactly one partial may keep."""
+        rng = np.random.default_rng(2)
+        weight = (rng.standard_normal((NOTCH_OUT, NOTCH_IN)) * 0.02).astype(np.float16)
+        bias = (rng.standard_normal(NOTCH_OUT) * 0.1).astype(np.float16)
+        x = rng.standard_normal((3, NOTCH_IN)).astype(np.float16)
+
+        def build():
+            @mb.program(
+                input_specs=[mb.TensorSpec(shape=x.shape, dtype=types.fp16)],
+                opset_version=ct.target.iOS18,
+            )
+            def prog(x):
+                return mb.linear(x=x, weight=weight, bias=bias)
+
+            return prog
+
+        reference = x.astype(np.float32) @ weight.astype(np.float32).T + bias.astype(np.float32)
+        self._check(build, x, reference, "linear")
+
+    def test_uneven_three_way_split_sums_to_the_fp32_reference(self):
+        """A 2 MiB payload is split into chunks that do not divide the contracting dim.
+
+        ``4096 -> 1366 + 1365 + 1365``: the partials cover different numbers of
+        input channels, so an off-by-one in the running offset would show up
+        here and nowhere else.
+        """
+        out_units = 2 * NOTCH_OUT
+        assert per_core_payload_bytes(out_units, NOTCH_IN, 1) == 2 * MIB
+        sizes = choose_chunks(out_units, NOTCH_IN, 1)
+        assert sizes == [1366, 1365, 1365]
+
+        rng = np.random.default_rng(3)
+        weight = (rng.standard_normal((out_units, NOTCH_IN, 1, 1)) * 0.02).astype(np.float16)
+        x = rng.standard_normal((1, NOTCH_IN, 1, 1)).astype(np.float16)
+
+        reference = (
+            weight[:, :, 0, 0].astype(np.float32) @ x[0, :, 0, 0].astype(np.float32)
+        ).reshape(1, out_units, 1, 1)
+
+        self._check(
+            lambda: _conv_prog(weight, x.shape), x, reference, "conv", partials=len(sizes)
+        )
+
+
+def _convert_jax(jax_func, input_specs, *, avoid_ane_dma_notch):
+    """Convert ``jax_func`` the way a user would, with the ANE group opt-in.
+
+    Unlike ``tests.utils.run_and_compare`` this keeps ``common::add_fp16_cast``:
+    the pass only matches fp16 constants, which is what the weights become once
+    that pass and the ``const_elimination`` behind it have run.
+    """
+    hlo_module = export_hlo_module(jax_func, input_specs)
+    mil_program = convert(hlo_module, minimum_deployment_target=ct.target.iOS18)
+    return ct.convert(
+        mil_program,
+        source="milinternal",
+        minimum_deployment_target=ct.target.iOS18,
+        pass_pipeline=build_pass_pipeline(avoid_ane_dma_notch=avoid_ane_dma_notch),
+        compute_units=ct.ComputeUnit.CPU_ONLY,
+    )
+
+
+def _predict(cml_model, value):
+    name = cml_model.get_spec().description.input[0].name
+    result = cml_model.predict({name: np.asarray(value)})
+    return np.asarray(next(iter(result.values())))
+
+
+class TestAvoidAneDmaNotchEndToEnd:
+    """End-to-end tests going through the real converter + pipeline."""
+
+    @staticmethod
+    def _conv_fn(weight):
+        def f(x):
+            return jax.lax.conv_general_dilated(
+                x, jnp.asarray(weight), (1, 1), "VALID",
+                dimension_numbers=("NCHW", "OIHW", "NCHW"),
+            )
+        return f
+
+    def test_jax_1x1_conv_in_the_notch_is_split(self):
+        rng = np.random.default_rng(0)
+        weight = (rng.standard_normal((NOTCH_OUT, NOTCH_IN, 1, 1)) * 0.02).astype(np.float32)
+        x = rng.standard_normal((1, NOTCH_IN, 1, 1)).astype(np.float32)
+        f = self._conv_fn(weight)
+        specs = [jax.ShapeDtypeStruct(x.shape, jnp.float32)]
+
+        cml_model = _convert_jax(f, specs, avoid_ane_dma_notch=True)
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("conv") == 2
+        assert ops.count("slice_by_index") == 2
+        assert ops.count("add") == 1
+
+        # fp16 weights and a 4096-long reduction, so this is an fp16 comparison.
+        np.testing.assert_allclose(
+            _predict(cml_model, x),
+            np.asarray(f(jnp.asarray(x))),
+            atol=FP16_REDUCTION_ATOL,
+            rtol=0,
+        )
+
+    def test_jax_1x1_conv_is_untouched_without_the_flag(self):
+        rng = np.random.default_rng(0)
+        weight = (rng.standard_normal((NOTCH_OUT, NOTCH_IN, 1, 1)) * 0.02).astype(np.float32)
+        specs = [jax.ShapeDtypeStruct((1, NOTCH_IN, 1, 1), jnp.float32)]
+
+        cml_model = _convert_jax(
+            self._conv_fn(weight), specs, avoid_ane_dma_notch=False
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("conv") == 1
+        assert ops.count("slice_by_index") == 0
+
+    def test_jax_matmul_in_the_notch_is_split(self):
+        rng = np.random.default_rng(2)
+        weight = (rng.standard_normal((NOTCH_IN, NOTCH_OUT)) * 0.02).astype(np.float32)
+        x = rng.standard_normal((3, NOTCH_IN)).astype(np.float32)
+
+        def f(value):
+            return value @ jnp.asarray(weight)
+
+        cml_model = _convert_jax(
+            f, [jax.ShapeDtypeStruct(x.shape, jnp.float32)], avoid_ane_dma_notch=True
+        )
+        ops = get_model_instruction_types(cml_model)
+        assert ops.count("matmul") == 2
+        assert ops.count("slice_by_index") == 2
+        assert ops.count("add") == 1
+
+        np.testing.assert_allclose(
+            _predict(cml_model, x),
+            np.asarray(f(jnp.asarray(x))),
+            atol=FP16_REDUCTION_ATOL,
+            rtol=0,
+        )

--- a/tests/passes/test_pass_pipeline.py
+++ b/tests/passes/test_pass_pipeline.py
@@ -5,6 +5,7 @@ import pytest
 
 from stablehlo_coreml import build_pass_pipeline
 from stablehlo_coreml.passes.utils import (
+    ANE_PASSES,
     CLEANUP_PASSES,
     FUSION_PASSES,
     LATE_FUSION_PASSES,
@@ -16,6 +17,8 @@ from tests.passes.helpers import DCE_PASS_NAME
 # once.
 ALL_PASSES = list(dict.fromkeys(CLEANUP_PASSES + FUSION_PASSES + LATE_FUSION_PASSES))
 OUR_PASSES = [name for name in ALL_PASSES if name != DCE_PASS_NAME]
+# `ANE_PASSES` is opt-in, so it is registered but not part of the default pipeline.
+REGISTERED_PASSES = list(dict.fromkeys(ALL_PASSES + ANE_PASSES))
 # Most of our passes run once, but a pass may belong to more than one group:
 # `fuse_reduce_keep_dims` runs in the cleanup slot and again in the late-fusion
 # slot, where `fuse_reduce_mean` has just made new reduce/reshape pairs visible.
@@ -24,7 +27,7 @@ EXPECTED_PASS_COUNTS = Counter(
 )
 
 
-@pytest.mark.parametrize("pass_name", ALL_PASSES)
+@pytest.mark.parametrize("pass_name", REGISTERED_PASSES)
 def test_pass_is_registered(pass_name):
     from coremltools.converters.mil.mil.passes.pass_pipeline import PASS_REGISTRY  # noqa: PLC0415
     assert pass_name in PASS_REGISTRY
@@ -138,3 +141,41 @@ def test_group_is_inserted_even_when_the_base_already_has_one_of_its_passes():
     passes = build_pass_pipeline(base).passes
     assert passes[: len(CLEANUP_PASSES) + 1] == ["common::fuse_reduce_keep_dims"] + CLEANUP_PASSES
     assert passes.count("common::fuse_reduce_keep_dims") == 3
+
+
+def test_ane_passes_are_absent_unless_asked_for():
+    """The DMA notch only exists on the ANE, so the group has to be opted into."""
+    passes = build_pass_pipeline().passes
+    assert "common::avoid_ane_dma_notch" not in passes
+
+
+def test_ane_passes_run_before_merge_affine_dequantize():
+    passes = build_pass_pipeline(avoid_ane_dma_notch=True).passes
+    anchor = passes.index("common::merge_affine_dequantize_with_consecutive_ops")
+    assert passes[anchor - len(ANE_PASSES):anchor] == ANE_PASSES
+    assert passes.count("common::avoid_ane_dma_notch") == 1
+
+
+def test_ane_group_adds_nothing_but_itself():
+    without = build_pass_pipeline().passes
+    with_ane = build_pass_pipeline(avoid_ane_dma_notch=True).passes
+    index = with_ane.index("common::avoid_ane_dma_notch")
+    assert with_ane[:index] + with_ane[index + len(ANE_PASSES):] == without
+
+
+def test_ane_group_can_be_added_to_a_pipeline_built_without_it():
+    upgraded = build_pass_pipeline(build_pass_pipeline(), avoid_ane_dma_notch=True)
+    assert upgraded.passes == build_pass_pipeline(avoid_ane_dma_notch=True).passes
+
+
+def test_build_pass_pipeline_with_the_ane_group_is_idempotent():
+    once = build_pass_pipeline(avoid_ane_dma_notch=True)
+    assert build_pass_pipeline(once, avoid_ane_dma_notch=True).passes == once.passes
+
+
+def test_ane_group_falls_back_to_the_end_without_its_anchor():
+    base = ct.PassPipeline.EMPTY
+    base.passes = ["common::noop_elimination", DCE_PASS_NAME]
+
+    passes = build_pass_pipeline(base, avoid_ane_dma_notch=True).passes
+    assert passes[-len(ANE_PASSES):] == ANE_PASSES


### PR DESCRIPTION
## What

Adds an **opt-in** MIL graph pass, `common::avoid_ane_dma_notch`, that works around an Apple Neural Engine
kernel-DMA erratum by splitting weight-streaming ops along their contracting dimension.

Enable it with:

```python
pass_pipeline=build_pass_pipeline(avoid_ane_dma_notch=True)
```

It is off by default, and nothing changes for existing callers.

## Why

Eileen Yoon's reverse engineering of the ANE kernel DMA
([*Getting 50 GB/s Back Out of the ANE*](https://eiln.github.io/posts/ane-dma.html)) found that the speculative
prefetch ring computes its distance in a 14-bit line-pointer domain. `0x4000` 64-byte lines is exactly 1 MiB, so a
transfer whose length is an integer multiple of 1 MiB aliases "one full lap remaining" to "empty", the prefetcher
stops issuing lookahead, and the transfer falls onto a serialized path. Measured DRAM weight-streaming throughput
collapses from the nominal 45-60 GB/s to 17-19 GB/s, recovering linearly over a 256-line (16 KiB) window on either
side of every 1 MiB multiple.

The quantity that matters is what **one core** streams. The ANE spreads output units over its 16 cores and each core
streams the whole contracting dimension for the units it owns:

```
payload_bytes = ceil(N / 16) * D * prod(kernel) * 2      # fp16
```

so an ordinary 2048x4096 fp16 projection sits on exactly 1 MiB per core. The post's software workaround is to split
such an op into partial reductions whose payloads are not 1 MiB multiples; it reports 10.0 -> 24.3 tok/s on
Llama 3.2 1B and 1.36 -> 2.97 tok/s on Qwen3-8B for hand-patched models. This pass does that automatically at the
MIL level, from the shapes in the graph.

## What the pass does

Matches leaf `conv`, `linear` and `matmul` ops whose weight is a plain fp16 `const` with a static shape, computes the
per-core payload, and when it lands within 16 KiB of a multiple of 1 MiB, rewrites

```
%y = conv(x=%x, weight=%w)                                    # w is [2048, 4096, 1, 1], 1 MiB/core
```

into the fewest partial products that clear the notch:

```
%x0 = slice_by_index(x=%x, ...)      %y0 = conv(x=%x0, weight=%w[:, :2048])
%x1 = slice_by_index(x=%x, ...)      %y1 = conv(x=%x1, weight=%w[:, 2048:])
%y  = add(x=%y0, y=%y1)
```

Deliberately conservative: `constexpr_*` (palettized/quantized) weights are skipped because the bytes that reach the
DMA engine are not the ones this model counts; grouped convolutions are skipped because their contracting dimension
is per-group; runtime weights, non-fp16 weights, symbolic contracting dimensions and `transpose_x=True` matmuls are
skipped. The op is left alone when no split into at most 8 chunks clears the notch. Bias is applied exactly once, and
every other attribute (strides, pads, dilations, `pad_type`, transpose flags) is forwarded unchanged.

The group runs late, immediately before `common::merge_affine_dequantize_with_consecutive_ops` — after
`common::add_fp16_cast` and its trailing `const_elimination`, which is when the weights are the fp16 constants whose
bytes actually reach the hardware.

## Measurements (Mac mini M4, 16 GB, macOS 26.6.2, coremltools 9.0)

All timings are medians of interleaved rounds after warmup; every op below was confirmed on the
`NeuralEngineComputeDevice` via `MLComputePlan`.

### The notch reproduces on M4

fp16 1x1 `conv` on `x[1, D, 1, 1]`, single token, 3 rounds x 200 predicts, `CPU_AND_NE`:

| Weight (Cout x Cin) | Per core | Unsplit | Split | Speedup |
| --- | --- | --- | --- | --- |
| 2048 x 4096 | 1 MiB | 840 us (20.0 GB/s) | 430 us (39.0 GB/s), 2-way | 1.95x |
| 4096 x 4096 | 2 MiB | 1142 us (29.4 GB/s) | 697 us (48.1 GB/s), 4-way | 1.64x |
| 4096 x 4096 | 2 MiB | 1142 us | 1323 us, **2-way** (chunks still 1 MiB) | 0.86x |
| 2048 x 8192 | 2 MiB | 1350 us (24.9 GB/s) | 698 us (48.1 GB/s), 4-way | 1.93x |
| 4096 x 14336 | 7 MiB | 3522 us (33.3 GB/s) | 1989 us (59.0 GB/s), 2-way | 1.77x |
| 2016 x 4096 | 0.98 MiB | 426 us (38.8 GB/s) | 423 us, 2-way (control) | 1.01x |
| 1536 x 4096 | 0.75 MiB | 367 us (34.3 GB/s) | not split (control) | - |

The control rows are the important ones: splitting a shape that was never in the notch buys nothing, and splitting a
2 MiB payload into two 1 MiB chunks makes it *worse* — both exactly as the erratum predicts.

### Per-projection, through the real converter path

JAX -> `stablehlo_coreml.convert` -> `ct.convert(pass_pipeline=build_pass_pipeline(avoid_ane_dma_notch=...))`, fp16,
`CPU_AND_NE`, single token. The split column is what the pass chose on its own:

| projection (Cin x Cout) | per-core | split k | unsplit | split | speedup | GB/s |
| --- | --- | --- | --- | --- | --- | --- |
| Llama-3.2-1B gate/up 2048x8192 | 2.00 MiB | 3 (683+683+682) | 1377 us | 773 us | 1.78x | 24.4 -> 43.4 |
| Llama-3.2-1B down 8192x2048 | 2.00 MiB | 3 (2731+2731+2730) | 1110 us | 728 us | 1.53x | 30.2 -> 46.1 |
| Llama-3.1-8B q/o 4096x4096 | 2.00 MiB | 3 (1366+1365+1365) | 1154 us | 722 us | 1.60x | 29.1 -> 46.5 |
| Llama-3.1-8B gate/up 4096x14336 | 7.00 MiB | 2 (2048+2048) | 3563 us | 2035 us | 1.75x | 33.0 -> 57.7 |
| Llama-3.1-8B down 14336x4096 | 7.00 MiB | 2 (7168+7168) | 3388 us | 1988 us | 1.70x | 34.7 -> 59.1 |
| Qwen3-8B gate/up 4096x12288 | 6.00 MiB | 4 (1024+1024+1024+1024) | 3081 us | 1747 us | 1.76x | 32.7 -> 57.6 |
| DeepHermes-3B gate/up 3072x8192 | 3.00 MiB | 2 (1536+1536) | 1814 us | 999 us | 1.82x | 27.8 -> 50.4 |
| Gemma-3-4B lm_head shard 2560x16384 | 5.00 MiB | 2 (1280+1280) | 2906 us | 1554 us | 1.87x | 28.9 -> 54.0 |
| control 0.98 MiB/core 2016x4096 | 0.98 MiB | 1 (not split) | 444 us | 440 us | 1.01x | 37.2 -> 37.5 |
| control 0.75 MiB/core 1536x4096 | 0.75 MiB | 1 (not split) | 380 us | 381 us | 1.00x | 33.1 -> 33.1 |

Numerically, flag-on versus flag-off differs by 0.002-0.004 absolute — one fp16 ulp at these output magnitudes.
Against a float64 reference the unsplit op is 0.0011-0.0033 off and the split one 0.0022-0.0044, so the regrouped
accumulation costs at most about one extra ulp. The two control shapes are left untouched and their outputs are
bit-identical.

### Whole model: synthetic Llama-3.2-1B decode step

16 layers, dim 2048, 32 q-heads x 64, 8 KV heads, MLP 8192 SiLU-gated, RMSNorm, residuals, 1.95 GB of fp16 weights,
all seven projections per layer as 1x1 NCHW convs, fixed 512-position KV cache, single token. RoPE, the embedding
table and the lm_head are left out. 5 interleaved rounds x 50 predicts.

| | ms/step | tokens/s | effective weight-stream GB/s | ops on ANE | convs |
| --- | --- | --- | --- | --- | --- |
| flag off | 76.12 | 13.1 | 25.6 | 674 / 674 | 112 |
| flag on | 31.65 | 31.6 | 61.5 | 962 / 962 | 208 |
| | **2.41x** | **2.41x** | | | |

Nothing fell off the ANE: both packages are 100% `NeuralEngineComputeDevice`, attention included (the existing
`fuse_attention_to_sdpa` pass produces one `scaled_dot_product_attention` per layer and the ANE runs it). The pass
split the 48 MLP projections (2 MiB/core each) 3-way and correctly left q/o (0.5 MiB/core) and k/v (0.125 MiB/core)
alone. Final hidden state differs by 0.047 max-abs at |h| up to 11.8; against an fp32 JAX reference the rms error is
0.0144 flag-off and 0.0146 flag-on, i.e. the split changes fp16 rounding without degrading accuracy.

This is deliberately a synthetic model with random weights, so the tokens/s figure is not a quality-of-output claim —
it is a weight-streaming measurement on a realistically shaped graph.

### Two real models where the pass does nothing (checked)

**Gemma 4 E2B** (this repo's own [gemma-coreml-chat](https://github.com/kasper0406/gemma-coreml-chat) export,
16 multifunction decode/prefill pairs, 2.7 GB): the pass matches **0 of 277** weight-bearing ops per function. Every
projection weight is a `constexpr_blockwise_shift_scale` (int4 data, fp16 scales, group 32), not a plain fp16 `const`,
so the skip path fires on all of them. Were the same model exported unquantized, exactly one op per function would be a
candidate: the `[1536, 262144]` logit projection at 48 MiB per core, which the pass would split 5-way. Every other shape
is at least 128 KiB from a multiple of 1 MiB.

While checking this I found something worth recording: on this machine **an int4 `constexpr_blockwise_shift_scale`
weight makes its op ANE-ineligible altogether**. `MLComputePlan` reports `supported=[CPU]` for a `matmul` *and* for a
`conv` with such a weight, where the same ops with fp16 `const` weights report `[CPU, NeuralEngine]`. The whole Gemma
graph plans onto the CPU: 4641 scheduled ops, zero on the Neural Engine. So extending this pass to quantized weights
would buy nothing until that changes.

**sphere-detector** (fp32, `CPU_AND_GPU`, the model optimised in #107/#108): a verified no-op. The pass visits 71 weight-bearing
ops and matches none (the model is fp32, and its convolution weights are 2x2 and 3x3 single-channel correlation
kernels of 8 and 18 bytes per core, roughly 58000x below the first notch). Flag off and flag on produce byte-identical
model specs (`spec` SHA-256 `32e288bf…`, same weight blob, same 8209-op histogram, same GPU/CPU placement), and a
timing sanity check lands at 10.769 ms against 10.772 ms. Across the four benchmark inputs 7 of 8 output arrays are
bitwise identical and the eighth differs by 2.96e-3, at or below this model's own GPU scatter-add noise floor of
1.11e-2. A positive control in the same harness (a hand-built 1 MiB/core fp16 conv) does produce different specs and
fires the pass's debug log, so the comparison is not blind.


## Why opt-in

The erratum is ANE-only. Running the same sweep on the GPU shows no notch at all (2048 x 4096: 158 us against 156 us
for the control shape) and splitting there costs 30-45% because of the extra kernel launches; the CPU shows no notch
either. The rewrite also adds k slices and k-1 adds, and regroups an fp16 accumulation. So it only runs when the
caller asks for it.

## Tests

`tests/passes/test_avoid_ane_dma_notch.py` adds 61 tests: the payload/notch/split arithmetic on its own
(including the blog's own model table), the rewrite for `conv` (1x1 and 3x3, strides/pads/dilations/`pad_type`,
with and without bias, symbolic batch), `linear` and `matmul` (both `transpose_y`), every skip path
(`constexpr_*`, fp32, runtime, grouped, rank>2, `transpose_x`, symbolic contracting dim, `MAX_SPLITS` exhaustion),
nested blocks, shared weights, fan-out, idempotency, numerics against an fp32 reference for `conv`, `linear`, both
matmul layouts and the uneven 3-way split, and two end-to-end tests through the real converter asserting the split
survives the full pipeline. `tests/passes/test_pass_pipeline.py` covers the opt-in wiring: absent by default, present
once and before the anchor when enabled, idempotent, and not mutating the base pipeline.

`pytest tests/passes` is 478 passed, 1 xfailed; the full suite (minus `tests/pytorch`) is 698 passed, 1 xfailed;
`ruff check .` is clean.

## Limitations

- **Quantized weights are not handled.** `constexpr_blockwise_shift_scale` and friends stream bytes this payload model
  does not describe. On this machine that is currently moot: a `conv`, `linear` or `matmul` with an int4 or int8
  `constexpr` weight reports `supported=[CPU]` from `MLComputePlan` and never reaches the ANE at all, at any depth,
  and raising the deployment target to iOS26 does not change it. Worth rechecking on other silicon or a newer OS
  before extending the payload model.
- **The payload model is the blog's model**, validated on M4 through the shapes above. It assumes 16 cores and that
  output units are spread evenly over them. It has not been checked on M3 or A-series silicon.
- **`linear` and `matmul` are handled but have no hardware timings here.** Core ML runs all three spellings on the
  ANE once the graph is big enough (a 4-layer fp16 MLP stack is ANE-resident as `conv`, `linear` or `matmul`; only
  1-2 layer graphs stay on the CPU regardless of op type). The rewrite is covered by tests for all three, but the
  speedup numbers above were all taken on the `conv` path.
- `NUM_CORES`, `NOTCH_BYTES`, `WINDOW_BYTES` and `MAX_SPLITS` are module constants rather than pass options.

Credit for the erratum, the payload model and the workaround goes entirely to
[Eileen Yoon's writeup](https://eiln.github.io/posts/ane-dma.html).

